### PR TITLE
jobs moved to root instead of under jenkins in yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,16 +125,15 @@ Job-DSL plugin uses groovy syntax for it's job configuration DSL, so you'll have
 configuration-as-code file:
 
 ```yaml
-jenkins:
-  jobs:
-    - >
-        multibranchPipelineJob('configuration-as-code') {
-            branchSources {
-                git {
-                    remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
-                }
-            }
-        }
+jobs:
+  - >
+      multibranchPipelineJob('configuration-as-code') {
+          branchSources {
+              git {
+                  remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
+              }
+          }
+      }
 ```         
 
 ## How to provide initial secrets for Configuration-as-Code

--- a/src/test/resources/org/jenkinsci/plugins/casc/GithubOrganisationFolderTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/GithubOrganisationFolderTest.yml
@@ -1,8 +1,6 @@
-jenkins:
-  jobs:
-    - organizationFolder:
-        name: "ndeloof"
-        navigators:
-          - github:
-              repoOwner: "ndeloof"
-
+jobs:
+  - organizationFolder:
+      name: "ndeloof"
+      navigators:
+        - github:
+            repoOwner: "ndeloof"


### PR DESCRIPTION
we've decided to move `jobs:` from under `jenkins:` in yaml and I corrected some docs to follow that change
funny thing it's still working if we use

```
jenkins:
  jobs:
  (...)
```