### PR TITLE
Configurator#getExtensionPoint() was returning value for non-ExtensionPoint types

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
@@ -191,10 +191,12 @@ public abstract class Configurator<T> implements ExtensionPoint {
      *
      * @return The
      */
-    public Class getExtensionPoint() {
+    public Class<? extends ExtensionPoint> getExtensionPoint() {
         Class t = getTarget();
-        if (ExtensionPoint.class.isAssignableFrom(t)) return t;
-        return t;
+        if (ExtensionPoint.class.isAssignableFrom(t)) {
+            return (Class<? extends ExtensionPoint>)t;
+        }
+        return null; // Target is not an extension point or its implementation
     }
 
 


### PR DESCRIPTION
Noticed it while doing patches for #164 in #165.

It violates the behavior described in Javadoc, so IMHO the method should return null when invoked for non-ExtensionPoint implementations.
