### PR TITLE
Enable testing against 2.107.1 in order to reveal potential JEP-200 regressions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(jenkinsVersions: [null, "2.107.1"])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>3.7</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
The plugin is doing some configuration serialization operations. There is a potential risk that some operations or integration tests fail with [JEP-200](https://jenkins.io/blog/2018/03/15/jep-200-lts/) regressions on newer Jenkins core.

Testing against a new core is useful in general, so I would propose to enable it in CI independently from the JEP-200 context.

@reviewbybees 
