### PR TITLE
safe way to scan for configs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
@@ -5,7 +5,6 @@ import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.model.ManagementLink;
 import jenkins.model.Jenkins;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -13,17 +12,25 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.yaml.snakeyaml.Yaml;
 
 import javax.annotation.CheckForNull;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 
 /**
  * {@linkplain #configure() Main entry point of the logic}.
@@ -36,6 +43,7 @@ public class ConfigurationAsCode extends ManagementLink {
     public static final String CASC_JENKINS_CONFIG_PROPERTY = "casc.jenkins.config";
     public static final String CASC_JENKINS_CONFIG_ENV = "CASC_JENKINS_CONFIG";
     public static final String DEFAULT_JENKINS_YAML_PATH = "./jenkins.yaml";
+    public static final String YAML_FILES_PATTERN = "glob:**.{yml,yaml,YAML,YML}";
 
     @CheckForNull
     @Override
@@ -90,39 +98,84 @@ public class ConfigurationAsCode extends ManagementLink {
         get().configure();
     }
 
-
-    public void configure() throws Exception {
+    /**
+     * Main entry point to start configuration process
+     */
+    public void configure() {
         String configParameter = System.getProperty(
                 CASC_JENKINS_CONFIG_PROPERTY,
                 System.getenv(CASC_JENKINS_CONFIG_ENV)
         );
 
-        List<String> files = new ArrayList<>();
-        final Map<String, InputStream> is = getConfigurationInputs(configParameter);
-        for (Map.Entry<String, InputStream> e : is.entrySet()) {
-            files.add(e.getKey());
-            configure(e.getValue());
-        }
-        sources = files;
+        List<Path> configs = configs(configParameter);
+        sources = configs.stream().map(Path::toAbsolutePath).map(Path::toString).collect(toList());
+        configs.stream()
+                .flatMap(ConfigurationAsCode::entries)
+                .forEach(ConfigurationAsCode::configureWith);
+
         lastTimeLoaded = System.currentTimeMillis();
     }
 
