### PR TITLE
missing methods overriden

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/PersistedListAttribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/PersistedListAttribute.java
@@ -22,4 +22,14 @@ public class PersistedListAttribute<T> extends Attribute<T> {
         Collection values = (Collection) o;
         target.replaceBy(values);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/PersistedListAttribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/PersistedListAttribute.java
@@ -25,11 +25,14 @@ public class PersistedListAttribute<T> extends Attribute<T> {
 
     @Override
     public boolean equals(Object o) {
-        return super.equals(o);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PersistedListAttribute<?> pla = (PersistedListAttribute<?>) o;
+        return pla.target == target;
     }
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        return target.hashCode();
     }
 }


### PR DESCRIPTION
findbugs was complaining about missing equals() method, which requires to also override hashCode
need that so we can release new version with globalNodeProperties support
