### PR TITLE
Updated documentation for JNLP slaves for newer Jenkins versions

### DIFF
--- a/demos/build_agents/README.md
+++ b/demos/build_agents/README.md
@@ -4,6 +4,8 @@ Build agents configuration belongs (currently) under `jenkins` root element
 
 ## sample configuration
 
+### Jenkins versions < 2.68
+
 ```yaml
 jenkins:
   (...)
@@ -15,6 +17,44 @@ jenkins:
         remoteFS: "/home/user1"
         launcher:
           jnlp:
+    - dumb:
+        labelString: "linux docker test"
+        mode: NORMAL
+        name: "utility-node-2"
+        remoteFS: "/home/user2"
+        launcher:
+          SSHLauncher:
+            host: "192.168.1.1"
+            port: 22
+            credentialsId: test
+            launchTimeoutSeconds: 60
+            maxNumRetries: 3
+            retryWaitTime: 30
+            sshHostKeyVerificationStrategy:
+              manuallyTrustedKeyVerificationStrategy:
+                requireInitialManualTrust: false
+```
+
+### Jenkins versions >= 2.68
+
+Changes in remoting means a new setting is required for JNLP agents.
+
+```yaml
+jenkins:
+  (...)
+  nodes:
+    - dumb:
+        labelString: "linux docker test"
+        mode: NORMAL
+        name: "utility-node"
+        remoteFS: "/home/user1"
+        launcher:
+          jnlp:
+            workDirSettings:
+              disabled: true
+              workDirPath: 
+              internalDir:
+              failIfWorkDirIsMissing: false          
     - dumb:
         labelString: "linux docker test"
         mode: NORMAL


### PR DESCRIPTION
Found out while creating a demo, that recent changes in remoting requires a new configuration for JNLP slaves. 

So i updated the documentation with the new tidbits.