### PR TITLE
Fix #178: Remove duplicate scmCheckoutRetryCount -entries in jenkins.yaml example file

### DIFF
--- a/demos/jenkins/README.md
+++ b/demos/jenkins/README.md
@@ -15,7 +15,6 @@ jenkins:
   numExecutors: 5
   scmCheckoutRetryCount: 2
   mode: NORMAL
-  scmCheckoutRetryCount: 4
 ```
 
 # implementation note  

--- a/demos/jenkins/jenkins.yaml
+++ b/demos/jenkins/jenkins.yaml
@@ -3,7 +3,6 @@ jenkins:
   numExecutors: 5
   scmCheckoutRetryCount: 2
   mode: NORMAL
-  scmCheckoutRetryCount: 4
 
   globalLibraries:
     libraries:


### PR DESCRIPTION
For the sake of simplicity and readability in the example, I've removed the duplicate entries.
fixes: https://github.com/jenkinsci/configuration-as-code-plugin/issues/178