### PR TITLE
Plugins installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ work/
 
 # ignore jenkins.yaml from root folder (used by many for testing)
 /jenkins.yaml
+plugins.txt

--- a/src/main/java/org/jenkinsci/plugins/casc/model/Mapping.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/model/Mapping.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.casc.model;
 
+import org.jenkinsci.plugins.casc.ConfiguratorException;
+
 import java.util.HashMap;
 
 /**
@@ -30,5 +32,9 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
 
     public void put(String key, Boolean value) {
         super.put(key, new Scalar(String.valueOf(value)));
+    }
+
+    public String getScalarValue(String key) throws ConfiguratorException {
+        return get(key).asScalar().getValue();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/model/Mapping.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/model/Mapping.java
@@ -34,6 +34,14 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
         super.put(key, new Scalar(String.valueOf(value)));
     }
 
+    public void putIfNotNull(String key, CNode node) {
+        if (node != null) super.put(key, node);
+    }
+
+    public void putIfNotEmpry(String key, Sequence seq) {
+        if (!seq.isEmpty()) super.put(key, seq);
+    }
+
     public String getScalarValue(String key) throws ConfiguratorException {
         return get(key).asScalar().getValue();
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -141,7 +141,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                         json.accumulate("dependencies", new JSONArray());
                         final UpdateSite.Plugin installable = updateSite.new Plugin(updateSite.getId(), json);
                         try {
-                            final UpdateCenter.UpdateCenterJob job = installable.deploy().get();
+                            final UpdateCenter.UpdateCenterJob job = installable.deploy(true).get();
                             if (job.getError() != null) throw job.getError();
                             installed.add(p.shortname);
 
@@ -178,6 +178,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                 throw new ConfiguratorException("failed to write plugins.txt shrinkwrap file", e);
             }
 
+        /* FIXME Can wa always install plugin dynamically ? Some might require a restart to run a clean init
             if (!installed.isEmpty()) {
                 try {
                     Lifecycle.get().restart();
@@ -185,6 +186,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                     throw new ConfiguratorException("Can't restart master after plugins installation", e);
                 }
             }
+        */
         }
 
         try {

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
@@ -38,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
@@ -123,9 +121,6 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
         if (!plugins.isEmpty()) {
 
             boolean requireRestart = false;
-
-            UUID correlationId = UUID.randomUUID();
-
             Set<String> installed = new HashSet<>();
 
             // Install a plugin from the plugins list.
@@ -148,7 +143,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                     json.accumulate("dependencies", new JSONArray());
                     final UpdateSite.Plugin installable = updateSite.new Plugin(updateSite.getId(), json);
                     try {
-                        final UpdateCenter.UpdateCenterJob job = installable.deploy(true, correlationId).get();
+                        final UpdateCenter.UpdateCenterJob job = installable.deploy(true).get();
                         if (job.getError() != null) {
                             if (job.getError() instanceof UpdateCenter.DownloadJob.SuccessButRequiresRestart) {
                                 requireRestart = true;

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -180,7 +180,14 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
         try (PrintWriter w = new PrintWriter(shrinkwrap, UTF_8.name())) {
             for (PluginWrapper pw : pluginManager.getPlugins()) {
                 if (pw.getShortName().equals("configuration-as-code")) continue;
-                w.println(pw.getShortName() + ":" + pw.getVersionNumber().toString());
+                String from = UpdateCenter.PREDEFINED_UPDATE_SITE_ID;
+                for (UpdateSite site : jenkins.getUpdateCenter().getSites()) {
+                    if (site.getPlugin(pw.getShortName()) != null) {
+                        from = site.getId();
+                        break;
+                    }
+                }
+                w.println(pw.getShortName() + ':' + pw.getVersionNumber().toString() + '@' + from);
             }
         } catch (IOException e) {
             throw new ConfiguratorException("failed to write plugins.txt shrinkwrap file", e);

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -266,9 +266,10 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
     @Override
     public CNode describe(PluginManager instance) throws Exception {
         final Mapping mapping = new Mapping();
-        mapping.putIfNotNull("proxy", Configurator.lookup(ProxyConfiguration.class).describe(Jenkins.getInstance().proxy));
+        final Configurator cp = Configurator.lookupOrFail(ProxyConfiguration.class);
+        mapping.putIfNotNull("proxy", cp.describe(Jenkins.getInstance().proxy));
         Sequence seq = new Sequence();
-        final Configurator cs = Configurator.lookup(UpdateSite.class);
+        final Configurator cs = Configurator.lookupOrFail(UpdateSite.class);
         for (UpdateSite site : Jenkins.getInstance().getUpdateCenter().getSiteList()) {
             seq.add(cs.describe(site));
         }

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -1,0 +1,138 @@
+package org.jenkinsci.plugins.casc.plugins;
+
+import hudson.Extension;
+import hudson.Plugin;
+import hudson.PluginManager;
+import hudson.ProxyConfiguration;
+import hudson.model.UpdateCenter;
+import hudson.model.UpdateSite;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.casc.Attribute;
+import org.jenkinsci.plugins.casc.BaseConfigurator;
+import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.RootElementConfigurator;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension
+public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> implements RootElementConfigurator {
+
+    @Override
+    public Class<PluginManager> getTarget() {
+        return PluginManager.class;
+    }
+
+    @Override
+    public PluginManager configure(Object config) throws Exception {
+        Map<?,?> map = (Map) config;
+        final Jenkins jenkins = Jenkins.getInstance();
+
+        final Object proxy = map.get("proxy");
+        if (proxy != null) {
+            Configurator<ProxyConfiguration> pc = Configurator.lookup(ProxyConfiguration.class);
+            ProxyConfiguration pcc = pc.configure(proxy);
+            jenkins.proxy = pcc;
+        }
+
+        final List<?> sites = (List<?>) map.get("updateSites");
+        final UpdateCenter updateCenter = jenkins.getUpdateCenter();
+        if (sites != null) {
+            Configurator<UpdateSite> usc = Configurator.lookup(UpdateSite.class);
+            List<UpdateSite> updateSites = new ArrayList<>();
+            for (Object data : sites) {
+                UpdateSite in = usc.configure(data);
+                updateSites.add(in);
+            }
+
+            List<UpdateSite> us = updateCenter.getSites();
+            us.clear();
+            us.addAll(updateSites);
+        }
+
+
+        final Map<String, String> plugins = (Map) map.get("required");
+        final List<UpdateSite.Plugin> requiredPlugins = getRequiredPlugins(plugins, jenkins, updateCenter);
+        List<Future<UpdateCenter.UpdateCenterJob>> installations = new ArrayList<>();
+        for (UpdateSite.Plugin plugin : requiredPlugins) {
+            installations.add(plugin.deploy());
+        }
+
+        for (Future<UpdateCenter.UpdateCenterJob> job : installations) {
+            // TODO manage failure, timeout, etc
+            job.get();
+        }
+
+        if (!installations.isEmpty()) jenkins.restart();
+
+        jenkins.save();
+        return jenkins.getPluginManager();
+    }
+
+    /**
+     * Collect required plugins as {@link UpdateSite.Plugin} so we can trigger installation if required
+     */
+    private List<UpdateSite.Plugin> getRequiredPlugins(Map<String, String> plugins, Jenkins jenkins, UpdateCenter updateCenter) throws IOException {
+        List<UpdateSite.Plugin> installations = new ArrayList<>();
+        if (plugins != null) {
+            for (Map.Entry<String, String> e : plugins.entrySet()) {
+                String shortname = e.getKey();
+                String version = e.getValue();
+                final Plugin plugin = jenkins.getPlugin(shortname);
+                if (plugin == null || !plugin.getWrapper().getVersion().equals(e.getValue())) { // Need to install
+
+                    boolean found = false;
+                    for (UpdateSite updateSite : updateCenter.getSites()) {
+                        final UpdateSite.Plugin p = updateSite.getPlugin(shortname);
+                        if (p != null) {
+                            // This plugin is distributed by this update site
+
+                            // FIXME see https://github.com/jenkins-infra/update-center2/pull/192
+                            // get plugin metadata for this specific version of the target plugin
+                            final URI metadata = URI.create(updateSite.getUrl()).resolve("download/plugins/" + shortname + "/" + version + "/metadata.json");
+                            try (InputStream open = ProxyConfiguration.open(metadata.toURL()).getInputStream()) {
+                                final JSONObject json = JSONObject.fromObject(IOUtils.toString(open));
+                                final UpdateSite.Plugin installable = updateSite.new Plugin(updateSite.getId(), json);
+                                installations.add(installable);
+                            }
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found) {
+                        throw new IllegalArgumentException("Can't find plugin "+shortname+" in configured update sites");
+                    }
+                }
+            }
+        }
+        return installations;
+    }
+
+    @Override
+    public String getName() {
+        return "plugins";
+    }
+
+    @Override
+    public Set<Attribute> describe() {
+        Set<Attribute> attr =  new HashSet<>();
+        attr.add(new Attribute("proxy", ProxyConfiguration.class));
+        attr.add(new Attribute("updateSites", new ArrayList<UpdateSite>().getClass()));
+        attr.add(new Attribute("required", new ArrayList<Plugins>().getClass()));
+        return attr;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -140,6 +140,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
 
                 boolean downloaded = false;
                 UpdateSite updateSite = updateCenter.getSite(p.site);
+                if (updateSite == null) throw new ConfiguratorException("Can't install "+p+": no update site "+p.site);
                 final UpdateSite.Plugin installable = updateSite.new Plugin(updateSite.getId(), json);
                 try {
                     final UpdateCenter.UpdateCenterJob job = installable.deploy(true).get();

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -161,12 +161,11 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                             final JSONObject json = JSONObject.fromObject(IOUtils.toString(open));
                             final UpdateSite.Plugin installable = updateSite.new Plugin(updateSite.getId(), json);
                             installations.add(installable);
+                            found = true;
+                            break;
                         } catch (IOException io) {
                             // Not published by this update site
-                            System.err.println(io);
                         }
-                        found = true;
-                        break;
                     }
 
                     if (!found) {

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -6,9 +6,9 @@ import hudson.PluginManager;
 import hudson.PluginWrapper;
 import hudson.ProxyConfiguration;
 import hudson.lifecycle.RestartNotSupportedException;
+import hudson.model.DownloadService;
 import hudson.model.UpdateCenter;
 import hudson.model.UpdateSite;
-import hudson.util.PersistedList;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
@@ -21,10 +21,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -74,7 +71,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
             for (Object data : sites) {
                 UpdateSite in = usc.configure(data);
                 if (in.isDue()) {
-                    in.updateDirectly(true);
+                    in.updateDirectly(DownloadService.signatureCheck);
                 }
                 updateSites.add(in);
             }

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -143,7 +143,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
     /**
      * Collect required plugins as {@link UpdateSite.Plugin} so we can trigger installation if required
      */
-    private List<UpdateSite.Plugin> getRequiredPlugins(Map<String, String> plugins, Jenkins jenkins, UpdateCenter updateCenter) {
+    private List<UpdateSite.Plugin> getRequiredPlugins(Map<String, String> plugins, Jenkins jenkins, UpdateCenter updateCenter) throws ConfiguratorException {
         List<UpdateSite.Plugin> installations = new ArrayList<>();
         if (plugins != null) {
             for (Map.Entry<String, String> e : plugins.entrySet()) {
@@ -169,7 +169,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                     }
 
                     if (!found) {
-                        throw new IllegalArgumentException("Can't find plugin "+shortname+" in configured update sites");
+                        throw new ConfiguratorException("Can't find plugin "+shortname+" in configured update sites");
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginToInstall.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginToInstall.java
@@ -31,12 +31,14 @@ class PluginToInstall {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PluginToInstall that = (PluginToInstall) o;
-        return Objects.equals(shortname, that.shortname);
+        return Objects.equals(site, that.site) &&
+                Objects.equals(shortname, that.shortname) &&
+                Objects.equals(version, that.version);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(shortname);
+        return Objects.hash(site, shortname, version);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginToInstall.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginToInstall.java
@@ -20,6 +20,13 @@ class PluginToInstall {
     }
 
     @Override
+    public String toString() {
+        return new StringBuilder(shortname)
+                .append(':').append(version)
+                .append('@').append(site).toString();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginToInstall.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginToInstall.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.casc.plugins;
+
+import hudson.model.UpdateCenter;
+
+import java.util.Objects;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+class PluginToInstall {
+    public final String site;
+    public final String shortname;
+    public final String version;
+
+    public PluginToInstall(String shortname, String version) {
+        this.shortname = shortname;
+        final int i = version.indexOf('@');
+        this.version = i < 0 ? version : version.substring(0,i);
+        this.site = i < 0 ? UpdateCenter.PREDEFINED_UPDATE_SITE_ID : version.substring(i+1);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PluginToInstall that = (PluginToInstall) o;
+        return Objects.equals(shortname, that.shortname);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(shortname);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/Plugins.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/Plugins.java
@@ -1,0 +1,12 @@
+package org.jenkinsci.plugins.casc.plugins;
+
+import hudson.util.VersionNumber;
+
+import java.util.HashMap;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class Plugins extends HashMap<String, VersionNumber> {
+
+}

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
@@ -19,7 +19,7 @@ public class UpdateSiteConfigurator extends BaseConfigurator<UpdateSite> {
     }
 
     @Override
-    public UpdateSite configure(Object config) throws Exception {
+    public UpdateSite configure(Object config) {
         Map<String, String> map = (Map) config;
         return new UpdateSite(map.get("id"), map.get("url"));
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
@@ -3,7 +3,11 @@ package org.jenkinsci.plugins.casc.plugins;
 import hudson.Extension;
 import hudson.model.UpdateSite;
 import org.jenkinsci.plugins.casc.BaseConfigurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
+import org.jenkinsci.plugins.casc.model.CNode;
+import org.jenkinsci.plugins.casc.model.Mapping;
 
+import javax.annotation.CheckForNull;
 import java.util.Map;
 
 /**
@@ -19,8 +23,19 @@ public class UpdateSiteConfigurator extends BaseConfigurator<UpdateSite> {
     }
 
     @Override
-    public UpdateSite configure(Object config) {
-        Map<String, String> map = (Map) config;
-        return new UpdateSite(map.get("id"), map.get("url"));
+    public UpdateSite configure(CNode config) throws ConfiguratorException {
+        Mapping map = config.asMapping();
+        return new UpdateSite(map.getScalarValue("id"), map.getScalarValue("url"));
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(UpdateSite instance) throws Exception {
+        final Mapping mapping = new Mapping();
+        // TODO would need to compare with hudson.model.UpdateCenter.createDefaultUpdateSite
+        // so we return null if default update site is in use.
+        mapping.put("id", instance.getId());
+        mapping.put("url", instance.getUrl());
+        return mapping;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins.casc.plugins;
+
+import hudson.Extension;
+import hudson.model.UpdateSite;
+import org.jenkinsci.plugins.casc.BaseConfigurator;
+
+import java.util.Map;
+
+/**
+ * TODO would  not be required if UpdateSite had a DataBoundConstructor
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension
+public class UpdateSiteConfigurator extends BaseConfigurator<UpdateSite> {
+
+    @Override
+    public Class<UpdateSite> getTarget() {
+        return UpdateSite.class;
+    }
+
+    @Override
+    public UpdateSite configure(Object config) throws Exception {
+        Map<String, String> map = (Map) config;
+        return new UpdateSite(map.get("id"), map.get("url"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.java
@@ -20,8 +20,8 @@ public class PluginManagerConfiguratorTest {
     @Test
     @ConfiguredWithCode("PluginManagerConfiguratorTest.yml")
     public void testInstallPlugins() {
-        final Plugin git = j.jenkins.getPlugin("git");
-        assertNotNull(git);
-        assertEquals("3.8.0", git.getWrapper().getVersion());
+        final Plugin chucknorris = j.jenkins.getPlugin("chucknorris");
+        assertNotNull(chucknorris);
+        assertEquals("1.0", chucknorris.getWrapper().getVersion());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.java
@@ -1,0 +1,27 @@
+package org.jenkinsci.plugins.casc;
+
+import hudson.Plugin;
+import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
+import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class PluginManagerConfiguratorTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("PluginManagerConfiguratorTest.yml")
+    public void testInstallPlugins() {
+        final Plugin git = j.jenkins.getPlugin("git");
+        assertNotNull(git);
+        assertEquals("3.8.0", git.getWrapper().getVersion());
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.yml
@@ -1,3 +1,3 @@
 plugins:
   required:
-    git: 3.8.0
+    chucknorris: 1.0

--- a/src/test/resources/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/PluginManagerConfiguratorTest.yml
@@ -1,0 +1,3 @@
+plugins:
+  required:
+    git: 3.8.0


### PR DESCRIPTION
This is implementation for https://github.com/jenkinsci/jep/pull/59

- [x] declare required plugins in yaml file, as well as update site configuration
- [x] lock all transitive dependencies in a shrinkwrap file for reproducibility
- [x] install plugins if required then restart
- [x] apply plugin configuration before any other configuration
- [x] test case

a better implementation would require metadata for plugins' versions (not just latest) hosted by update-center