-    public static ConfigurationAsCode get() {
-        return Jenkins.getInstance().getExtensionList(ConfigurationAsCode.class).get(0);
+    /**
+     * Recursive search for all {@link #YAML_FILES_PATTERN} in provided base path
+     *
+     * @param path base path to start (can be file or directory)
+     * @return list of all paths matching pattern. Only base file itself if it is a file matching pattern
+     */
+    public List<Path> configs(String path) {
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher(YAML_FILES_PATTERN);
+
+        try (Stream<Path> configs = Files.find(
+                Paths.get(StringUtils.defaultIfBlank(path, DEFAULT_JENKINS_YAML_PATH)),
+                Integer.MAX_VALUE,
+                (next, attrs) -> attrs.isRegularFile() && matcher.matches(next)
+        )) {
+            return configs.collect(toList());
+        } catch (NoSuchFileException e) {
+            return Collections.emptyList();
+        } catch (IOException e) {
+            throw new IllegalStateException("failed config scan for " + path, e);
+        }
     }
 
     /**
-     * Reads YAML from the given {@link InputStream} and applies that to Jenkins.
+     * Creates the stream of configurable entries in config in form [root key -> some object]
+     *
+     * @param config path to read from
+     * @return stream of entries from yaml
      */
-    public static void configure(InputStream in) throws Exception {
-        Map<String, Object> config = new Yaml().loadAs(in, Map.class);
-        for (Map.Entry<String, Object> e : config.entrySet()) {
-            final RootElementConfigurator configurator = Configurator.lookupRootElement(e.getKey());
-            if (configurator == null) {
-                throw new IllegalArgumentException("no configurator for root element '"+e.getKey()+"'");
-            }
-            configurator.configure(e.getValue());
+    private static Stream<? extends Map.Entry<String, Object>> entries(Path config) {
+        try (Reader reader = Files.newBufferedReader(config)) {
+            return ((Map<String, Object>) new Yaml().loadAs(reader, Map.class)).entrySet().stream();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
         }
+    }
+
+    /**
+     * Configuration with help of {@link RootElementConfigurator}s.
+     * Corresponding configurator is searched by entry key, passing entry value as object with all required properties.
+     *
+     * @param entry key-value pair, where key should match to root configurator and value have all required properties
+     */
+    public static void configureWith(Map.Entry<String, Object> entry) {
+        RootElementConfigurator configurator = Objects.requireNonNull(
+                Configurator.lookupRootElement(entry.getKey()),
+                format("no configurator for root element <%s>", entry.getKey())
+        );
+        try {
+            configurator.configure(entry.getValue());
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    format("error configuring <%s> with <%s> configurator", entry.getKey(), configurator.getName()),
+                    e
+            );
+        }
+    }
+
+
+    public static ConfigurationAsCode get() {
+        return Jenkins.getInstance().getExtensionList(ConfigurationAsCode.class).get(0);
     }
 
     // for documentation generation in index.jelly
@@ -156,26 +209,4 @@ public class ConfigurationAsCode extends ManagementLink {
             listElements(elements, configurator.describe());
         }
     }
-
-    public Map<String, InputStream> getConfigurationInputs(String configPath) throws IOException {
-        //Default
-        if(StringUtils.isBlank(configPath)) {
-            File defaultConfig = new File(DEFAULT_JENKINS_YAML_PATH);
-            if(defaultConfig.exists()) {
-                return Collections.singletonMap("jenkins.yaml", new FileInputStream(defaultConfig));
-            } else {
-                return Collections.emptyMap();
-            }
-        }
-        File cfg = new File(configPath);
-        if(cfg.isDirectory()) {
-            Map<String, InputStream> is = new HashMap<>();
-            for(File cfgFile : FileUtils.listFiles(cfg, new String[]{"yml","yaml"},true)) {
-                is.put(cfgFile.getName(), new FileInputStream(cfgFile));
-            }
-            return is;
-        }
-        return Collections.singletonMap(cfg.getName(), new FileInputStream(cfg));
-    }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/ConfigurationAsCodeTest.java
@@ -5,8 +5,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 
 public class ConfigurationAsCodeTest {
 
@@ -16,9 +18,21 @@ public class ConfigurationAsCodeTest {
     @Test
     public void init_test_from_accepted_sources() throws Exception {
         ConfigurationAsCode casc = new ConfigurationAsCode();
-        File tmpConfigFile = tempFolder.newFile("jenkins_tmp.yaml");
+
+        File exactFile = tempFolder.newFile("jenkins_tmp.yaml");
         tempFolder.newFile("jenkins_tmp2.yaml");
-        assertEquals(1, casc.getConfigurationInputs(tmpConfigFile.getAbsolutePath()).size());
-        assertEquals(2, casc.getConfigurationInputs(tempFolder.getRoot().getAbsolutePath()).size());
+        tempFolder.newFile("jenkins_tmp3.YAML");
+        tempFolder.newFile("jenkins_tmp4.YML");
+        tempFolder.newFile("jenkins_tmp5.yml");
+        tempFolder.newFolder("jenkins_folder.yml");
+
+        assertThat(casc.configs(exactFile.getAbsolutePath()), hasSize(1));
+        assertThat(casc.configs(tempFolder.getRoot().getAbsolutePath()), hasSize(5));
+    }
+
+    @Test
+    public void shouldReturnEmptyMapOnNotFoundConfig() {
+        ConfigurationAsCode casc = new ConfigurationAsCode();
+        assertThat(casc.configs("some"), hasSize(0));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/casc/misc/TestConfiguration.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/misc/TestConfiguration.java
@@ -1,6 +1,14 @@
 package org.jenkinsci.plugins.casc.misc;
 
 import org.jenkinsci.plugins.casc.ConfigurationAsCode;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Loads resource as configuration-as-code
@@ -17,10 +25,12 @@ public class TestConfiguration {
     }
 
     public void configure(Class<?> clazz) {
-        try {
-            ConfigurationAsCode.configure(clazz.getResourceAsStream(resource));
-        } catch (Exception e) {
-            throw new IllegalStateException("Can't configure test with " + resource, e);
+        try (Reader reader = new InputStreamReader(clazz.getResourceAsStream(resource), UTF_8)) {
+            ((Map<String, Object>) new Yaml().loadAs(reader, Map.class))
+                    .entrySet()
+                    .forEach(ConfigurationAsCode::configureWith);
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format("Can't configure test <%s> with <%s>", clazz, resource), e);
         }
     }
 }


### PR DESCRIPTION
This commit adds resource control for all files, as previously the
stream close was neglected which may lead to resource leaks.

This commit uses stream api to search configs and run reconfiguration.
The stream api here allows to reduce code complexity as we get
flat flow of paths, that converted to entries in config and then
processed by configurators.

In case of files search stream api gives us one line to get the flat
stream of paths - it allows us to pay more attention to error handling

Passing InputStreams by reference between method without error handling
usually looks like antipattern, so all the file logic is concentrated
inside of dedicated methods.