### PR TITLE
Example of Active Directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If all those 4 are present, Configuration-as-Code will try to gather initial sec
 
 Here is a list of plugin we have successfully tested to support configuration-as-code approach :
 
- - [x] active directory plugin ([details](demos/credentials/README.md))
+ - [x] active directory plugin ([details](demos/active-directory/README.md))
  - [x] artifactory plugin ([details](demos/artifactory/README.md))
  - [x] credentials plugin ([details](demos/credentials/README.md))
  - [x] docker plugin ([details](demos/docker/README.md))

--- a/demos/active-directory/README.md
+++ b/demos/active-directory/README.md
@@ -1,0 +1,16 @@
+# Configure activeDirectory Security Realm
+
+Basic configuration of the [Active Directory plugin](https://wiki.jenkins.io/display/JENKINS/Active+Directory+Plugin)
+
+## sample configuration
+
+```yaml
+jenkins:
+  SecurityRealm:
+    activeDirectory:
+      groupLookupStrategy: AUTO
+      startTls: true
+      tlsConfiguration: TRUST_ALL_CERTIFICATES
+      domains:
+        - name: "domain.local"
+```


### PR DESCRIPTION
Add a demo of configuring the Active Directory plugin.
Update link in README to the demo

Fixes #180