### PR TITLE
Improve diagnosability of errors in attribute management

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -35,6 +35,11 @@ public class Attribute<T> {
         this.type = type;
     }
 
+    @Override
+    public String toString() {
+        return String.format("%s(class: %s, multiple: %s)", name, type, multiple);
+    }
+
     public String getName() {
         return preferredName != null ? preferredName : name;
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -93,14 +93,18 @@ public class Attribute<T> {
      * Default Setter implementation based on JavaBean property write method.
      */
     private static final Setter DEFAULT_SETTER = (target, attribute, value) -> {
-        logger.info("Setting "+target.getClass().getCanonicalName()+'#'+attribute.name+" = " + value);
+        final String setterId = target.getClass().getCanonicalName()+'#'+attribute.name;
+        logger.info("Setting " + setterId + " = " + value);
         final PropertyDescriptor property = PropertyUtils.getPropertyDescriptor(target, attribute.name);
+        if (property == null) {
+            throw new Exception("Default value setter cannot find Property Descriptor for " + setterId);
+        }
         final Method writeMethod = property.getWriteMethod();
 
         Object o = value;
         if (attribute.multiple) {
             if (!(value instanceof Collection)) {
-                throw new IllegalArgumentException(target + "#" + attribute.name + " should be a list.");
+                throw new IllegalArgumentException(setterId + " should be a list.");
             }
             // if setter expect an Array, convert Collection to expected array type
             // Typically required for hudson.tools.ToolDescriptor.setInstallations

--- a/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
@@ -160,16 +160,23 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
                 final Class k = attribute.getType();
                 final Configurator configurator = Configurator.lookup(k);
                 if (configurator == null) throw new IllegalStateException("No configurator implementation to manage "+k);
+
+                final Object valueToSet;
                 if (attribute.isMultiple()) {
                     List values = new ArrayList<>();
                     for (Object o : (List) sub) {
                         Object value = configurator.configure(o);
                         values.add(value);
                     }
-                    attribute.setValue(instance, values);
+                    valueToSet= values;
                 } else {
-                    Object value = configurator.configure(sub);
-                    attribute.setValue(instance, value);
+                    valueToSet = configurator.configure(sub);
+                }
+
+                try {
+                    attribute.setValue(instance, valueToSet);
+                } catch (Exception ex) {
+                    throw new Exception("Failed to set attribute " + attribute, ex);
                 }
             }
         }


### PR DESCRIPTION
- [x] - Prevent NPE in `Attribute#DEFAULT_SETTER`, print diagnostics instead
- [x] - BaseConfigurator now reports fields which it failed to modify
- [x] - `Attribute#toString()` returns a user-readable description

@reviewbybees @ndeloof @ewelinawilkosz 
