### PR TITLE
Fix case in option for specifying the type of container used

### DIFF
--- a/demos/mesos/README.md
+++ b/demos/mesos/README.md
@@ -34,7 +34,7 @@ jenkins:
             defaultSlave: true
             idleTerminationMinutes: '5'
             containerInfo:
-              type: "docker"
+              type: "DOCKER"
               dockerImage: "cloudbees/java-with-docker-client:latest"
               networking: "BRIDGE"
               volumes:


### PR DESCRIPTION
We observed that the type of container must be in capital to be valid