### PR TITLE
Support for update cloud configuration + tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -73,10 +73,11 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
             public void setValue(Jenkins jenkins, Object value) throws Exception {
                 List<Cloud> clouds = (List<Cloud>) value;
                 for (Cloud cloud : clouds) {
-                    if (jenkins.getCloud(cloud.name) == null) {
+                    Cloud currentCloud = jenkins.getCloud(cloud.name);
+                    if (currentCloud == null) {
                         jenkins.clouds.add(cloud);
                     } else {
-                        // FIXME re-configure ? remove/replace ?
+                        jenkins.clouds.replace(currentCloud, cloud);
                     }
                 }
             }

--- a/src/test/java/org/jenkinsci/plugins/casc/DockerCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/DockerCloudTest.java
@@ -2,18 +2,14 @@ package org.jenkinsci.plugins.casc;
 
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
-import com.nirima.jenkins.plugins.docker.launcher.AttachedDockerComputerLauncher;
-import hudson.plugins.active_directory.ActiveDirectoryDomain;
-import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
+import hudson.model.Label;
 import io.jenkins.docker.connector.DockerComputerAttachConnector;
-import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -31,8 +27,46 @@ public class DockerCloudTest {
         final DockerCloud docker = DockerCloud.getCloudByName("docker");
         assertNotNull(docker);
         final DockerTemplate template = docker.getTemplate("jenkins/slave");
+        checkTemplate(template, "docker-agent", "jenkins", "/home/jenkins/agent", "10");
+    }
+
+    @Test
+    public void update_docker_cloud() throws Exception {
+        ConfigurationAsCode.configure(getClass().getResourceAsStream(
+                "DockerCloudTest/update_docker_cloud/DockerCloudTest1.yml"));
+
+        DockerCloud docker = DockerCloud.getCloudByName("docker");
+        assertNotNull(docker);
+        assertNotNull(docker.getDockerApi());
+        assertNotNull(docker.getDockerApi().getDockerHost());
+        assertEquals("unix:///var/run/docker.sock", docker.getDockerApi().getDockerHost().getUri());
+
+        DockerTemplate template = docker.getTemplate(Label.get("docker-agent"));
+        checkTemplate(template, "docker-agent", "jenkins", "/home/jenkins/agent", "10");
+
+        ConfigurationAsCode.configure(getClass().getResourceAsStream(
+                "DockerCloudTest/update_docker_cloud/DockerCloudTest2.yml"));
+
+        docker = DockerCloud.getCloudByName("docker");
+        assertNotNull(docker);
+        assertNotNull(docker.getDockerApi());
+        assertNotNull(docker.getDockerApi().getDockerHost());
+        assertEquals("unix:///var/run/docker.sock", docker.getDockerApi().getDockerHost().getUri());
+
+        template = docker.getTemplate(Label.get("docker-agent"));
+        checkTemplate(template, "docker-agent", "jenkins", "/home/jenkins/agent", "10");
+
+        template = docker.getTemplate(Label.get("generic"));
+        checkTemplate(template, "generic", "jenkins", "/home/jenkins/agent2", "5");
+
+    }
+
+    private void checkTemplate(DockerTemplate template, String labelString, String user, String remoteFs,
+                               String instanceCapStr){
         assertNotNull(template);
-        assertEquals("docker-agent", template.getLabelString());
-        assertEquals("jenkins", ((DockerComputerAttachConnector) template.getConnector()).getUser());
+        assertEquals(labelString, template.getLabelString());
+        assertEquals(user, ((DockerComputerAttachConnector) template.getConnector()).getUser());
+        assertEquals(remoteFs, template.getRemoteFs());
+        assertEquals(instanceCapStr, template.getInstanceCapStr());
     }
 }

--- a/src/test/resources/org/jenkinsci/plugins/casc/DockerCloudTest/update_docker_cloud/DockerCloudTest1.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/DockerCloudTest/update_docker_cloud/DockerCloudTest1.yml
@@ -1,0 +1,16 @@
+jenkins:
+  clouds:
+    - docker:
+        name: "docker"
+        dockerApi:
+          dockerHost:
+            uri: "unix:///var/run/docker.sock"
+        templates:
+          - labelString: "docker-agent"
+            dockerTemplateBase:
+              image: "jenkins/slave"
+            remoteFs: "/home/jenkins/agent"
+            connector:
+              attach:
+                user: "jenkins"
+            instanceCapStr: "10"

--- a/src/test/resources/org/jenkinsci/plugins/casc/DockerCloudTest/update_docker_cloud/DockerCloudTest2.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/DockerCloudTest/update_docker_cloud/DockerCloudTest2.yml
@@ -1,0 +1,25 @@
+jenkins:
+  clouds:
+    - docker:
+        name: "docker"
+        dockerApi:
+          dockerHost:
+            uri: "unix:///var/run/docker.sock"
+        templates:
+          - labelString: "docker-agent"
+            dockerTemplateBase:
+              image: "jenkins/slave"
+            remoteFs: "/home/jenkins/agent"
+            connector:
+              attach:
+                user: "jenkins"
+            instanceCapStr: "10"
+
+          - labelString: "generic"
+            dockerTemplateBase:
+              image: "jenkins/slave"
+            remoteFs: "/home/jenkins/agent2"
+            connector:
+              attach:
+                user: "jenkins"
+            instanceCapStr: "5"


### PR DESCRIPTION
When changing cloud configuration, we need to replace the current configuration with the new one.
Otherwise, we will not be able to support on the fly configuration changes.
Added additional test for that.