### PR TITLE
Issue #29 - Allow configuring Slave2MasterSecurity within Jenkins settings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -10,6 +10,7 @@ import javaposse.jobdsl.plugin.JenkinsJobManagement;
 import javaposse.jobdsl.plugin.LookupStrategy;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
+import jenkins.security.s2m.AdminWhitelistRule;
 
 import java.util.List;
 import java.util.Map;
@@ -67,6 +68,9 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
                 attributes.add(new Attribute(configurator.getName(), configurator.getTarget()).setter(NOOP));
             }
         }
+
+        // Add remoting security, all legwork will be done by a configurator
+        attributes.add(new Attribute("remotingSecurity", AdminWhitelistRule.class).setter(NOOP));
 
         return attributes;
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.casc.core;
+
+import com.google.inject.Injector;
+import hudson.Extension;
+import jenkins.model.Jenkins;
+import jenkins.security.s2m.AdminWhitelistRule;
+import org.jenkinsci.plugins.casc.Attribute;
+import org.jenkinsci.plugins.casc.BaseConfigurator;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Virtual configurator for Remoting security settings.
+ * See the unit tests for configuration examples.
+ * @author Oleg Nenashev
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class AdminWhitelistRuleConfigurator extends BaseConfigurator<AdminWhitelistRule> {
+
+    @Override
+    public String getName() {
+        return "remotingSecurity";
+    }
+
+    @Override
+    public Class<AdminWhitelistRule> getTarget() {
+        return AdminWhitelistRule.class;
+    }
+
+    @Override
+    public AdminWhitelistRule configure(Object config) throws Exception {
+        Injector injector = Jenkins.getInstance().getInjector();
+        AdminWhitelistRule instance = injector.getInstance(AdminWhitelistRule.class);
+        configure((Map)config, instance);
+        return instance;
+    }
+
+    @Override
+    public Set<Attribute> describe() {
+        return new HashSet<>(Arrays.asList(
+                new Attribute<>("enabled", Boolean.class).setter(new EnableSwitch())
+        ));
+    }
+
+    private static final class EnableSwitch extends AdminWhitelistRuleSetter<Boolean> {
+
+        @Override
+        public void set(AdminWhitelistRule instance, Boolean value) {
+            instance.setMasterKillSwitch(value);
+        }
+    }
+
+    private abstract static class AdminWhitelistRuleSetter<TValue> implements Attribute.Setter {
+        @Override
+        public void setValue(Object target, Attribute attribute, Object value) throws Exception {
+            Injector injector = Jenkins.getInstance().getInjector();
+            AdminWhitelistRule instance = injector.getInstance(AdminWhitelistRule.class);
+            set(instance, (TValue) value);
+        }
+
+        public abstract void set(AdminWhitelistRule instance, TValue value);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfiguratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.casc.core;
+
+import jenkins.model.Jenkins;
+import jenkins.security.s2m.AdminWhitelistRule;
+import org.jenkinsci.plugins.casc.ConfigurationAsCode;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+@For(AdminWhitelistRule.class)
+public class AdminWhitelistRuleConfiguratorTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("Issue #28")
+    public void checkM2SSecurityKillSwitch_enabled() throws Exception {
+        ConfigurationAsCode.configure(getClass().getResourceAsStream("AdminWhitelistRuleConfigurator/Slave2MasterSecurityKillSwitch_enabled.yml"));
+
+        final Jenkins jenkins = Jenkins.getInstance();
+        AdminWhitelistRule rule = jenkins.getInjector().getInstance(AdminWhitelistRule.class);
+        Assert.assertTrue("MasterToSlave Security should be enabled", rule.getMasterKillSwitch());
+    }
+
+    @Test
+    @Issue("Issue #28")
+    public void checkM2SSecurityKillSwitch_disabled() throws Exception {
+        ConfigurationAsCode.configure(getClass().getResourceAsStream("AdminWhitelistRuleConfigurator/Slave2MasterSecurityKillSwitch_disabled.yml"));
+
+        final Jenkins jenkins = Jenkins.getInstance();
+        AdminWhitelistRule rule = jenkins.getInjector().getInstance(AdminWhitelistRule.class);
+        Assert.assertFalse("MasterToSlave Security should be disabled", rule.getMasterKillSwitch());
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator/Slave2MasterSecurityKillSwitch_disabled.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator/Slave2MasterSecurityKillSwitch_disabled.yml
@@ -1,0 +1,3 @@
+jenkins:
+  remotingSecurity:
+    enabled: false

--- a/src/test/resources/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator/Slave2MasterSecurityKillSwitch_enabled.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator/Slave2MasterSecurityKillSwitch_enabled.yml
@@ -1,0 +1,3 @@
+jenkins:
+  remotingSecurity:
+    enabled: true


### PR DESCRIPTION
Fixes #29. I used some hacks in order to bind `AdminWhitelistRule ` into the Jenkins configuration section. Sanity check is required before I proceed with other controls.

```yaml
jenkins:
  remotingSecurity:
    enabled: true
```

@reviewbybees @ndeloof @ewelinawilkosz 


