### PR TITLE
Support (global) node properties, including environment variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -137,4 +138,16 @@ public class Attribute<T> {
         writeMethod.invoke(target, o);
     };
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Attribute<?> attribute = (Attribute<?>) o;
+        return Objects.equals(name, attribute.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -4,7 +4,9 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
+import hudson.model.Node;
 import hudson.slaves.Cloud;
+import hudson.slaves.NodeProperty;
 import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
 import javaposse.jobdsl.plugin.JenkinsJobManagement;
 import javaposse.jobdsl.plugin.LookupStrategy;
@@ -12,6 +14,7 @@ import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
 import jenkins.security.s2m.AdminWhitelistRule;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +62,11 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
                 new JenkinsDslScriptLoader(mng).runScript(script);
             }
         }));
+        attributes.add(new Attribute("nodeProperties", NodeProperty.class).multiple(true).setter(
+                (target, attribute, value) -> jenkins.getNodeProperties().replaceBy((Collection) value)));
+        attributes.add(new Attribute("globalNodeProperties", NodeProperty.class).multiple(true).setter(
+                (target, attribute, value) -> jenkins.getGlobalNodeProperties().replaceBy((Collection) value)));
+
         
         // Check for unclassified Descriptors
         final ExtensionList<Descriptor> descriptors = jenkins.getExtensionList(Descriptor.class);

--- a/src/test/java/org/jenkinsci/plugins/casc/JenkinsConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/JenkinsConfiguratorTest.java
@@ -1,8 +1,14 @@
 package org.jenkinsci.plugins.casc;
 
+import hudson.EnvVars;
+import hudson.model.TaskListener;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import hudson.util.DescribableList;
 import jenkins.model.Jenkins;
 import org.hamcrest.CoreMatchers;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
@@ -55,6 +61,18 @@ public class JenkinsConfiguratorTest {
         assertThat("Authorization strategy has not been set",
                 j.jenkins.getAuthorizationStrategy(),
                 CoreMatchers.instanceOf(AuthorizationStrategy.Unsecured.class));
+    }
+
+    @Test
+    @Issue("Issue #173")
+    @ConfiguredWithCode("SetEnvironmentVariable.yml")
+    public void shouldSetEnvironmentVariable() throws Exception {
+        final DescribableList<NodeProperty<?>, NodePropertyDescriptor> properties = Jenkins.getInstance().getNodeProperties();
+        EnvVars env = new EnvVars();
+        for (NodeProperty<?> property : properties) {
+            property.buildEnvVars(env, TaskListener.NULL);
+        }
+        assertEquals("BAR", env.get("FOO"));
     }
 
 }

--- a/src/test/resources/org/jenkinsci/plugins/casc/SetEnvironmentVariable.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/SetEnvironmentVariable.yml
@@ -1,0 +1,6 @@
+jenkins:
+  nodeProperties:
+    - envVars:
+        env:
+          - key: FOO
+            value: BAR


### PR DESCRIPTION
fix #173 
supported syntax :
```
jenkins:
  nodeProperties:
    - envVars:
        env:
          - key: FOO
            value: BAR
```
