### PR TITLE
Support seed job creation relying on job-dsl-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ The configuration file format depends on the version of jenkins-core and install
 Documentation is generated from a live instance, as well as a JSON-schema you can use to validate configuration file
 with your favourite yaml tools.
 
+## How to create initial "seed" job
+
+Configuration is not just about setting up jenkins master, it's also about creating an initial set of jobs.
+For this purpose, we delegate to the popular [job-dsl-plugin](https://wiki.jenkins.io/display/JENKINS/Job+DSL+Plugin)
+and run a job-dsl script to create an initial set of jobs.
+
+Typical usage is to rely on a multi-branch, or organization folder job type, so further jobs will be dynamically 
+created. So a multi-branch seed job will prepare a master to be fully configured for CI/CD targetting a repository
+or organization.
+
+Job-DSL plugin uses groovy syntax for it's job configuration DSL, so you'll have to mix yaml and groovy within your
+configuration-as-code file: 
+
+```yaml
+jenkins:
+  jobs:
+    - >
+        multibranchPipelineJob('configuration-as-code') {
+            branchSources {
+                git {
+                    remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
+                }
+            }
+        }
+```         
+
 ## How to provide initial secrets for Configuration-as-Code
 
 Currently you can provide initial secrets to Configuration-as-Code that all rely on <key,value>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
       <version>1.18</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>job-dsl</artifactId>
+      <version>1.66</version>
+    </dependency>
+
     <!-- plugin adapters-->
 
     <dependency>
@@ -130,14 +136,7 @@
       <version>2.9</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>job-dsl</artifactId>
-      <version>1.66</version>
-      <scope>test</scope>
-    </dependency>
-
+    
     <!-- required to satisfy plugins dependencies and get testPluginActive to pass -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -168,6 +167,11 @@
       <artifactId>workflow-support</artifactId>
       <version>2.16</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+      <version>2.9.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -45,17 +45,17 @@ public class Attribute<T> {
         return multiple;
     }
 
-    public Attribute multiple(boolean multiple) {
+    public Attribute<T> multiple(boolean multiple) {
         this.multiple = multiple;
         return this;
     }
 
-    public Attribute preferredName(String preferredName) {
+    public Attribute<T> preferredName(String preferredName) {
         this.preferredName = preferredName;
         return this;
     }
 
-    public Attribute setter(Setter setter) {
+    public Attribute<T> setter(Setter setter) {
         this.setter = setter;
         return this;
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/SeedJobConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/SeedJobConfigurator.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.plugins.casc;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
+import javaposse.jobdsl.plugin.JenkinsJobManagement;
+import javaposse.jobdsl.plugin.LookupStrategy;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension
+public class SeedJobConfigurator implements RootElementConfigurator {
+
+    @Override
+    public String getName() {
+        return "jobs";
+    }
+
+    @Override
+    public Set<Attribute> describe() {
+        // no attribute this is a raw list
+        return Collections.EMPTY_SET;
+    }
+
+    @Override
+    public Object configure(Object config) throws Exception {
+        JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
+        for (String script : (List<String>) config) {
+            new JenkinsDslScriptLoader(mng).runScript(script);
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/casc/SeedJobConfigurator/documentation.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/casc/SeedJobConfigurator/documentation.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+
+  <div class='section'>
+    <h4 id="${it.extensionPoint.simpleName}-${it.name}">${it.name}</h4>
+    <div class='paragraph'>${it.displayName}</div>
+    <div class='dlist'>
+      <dl>list of strings</dl>
+      <dd>JobDSL plugin scripts to generate initial seed jobs.</dd>
+    </div>
+
+  </div>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/casc/SeedJobConfigurator/schema.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/casc/SeedJobConfigurator/schema.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+    "${it.target.name}": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/casc/SeedJobTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/SeedJobTest.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.casc;
+
+import hudson.model.TopLevelItem;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class SeedJobTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void configure_seed_job() throws Exception {
+        ConfigurationAsCode.configure(getClass().getResourceAsStream("SeedJobTest.yml"));
+        final Jenkins jenkins = Jenkins.getInstance();
+        final TopLevelItem test = jenkins.getItem("configuration-as-code");
+        assertNotNull(test);
+        assertTrue(test instanceof WorkflowMultiBranchProject);
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/casc/SeedJobTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/SeedJobTest.yml
@@ -1,10 +1,9 @@
-jenkins:
-  jobs:
-    - >
-        multibranchPipelineJob('configuration-as-code') {
-            branchSources {
-                git {
-                    remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
-                }
-            }
-        }
+jobs:
+  - >
+      multibranchPipelineJob('configuration-as-code') {
+          branchSources {
+              git {
+                  remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
+              }
+          }
+      }

--- a/src/test/resources/org/jenkinsci/plugins/casc/SeedJobTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/SeedJobTest.yml
@@ -1,0 +1,10 @@
+jenkins:
+  jobs:
+    - >
+        multibranchPipelineJob('configuration-as-code') {
+            branchSources {
+                git {
+                    remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
+                }
+            }
+        }


### PR DESCRIPTION
close #11

I introduced `jobs` pseudo-attribute into Jenkins root element configuration, which actually expect a job-dsl script. This one is ran during configuration process (without a `run` as execution context). This limits the scope of job-dsl (there's no workspace) but should be enough to setup a reasonable set of seed jobs. 