### PR TITLE
Supporting  attributes with type Set and added agentProtocols test

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -5,10 +5,7 @@ import org.apache.commons.beanutils.PropertyUtils;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -77,9 +74,14 @@ public class Attribute<T> {
             // Typically required for hudson.tools.ToolDescriptor.setInstallations
             // as java varargs unfortunately only supports Arrays, not all Iterable (sic)
             final Class c = writeMethod.getParameterTypes()[0];
-            if (c.isArray() && value instanceof Collection) {
+            if (c.isArray()) {
                 Collection collection = (Collection) value;
                 o = collection.toArray((Object[]) Array.newInstance(type, collection.size()));
+
+            // if setter expect a Set, convert Collection to Set
+            // see jenkins.agentProtocols
+            } else if(c.isAssignableFrom(Set.class)){
+                o = new HashSet((Collection)value);
             }
 
         }

--- a/src/test/java/org/jenkinsci/plugins/casc/AgentProtocolsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/AgentProtocolsTest.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.plugins.casc;
+
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by odavid on 23/12/2017.
+ */
+public class AgentProtocolsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void configure_agent_protocols() throws Exception {
+        ConfigurationAsCode.configure(getClass().getResourceAsStream("AgentProtocolsTest.yml"));
+
+        final Jenkins jenkins = Jenkins.getInstance();
+        final Set<String> agentProtocols =
+                Arrays.stream(new String[]{"JNLP4-connect", "Ping"}).collect(Collectors.toSet());
+        assertEquals(agentProtocols, jenkins.getAgentProtocols());
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/casc/AgentProtocolsTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/AgentProtocolsTest.yml
@@ -1,0 +1,3 @@
+jenkins:
+  agentProtocols:
+    - JNLP4-connect


### PR DESCRIPTION
jenkins.agentProtocols expects a java.util.Set<String>. Added support for set 
Also added agentProtocols test