### PR TITLE
Implemented a configurator for AuthorizationStrategy.Unsecured

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/HeteroDescribableConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/HeteroDescribableConfigurator.java
@@ -2,7 +2,10 @@ package org.jenkinsci.plugins.casc;
 
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.security.SecurityRealm;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 
 import java.util.Collections;
 import java.util.List;
@@ -11,6 +14,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
+ * {@link Configurator} that works with {@link Describable} subtype as a {@link #target}.
+ *
+ * <p>
+ * The configuration object will be specify the 'short name' which we use to resolve to a specific
+ * subtype of {@link #target}. For example, if {@link #target} is {@link SecurityRealm} and the short name
+ * is 'local', we resolve to {@link HudsonPrivateSecurityRealm} (because it has {@link Symbol} annotation that
+ * specifies that name.
+ *
+ * <p>
+ * The corresponding {@link Configurator} will be then invoked to configure the chosen subtype.
+ *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class HeteroDescribableConfigurator extends Configurator<Describable> {

--- a/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.casc.core;
+
+import hudson.Extension;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.AuthorizationStrategy.Unsecured;
+import org.jenkinsci.plugins.casc.BaseConfigurator;
+
+/**
+ * Handles {@link AuthorizationStrategy.Unsecured} that requires a special treatment due to its singleton semantics.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@Extension
+public class UnsecuredAuthorizationStrategyConfigurator extends BaseConfigurator<Unsecured> {
+    @Override
+    public Class<Unsecured> getTarget() {
+        return Unsecured.class;
+    }
+
+    @Override
+    public Unsecured configure(Object config) throws Exception {
+        return (Unsecured)AuthorizationStrategy.UNSECURED;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.casc.core;
+
+import hudson.security.AuthorizationStrategy;
+import org.jenkinsci.plugins.casc.ConfigurationAsCode;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class UnsecuredAuthorizationStrategyConfiguratorTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void configure_local_security_and_admin_user() throws Exception {
+        ConfigurationAsCode.configure(getClass().getResourceAsStream("UnsecuredAuthorizationStrategyConfiguratorTest.yml"));
+        assertSame(AuthorizationStrategy.UNSECURED, j.jenkins.getAuthorizationStrategy());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.java
@@ -16,7 +16,7 @@ public class UnsecuredAuthorizationStrategyConfiguratorTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void configure_local_security_and_admin_user() throws Exception {
+    public void unsecured() throws Exception {
         ConfigurationAsCode.configure(getClass().getResourceAsStream("UnsecuredAuthorizationStrategyConfiguratorTest.yml"));
         assertSame(AuthorizationStrategy.UNSECURED, j.jenkins.getAuthorizationStrategy());
     }

--- a/src/test/resources/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.yml
@@ -2,7 +2,4 @@ jenkins:
   securityRealm:
     local:
       allowsSignup: false
-      users:
-        - id: "admin"
-          password: "1234"
   authorizationStrategy: unsecured

--- a/src/test/resources/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.yml
@@ -1,0 +1,8 @@
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: "1234"
+  authorizationStrategy: unsecured


### PR DESCRIPTION
Fixes #24 by implementing a custom `Configurator`.

In hindsight there was no need to be clever with `Unsecured` being a singleton, but that cat is out of the bag.