### PR TITLE
#164 - Annotate API methods in the Configurator extension point

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
@@ -165,7 +165,7 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
         return attribute;
     }
 
-    protected void configure(Map config, T instance) throws Exception {
+    protected void configure(Map config, T instance) throws ConfiguratorException {
         final Set<Attribute> attributes = describe();
 
         for (Attribute attribute : attributes) {
@@ -191,13 +191,13 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
                 try {
                     attribute.setValue(instance, valueToSet);
                 } catch (Exception ex) {
-                    throw new Exception("Failed to set attribute " + attribute, ex);
+                    throw new ConfiguratorException(configurator, "Failed to set attribute " + attribute, ex);
                 }
             }
         }
         if (!config.isEmpty()) {
             final String invalid = StringUtils.join(config.keySet(), ',');
-            throw new IllegalArgumentException("Invalid configuration elements for type " + instance.getClass() + " : " + invalid);
+            throw new ConfiguratorException("Invalid configuration elements for type " + instance.getClass() + " : " + invalid);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.casc;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -207,6 +208,7 @@ public class ConfigurationAsCode extends ManagementLink {
      *
      * @param entry key-value pair, where key should match to root configurator and value have all required properties
      */
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "FindBugs is too picky about Objects.requireNonNull()")
     public static void configureWith(Map.Entry<String, Object> entry) {
         RootElementConfigurator configurator = Objects.requireNonNull(
                 Configurator.lookupRootElement(entry.getKey()),

--- a/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
@@ -112,8 +112,9 @@ public class ConfigurationAsCode extends ManagementLink {
 
     /**
      * Main entry point to start configuration process
+     * @throws ConfiguratorException Configuration error
      */
-    public void configure() {
+    public void configure() throws ConfiguratorException {
         String configParameter = System.getProperty(
                 CASC_JENKINS_CONFIG_PROPERTY,
                 System.getenv(CASC_JENKINS_CONFIG_ENV)
@@ -140,26 +141,29 @@ public class ConfigurationAsCode extends ManagementLink {
         return supportedProtocols.contains(uri.getScheme());
     }
 
-    private void _configureWithURI(String configParameter) {
+    private void _configureWithURI(String configParameter) throws ConfiguratorException {
         try {
             URL url = URI.create(configParameter).toURL();
             try(InputStreamReader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
-                entries(reader).forEach(ConfigurationAsCode::configureWith);
+                for (Map.Entry<String, Object> entry : entries(reader).collect(toList())) {
+                    configureWith(entry);
+                }
                 sources = Collections.singletonList(configParameter);
             } catch (IOException e) {
-                throw new IllegalStateException("Failed to read from URL: "+configParameter, e);
+                throw new ConfiguratorException("Failed to read from URL: "+configParameter, e);
             }
         } catch (MalformedURLException e) {
-            throw new IllegalStateException("Failed to read from url. Url is malformed: "+configParameter, e);
+            throw new ConfiguratorException("Failed to read from url. Url is malformed: "+configParameter, e);
         }
     }
 
-    private void _configureWithPaths(String configParameter) {
+    private void _configureWithPaths(String configParameter) throws ConfiguratorException  {
         List<Path> configs = configs(configParameter);
         sources = configs.stream().map(Path::toAbsolutePath).map(Path::toString).collect(toList());
-        configs.stream()
-                .flatMap(ConfigurationAsCode::entries)
-                .forEach(ConfigurationAsCode::configureWith);
+        for (Map.Entry<String, Object> entry : configs.stream()
+                .flatMap(ConfigurationAsCode::entries).collect(toList())) {
+            configureWith(entry);
+        }
     }
 
     /**
@@ -207,17 +211,19 @@ public class ConfigurationAsCode extends ManagementLink {
      * Corresponding configurator is searched by entry key, passing entry value as object with all required properties.
      *
      * @param entry key-value pair, where key should match to root configurator and value have all required properties
+     * @throws ConfiguratorException configuration error
      */
-    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "FindBugs is too picky about Objects.requireNonNull()")
-    public static void configureWith(Map.Entry<String, Object> entry) {
-        RootElementConfigurator configurator = Objects.requireNonNull(
-                Configurator.lookupRootElement(entry.getKey()),
-                format("no configurator for root element <%s>", entry.getKey())
-        );
+    public static void configureWith(Map.Entry<String, Object> entry) throws ConfiguratorException {
+
+        RootElementConfigurator configurator = Configurator.lookupRootElement(entry.getKey());
+        if (configurator == null) {
+            throw new ConfiguratorException(format("no configurator for root element <%s>", entry.getKey()));
+        }
         try {
             configurator.configure(entry.getValue());
-        } catch (Exception e) {
-            throw new IllegalStateException(
+        } catch (ConfiguratorException e) {
+            throw new ConfiguratorException(
+                    configurator,
                     format("error configuring <%s> with <%s> configurator", entry.getKey(), configurator.getName()),
                     e
             );

--- a/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
  *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public abstract class Configurator<T> implements ExtensionPoint {
+public abstract class Configurator<T> implements ExtensionPoint, ElementConfigurator {
 
     private final static Logger logger = Logger.getLogger(Configurator.class.getName());
 
@@ -173,9 +173,7 @@ public abstract class Configurator<T> implements ExtensionPoint {
         return Collections.singletonList(this);
     }
 
-    /**
-     * @return short name for this component when used in a configuration.yaml file
-     */
+    @Override
     public String getName() {
         final Symbol annotation = getTarget().getAnnotation(Symbol.class);
         if (annotation != null) return annotation.value()[0];
@@ -183,9 +181,7 @@ public abstract class Configurator<T> implements ExtensionPoint {
     }
 
     /**
-     * The actual component being managed by this Configurator
-     *
-     * @return the actual class that this configurator is configuring
+     * {@inheritDoc}
      */
     public abstract Class<T> getTarget();
 
@@ -233,16 +229,9 @@ public abstract class Configurator<T> implements ExtensionPoint {
     }
 
     /**
-     * Configures/creates a Jenkins object based on a tree.
-     *
-     * @param config
-     *      Map/List/primitive objects (think YAML) that represents the configuration from which
-     *      a Jenkins object is configured.
-     * @return
-     *      Fully configured Jenkins object that results from this configuration.
-     * @throws Exception if something went wrong, depends on the concrete implementation
+     * {@inheritDoc}
      */
-    public abstract T configure(Object config) throws Exception;
+    public abstract T configure(Object config) throws ConfiguratorException;
 
     /**
      * Ordered version of {@link #describe()} for documentation generation

--- a/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
@@ -49,7 +49,7 @@ public abstract class Configurator<T> implements ExtensionPoint {
 
     private final static Logger logger = Logger.getLogger(Configurator.class.getName());
 
-
+    @CheckForNull
     public static RootElementConfigurator lookupRootElement(String name) {
         for (RootElementConfigurator c : RootElementConfigurator.all()) {
             if (c.getName().equalsIgnoreCase(name)) {
@@ -141,7 +141,8 @@ public abstract class Configurator<T> implements ExtensionPoint {
         return null;
     }
 
-    public static Constructor getDataBoundConstructor(Class type) {
+    @CheckForNull
+    public static Constructor getDataBoundConstructor(@Nonnull Class type) {
         for (Constructor c : type.getConstructors()) {
             if (c.getAnnotation(DataBoundConstructor.class) != null) return c;
         }
@@ -149,7 +150,8 @@ public abstract class Configurator<T> implements ExtensionPoint {
 
     }
 
-    public static String normalize(String name) {
+    @Nonnull
+    public static String normalize(@Nonnull String name) {
         if (name.toUpperCase().equals(name)) {
             name = name.toLowerCase();
         } else {
@@ -166,6 +168,7 @@ public abstract class Configurator<T> implements ExtensionPoint {
      * @return the list of Configurator to be considered so one can fully configure this component.
      * Typically, an extension point with multiple implementations will return Configurators for available implementations.
      */
+    @Nonnull
     public List<Configurator> getConfigurators() {
         return Collections.singletonList(this);
     }
@@ -189,8 +192,9 @@ public abstract class Configurator<T> implements ExtensionPoint {
     /**
      * The extension point being implemented by this configurator.
      *
-     * @return The
+     * @return Extension point or {@code null} if undefined
      */
+    @CheckForNull
     public Class getExtensionPoint() {
         Class t = getTarget();
         if (ExtensionPoint.class.isAssignableFrom(t)) return t;
@@ -201,9 +205,11 @@ public abstract class Configurator<T> implements ExtensionPoint {
     /**
      * Retrieve which plugin do provide this extension point
      *
-     * @return String
+     * @return String representation of the extension source, usually artifactId.
+     *         {@code null} if {@link #getExtensionPoint()} returns {@code null}.
      * @throws IOException if config file cannot be saved
      */
+    @CheckForNull
     public String getExtensionSource() throws IOException {
         final Class e = getExtensionPoint();
         if (e == null) return null;
@@ -213,11 +219,13 @@ public abstract class Configurator<T> implements ExtensionPoint {
     }
 
 
+    //TODO: replace by a ClassName by default?
     /**
      * Human friendly display name for this component.
      *
-     * @return An empty string
+     * @return Display name or empty string
      */
+    @CheckForNull
     public String getDisplayName() { return ""; }
 
     private Klass getKlass() {
@@ -242,6 +250,7 @@ public abstract class Configurator<T> implements ExtensionPoint {
      * @return
      *      A list of {@link Attribute}s
      */
+    @Nonnull
     public List<Attribute> getAttributes() {
         final ArrayList<Attribute> attributes = new ArrayList<>(describe());
         Collections.sort(attributes, (a,b) -> a.name.compareTo(b.name));
@@ -264,15 +273,17 @@ public abstract class Configurator<T> implements ExtensionPoint {
      *
      * @return A set of {@link Attribute}s that describes this object
      */
+    @Nonnull
     public abstract Set<Attribute> describe();
 
     /**
      * Retrieve the html help tip associated to an attribute.
      * FIXME would prefer &lt;st:include page="help-${a.name}.html" class="${c.target}" optional="true"/&gt;
      * @param attribute to get help for
-     * @return String that shows help
+     * @return String that shows help. May be empty
      * @throws IOException if the resource cannot be read
      */
+    @Nonnull
     public String getHtmlHelp(String attribute) throws IOException {
         final URL resource = getKlass().getResource("help-" + attribute + ".html");
         if (resource != null) {

--- a/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
  *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public abstract class Configurator<T> implements ExtensionPoint, ElementConfigurator {
+public abstract class Configurator<T> implements ExtensionPoint, ElementConfigurator<T> {
 
     private final static Logger logger = Logger.getLogger(Configurator.class.getName());
 

--- a/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
@@ -62,6 +62,21 @@ public abstract class Configurator<T> implements ExtensionPoint, ElementConfigur
     /**
      * Looks for a configurator for exact type.
      * @param type Type
+     * @return Configurator
+     * @throws ConfiguratorException Configurator is not found
+     */
+    @Nonnull
+    public static Configurator lookupOrFail(Type type) throws ConfiguratorException {
+        Configurator cfg = lookup(type);
+        if (cfg == null) {
+            throw new ConfiguratorException("Cannot find configurator for type " + type);
+        }
+        return cfg;
+    }
+
+    /**
+     * Looks for a configurator for exact type.
+     * @param type Type
      * @return Configurator or {@code null} if it is not found
      */
     @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/casc/ConfiguratorException.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ConfiguratorException.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.casc;
+
+import javax.annotation.CheckForNull;
+import java.io.IOException;
+
+/**
+ * Exception type for {@link Configurator} issues.
+ * @author Oleg Nenashev
+ * @since TODO
+ * @see Configurator#configure(Object)
+ * @see ElementConfigurator
+ */
+public class ConfiguratorException extends IOException {
+
+    @CheckForNull
+    private final ElementConfigurator configurator;
+
+    public ConfiguratorException(@CheckForNull ElementConfigurator configurator, @CheckForNull String message, @CheckForNull Throwable cause) {
+        super(message, cause);
+        this.configurator = configurator;
+    }
+
+    public ConfiguratorException(@CheckForNull String message, @CheckForNull Throwable cause) {
+        this(null, message, cause);
+    }
+
+    public ConfiguratorException(@CheckForNull ElementConfigurator configurator, @CheckForNull String message) {
+        this(configurator, message, null);
+    }
+
+    public ConfiguratorException(@CheckForNull String message) {
+        this(null, message, null);
+    }
+
+    public ConfiguratorException(@CheckForNull Throwable cause) {
+        this(null, null, cause);
+    }
+
+    @CheckForNull
+    public ElementConfigurator getConfigurator() {
+        return configurator;
+    }
+
+    @Override
+    public String getMessage() {
+        if (configurator != null) {
+            return String.format("%s: %s", configurator.getName(), super.getMessage());
+        }
+        return super.getMessage();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/casc/DescriptorConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/DescriptorConfigurator.java
@@ -9,7 +9,7 @@ import java.util.Map;
  * Define a Configurator for a Descriptor
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class DescriptorConfigurator extends BaseConfigurator<Descriptor> implements RootElementConfigurator {
+public class DescriptorConfigurator extends BaseConfigurator<Descriptor> implements RootElementConfigurator<Descriptor> {
 
 
     private final String name;

--- a/src/main/java/org/jenkinsci/plugins/casc/DescriptorConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/DescriptorConfigurator.java
@@ -41,7 +41,7 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor> impleme
     }
 
     @Override
-    public Descriptor configure(Object config) throws Exception {
+    public Descriptor configure(Object config) throws ConfiguratorException {
         configure((Map) config, descriptor);
         return descriptor;
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.casc;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+/**
+ * Define a {@link Configurator} which handles a configuration element, identified by name.
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author Oleg Nenashev
+ * @see RootElementConfigurator
+ */
+public interface ElementConfigurator {
+
+    /**
+     * Get a configurator name.
+     * @return short name for this component when used in a configuration.yaml file
+     */
+    @Nonnull
+    String getName();
+
+    /**
+     * Determine the list of Attribute available for configuration of the managed component.
+     *
+     * @return A set of {@link Attribute}s that describes this object
+     */
+    @Nonnull
+    Set<Attribute> describe();
+
+    /**
+     * Configures/creates a Jenkins object based on a tree.
+     *
+     * @param config
+     *      Map/List/primitive objects (think YAML) that represents the configuration from which
+     *      a Jenkins object is configured.
+     * @return
+     *      Fully configured Jenkins object that results from this configuration.
+     *      {@code null} if no new objects got created, but in such case some existing objects may have been modified
+     * @throws ConfiguratorException if something went wrong, depends on the concrete implementation
+     */
+    @CheckForNull
+    Object configure(Object config) throws ConfiguratorException;
+}

--- a/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * @author Oleg Nenashev
  * @see RootElementConfigurator
  */
-public interface ElementConfigurator {
+public interface ElementConfigurator<T> {
 
     /**
      * Get a configurator name.
@@ -60,5 +60,25 @@ public interface ElementConfigurator {
      * @throws ConfiguratorException if something went wrong, depends on the concrete implementation
      */
     @CheckForNull
-    Object configure(Object config) throws ConfiguratorException;
+    T configure(Object config) throws ConfiguratorException;
+
+    /**
+     * Configures/creates a Jenkins object based on a tree.
+     *
+     * @param config
+     *      Map/List/primitive objects (think YAML) that represents the configuration from which
+     *      a Jenkins object is configured.
+     * @return
+     *      Fully configured Jenkins object that results from this configuration.
+     * @throws ConfiguratorException if something went wrong, depends on the concrete implementation.
+     *      Also throws exception if the converted object is {@code null}
+     */
+    @Nonnull
+    default T configureNonNull(Object config) throws ConfiguratorException {
+        T converted = configure(config);
+        if (converted == null) {
+            throw new ConfiguratorException(this, "Converted object is null, but a non-null object is required");
+        }
+        return converted;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/ExtensionConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ExtensionConfigurator.java
@@ -26,7 +26,7 @@ public class ExtensionConfigurator extends BaseConfigurator {
 
 
     @Override
-    public Object configure(Object c) throws Exception {
+    public Object configure(Object c) throws ConfiguratorException {
         final ExtensionList list = Jenkins.getInstance().getExtensionList(target);
         if (list.size() != 1) {
             throw new IllegalStateException();
@@ -43,7 +43,11 @@ public class ExtensionConfigurator extends BaseConfigurator {
                     final Configurator configurator = Configurator.lookup(k);
                     if (configurator == null) throw new IllegalStateException("No configurator implementation to manage "+ k);
                     final Object value = configurator.configure(config.get(name));
-                    attribute.setValue(o, value);
+                    try {
+                        attribute.setValue(o, value);
+                    } catch (Exception e) {
+                        throw new ConfiguratorException(this, "Failed to set attribute " + attribute, e);
+                    }
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/casc/GlobalConfigurationCategoryConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/GlobalConfigurationCategoryConfigurator.java
@@ -41,7 +41,7 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator im
     }
 
     @Override
-    public Object configure(Object config) throws Exception {
+    public Object configure(Object config) throws ConfiguratorException {
         configure((Map) config, category);
         return category;
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/HeteroDescribableConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/HeteroDescribableConfigurator.java
@@ -49,7 +49,7 @@ public class HeteroDescribableConfigurator extends Configurator<Describable> {
     }
 
     @Override
-    public Describable configure(Object config) throws Exception {
+    public Describable configure(Object config) throws ConfiguratorException {
         String shortname;
         Object subconfig = null;
         if (config instanceof String) {

--- a/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -39,7 +39,7 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
     }
 
     @Override
-    public Jenkins configure(Object c) throws Exception {
+    public Jenkins configure(Object c) throws ConfiguratorException {
         Map config = (Map) c;
         Jenkins jenkins = Jenkins.getInstance();
 

--- a/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Extension
-public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements RootElementConfigurator {
+public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements RootElementConfigurator<Jenkins> {
 
     private static final Logger LOGGER = Logger.getLogger(JenkinsConfigurator.class.getName());
 

--- a/src/main/java/org/jenkinsci/plugins/casc/RootElementConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/RootElementConfigurator.java
@@ -14,7 +14,7 @@ import java.util.Set;
  * Note: we assume any configurator here will use a unique name for root element.
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public interface RootElementConfigurator extends ElementConfigurator {
+public interface RootElementConfigurator<T> extends ElementConfigurator<T> {
 
     static List<RootElementConfigurator> all() {
         List<RootElementConfigurator> configurators = new ArrayList<>();

--- a/src/main/java/org/jenkinsci/plugins/casc/RootElementConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/RootElementConfigurator.java
@@ -14,7 +14,7 @@ import java.util.Set;
  * Note: we assume any configurator here will use a unique name for root element.
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public interface RootElementConfigurator {
+public interface RootElementConfigurator extends ElementConfigurator {
 
     static List<RootElementConfigurator> all() {
         List<RootElementConfigurator> configurators = new ArrayList<>();
@@ -27,10 +27,4 @@ public interface RootElementConfigurator {
 
         return configurators;
     }
-
-    String getName();
-
-    Set<Attribute> describe();
-
-    Object configure(Object config) throws Exception;
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/SeedJobConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/SeedJobConfigurator.java
@@ -28,10 +28,14 @@ public class SeedJobConfigurator implements RootElementConfigurator {
     }
 
     @Override
-    public Object configure(Object config) throws Exception {
+    public Object configure(Object config) throws ConfiguratorException {
         JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
         for (String script : (List<String>) config) {
-            new JenkinsDslScriptLoader(mng).runScript(script);
+            try {
+                new JenkinsDslScriptLoader(mng).runScript(script);
+            } catch (Exception ex) {
+                throw new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), ex);
+            }
         }
 
         return null;

--- a/src/main/java/org/jenkinsci/plugins/casc/TopLevelItemConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/TopLevelItemConfigurator.java
@@ -23,7 +23,7 @@ public class TopLevelItemConfigurator extends BaseConfigurator<TopLevelItem> {
     }
 
     @Override
-    public TopLevelItem configure(Object c) throws Exception {
+    public TopLevelItem configure(Object c) throws ConfiguratorException {
 
         Map config = (Map) c;
 

--- a/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
@@ -26,6 +26,7 @@ import jenkins.model.Jenkins;
 import jenkins.security.s2m.AdminWhitelistRule;
 import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.BaseConfigurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -54,7 +55,7 @@ public class AdminWhitelistRuleConfigurator extends BaseConfigurator<AdminWhitel
     }
 
     @Override
-    public AdminWhitelistRule configure(Object config) throws Exception {
+    public AdminWhitelistRule configure(Object config) throws ConfiguratorException {
         Injector injector = Jenkins.getInstance().getInjector();
         AdminWhitelistRule instance = injector.getInstance(AdminWhitelistRule.class);
         configure((Map)config, instance);

--- a/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.AuthorizationStrategy.Unsecured;
 import org.jenkinsci.plugins.casc.BaseConfigurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
 
 /**
  * Handles {@link AuthorizationStrategy.Unsecured} that requires a special treatment due to its singleton semantics.
@@ -18,7 +19,7 @@ public class UnsecuredAuthorizationStrategyConfigurator extends BaseConfigurator
     }
 
     @Override
-    public Unsecured configure(Object config) throws Exception {
+    public Unsecured configure(Object config) throws ConfiguratorException {
         return (Unsecured)AuthorizationStrategy.UNSECURED;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Extension(optional = true)
-public class CredentialsRootConfigurator extends Configurator<CredentialsStore> implements RootElementConfigurator {
+public class CredentialsRootConfigurator extends Configurator<CredentialsStore> implements RootElementConfigurator<CredentialsStore> {
 
     private final static Logger logger = Logger.getLogger(CredentialsRootConfigurator.class.getName());
 
@@ -46,11 +46,11 @@ public class CredentialsRootConfigurator extends Configurator<CredentialsStore> 
         final Map<Domain, List<Credentials>> target = SystemCredentialsProvider.getInstance().getDomainCredentialsMap();
         target.clear();
 
-        final Configurator<Domain> domainConfigurator = Configurator.lookup(Domain.class);
-        final Configurator<Credentials> credentialsConfigurator = Configurator.lookup(Credentials.class);
+        final Configurator<Domain> domainConfigurator = Configurator.lookupOrFail(Domain.class);
+        final Configurator<Credentials> credentialsConfigurator = Configurator.lookupOrFail(Credentials.class);
 
         for (Map.Entry dc : system.entrySet()) {
-            final Domain domain = domainConfigurator.configure(dc.getKey());
+            final Domain domain = domainConfigurator.configureNonNull(dc.getKey());
             List values = (List) dc.getValue();
             final List<Credentials> credentials =  new ArrayList<>();
             for (Object value : values) {

--- a/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
 import org.jenkinsci.plugins.casc.RootElementConfigurator;
 
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ public class CredentialsRootConfigurator extends Configurator<CredentialsStore> 
     }
 
     @Override
-    public CredentialsStore configure(Object config) throws Exception {
+    public CredentialsStore configure(Object config) throws ConfiguratorException {
         Map map = (Map) config;
         final Map<?,?> system = (Map) map.get("system");
         final Map<Domain, List<Credentials>> target = SystemCredentialsProvider.getInstance().getDomainCredentialsMap();

--- a/src/main/java/org/jenkinsci/plugins/casc/integrations/globalmatrixauth/GlobalMatrixAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/integrations/globalmatrixauth/GlobalMatrixAuthorizationStrategyConfigurator.java
@@ -20,7 +20,7 @@ import java.util.*;
  */
 @Extension(optional = true)
 @Restricted(NoExternalUse.class)
-public class GlobalMatrixAuthorizationStrategyConfigurator extends Configurator<GlobalMatrixAuthorizationStrategy> implements RootElementConfigurator {
+public class GlobalMatrixAuthorizationStrategyConfigurator extends Configurator<GlobalMatrixAuthorizationStrategy> implements RootElementConfigurator<GlobalMatrixAuthorizationStrategy> {
 
     @Override
     public String getName() {
@@ -42,10 +42,10 @@ public class GlobalMatrixAuthorizationStrategyConfigurator extends Configurator<
     public GlobalMatrixAuthorizationStrategy configure(Object config) throws ConfiguratorException {
         Map map = (Map) config;
         Collection o = (Collection<?>)map.get("grantedPermissions");
-        Configurator<GroupPermissionDefinition> permissionConfigurator = Configurator.lookup(GroupPermissionDefinition.class);
+        Configurator<GroupPermissionDefinition> permissionConfigurator = Configurator.lookupOrFail(GroupPermissionDefinition.class);
         Map<Permission,Set<String>> grantedPermissions = new HashMap<>();
         for(Object entry : o) {
-            GroupPermissionDefinition gpd = permissionConfigurator.configure(entry);
+            GroupPermissionDefinition gpd = permissionConfigurator.configureNonNull(entry);
             //We transform the linear list to a matrix (Where permission is the key instead)
             gpd.grantPermission(grantedPermissions);
         }

--- a/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
@@ -6,6 +6,7 @@ import hudson.security.Permission;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
 import org.jenkinsci.plugins.casc.RootElementConfigurator;
 import org.jenkinsci.plugins.casc.integrations.globalmatrixauth.GroupPermissionDefinition;
 import org.kohsuke.accmod.Restricted;
@@ -28,7 +29,7 @@ public class ProjectMatrixAuthorizationStrategyConfigurator extends Configurator
     }
 
     @Override
-    public ProjectMatrixAuthorizationStrategy configure(Object config) throws Exception {
+    public ProjectMatrixAuthorizationStrategy configure(Object config) throws ConfiguratorException {
         Map map = (Map) config;
         Collection o = (Collection<?>)map.get("grantedPermissions");
         Configurator<GroupPermissionDefinition> permissionConfigurator = Configurator.lookup(GroupPermissionDefinition.class);

--- a/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
@@ -16,7 +16,7 @@ import java.util.*;
 
 @Extension(optional = true)
 @Restricted(NoExternalUse.class)
-public class ProjectMatrixAuthorizationStrategyConfigurator extends Configurator<ProjectMatrixAuthorizationStrategy> implements RootElementConfigurator {
+public class ProjectMatrixAuthorizationStrategyConfigurator extends Configurator<ProjectMatrixAuthorizationStrategy> implements RootElementConfigurator<ProjectMatrixAuthorizationStrategy> {
 
     @Override
     public String getName() {
@@ -32,10 +32,10 @@ public class ProjectMatrixAuthorizationStrategyConfigurator extends Configurator
     public ProjectMatrixAuthorizationStrategy configure(Object config) throws ConfiguratorException {
         Map map = (Map) config;
         Collection o = (Collection<?>)map.get("grantedPermissions");
-        Configurator<GroupPermissionDefinition> permissionConfigurator = Configurator.lookup(GroupPermissionDefinition.class);
+        Configurator<GroupPermissionDefinition> permissionConfigurator = Configurator.lookupOrFail(GroupPermissionDefinition.class);
         Map<Permission,Set<String>> grantedPermissions = new HashMap<>();
         for(Object entry : o) {
-            GroupPermissionDefinition gpd = permissionConfigurator.configure(entry);
+            GroupPermissionDefinition gpd = permissionConfigurator.configureNonNull(entry);
             //We transform the linear list to a matrix (Where permission is the key instead)
             gpd.grantPermission(grantedPermissions);
         }

--- a/src/main/java/org/jenkinsci/plugins/casc/integrations/rolebasedauth/RoleBasedAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/integrations/rolebasedauth/RoleBasedAuthorizationStrategyConfigurator.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
 import org.jenkinsci.plugins.casc.RootElementConfigurator;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -42,12 +43,12 @@ public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<Rol
     }
 
     @Override
-    public RoleBasedAuthorizationStrategy configure(Object config) throws Exception {
+    public RoleBasedAuthorizationStrategy configure(Object config) throws ConfiguratorException {
         //TODO: API should return a qualified type
         final Configurator<RoleDefinition> roleDefinitionConfigurator =
                 (Configurator<RoleDefinition>) Configurator.lookup(RoleDefinition.class);
         if (roleDefinitionConfigurator == null) {
-            throw new IOException("Cannot find configurator for" + RoleDefinition.class);
+            throw new ConfiguratorException(this, "Cannot find configurator for" + RoleDefinition.class);
         }
 
 
@@ -67,7 +68,7 @@ public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<Rol
     }
 
     @Nonnull
-    private static RoleMap retrieveRoleMap(@Nonnull Object config, @Nonnull String name, Configurator<RoleDefinition> configurator) throws Exception {
+    private static RoleMap retrieveRoleMap(@Nonnull Object config, @Nonnull String name, Configurator<RoleDefinition> configurator) throws ConfiguratorException {
         Map map = (Map) config;
         final Collection<?> c = (Collection<?>) map.get(name);
 

--- a/src/main/java/org/jenkinsci/plugins/casc/integrations/rolebasedauth/RoleBasedAuthorizationStrategyConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/integrations/rolebasedauth/RoleBasedAuthorizationStrategyConfigurator.java
@@ -30,7 +30,8 @@ import java.util.TreeMap;
  */
 @Extension(optional = true)
 @Restricted({NoExternalUse.class})
-public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<RoleBasedAuthorizationStrategy> implements RootElementConfigurator {
+public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<RoleBasedAuthorizationStrategy>
+        implements RootElementConfigurator<RoleBasedAuthorizationStrategy> {
 
     @Override
     public String getName() {
@@ -46,11 +47,7 @@ public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<Rol
     public RoleBasedAuthorizationStrategy configure(Object config) throws ConfiguratorException {
         //TODO: API should return a qualified type
         final Configurator<RoleDefinition> roleDefinitionConfigurator =
-                (Configurator<RoleDefinition>) Configurator.lookup(RoleDefinition.class);
-        if (roleDefinitionConfigurator == null) {
-            throw new ConfiguratorException(this, "Cannot find configurator for" + RoleDefinition.class);
-        }
-
+                (Configurator<RoleDefinition>) Configurator.lookupOrFail(RoleDefinition.class);
 
         Map map = (Map) config;
         Map<String, RoleMap> grantedRoles = new HashMap<>();
@@ -79,7 +76,7 @@ public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<Rol
         }
 
         for (Object entry : c) {
-            RoleDefinition definition = configurator.configure(entry);
+            RoleDefinition definition = configurator.configureNonNull(entry);
             resMap.put(definition.getRole(), definition.getAssignments());
         }
 

--- a/src/test/java/org/jenkinsci/plugins/casc/misc/TestConfiguration.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/misc/TestConfiguration.java
@@ -26,9 +26,9 @@ public class TestConfiguration {
 
     public void configure(Class<?> clazz) {
         try (Reader reader = new InputStreamReader(clazz.getResourceAsStream(resource), UTF_8)) {
-            ((Map<String, Object>) new Yaml().loadAs(reader, Map.class))
-                    .entrySet()
-                    .forEach(ConfigurationAsCode::configureWith);
+            for (Map.Entry<String, Object> entry : ((Map<String, Object>) new Yaml().loadAs(reader, Map.class)).entrySet()) {
+                 ConfigurationAsCode.configureWith(entry);
+            }
         } catch (IOException e) {
             throw new IllegalStateException(String.format("Can't configure test <%s> with <%s>", clazz, resource), e);
         }


### PR DESCRIPTION
See #164. Just a first refactorings drop, which should improve issue diagnosability a bit

- [x] - Annotate API methods in the Configurator extension point
- [x] - Introduce `ElementConverter` interface which is a top-level interface for all converters
- [x] - Introduce `ConverterException`, switch convert() APIs to it
- [x] - Add some utility methods for null checks
- [x] - Fix error propagation and FindBugs issues

@reviewbybees 