### PR TITLE
Fix compilation error

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/casc/KubernetesCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/KubernetesCloudTest.java
@@ -1,16 +1,11 @@
 package org.jenkinsci.plugins.casc;
 
-import com.nirima.jenkins.plugins.docker.DockerCloud;
-import com.nirima.jenkins.plugins.docker.DockerTemplate;
-import hudson.model.Label;
-import io.jenkins.docker.connector.DockerComputerAttachConnector;
 import org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud;
 import org.csanchez.jenkins.plugins.kubernetes.PodTemplate;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.jenkinsci.plugins.casc.misc.TestConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 


### PR DESCRIPTION
_Apparently_ introduced in/by https://github.com/jenkinsci/configuration-as-code-plugin/issues/184 though the PR builder there had succeded.

cc @ndeloof @ewelinawilkosz 

Some unusued imports removed.

```
INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /home/tiste/dev/github/jenkinsci/configuration-as-code-plugin/src/test/java/org/jenkinsci/plugins/casc/KubernetesCloudTest.java:[13,39] cannot find symbol
  symbol:   class TestConfiguration
  location: package org.jenkinsci.plugins.casc.misc
[INFO] 1 error
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11.905 s
[INFO] Finished at: 2018-05-12T14:44:00+02:00
[INFO] Final Memory: 93M/1023M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.1:testCompile (default-testCompile) on project configuration-as-code: Compilation failure
[ERROR] /home/tiste/dev/github/jenkinsci/configuration-as-code-plugin/src/test/java/org/jenkinsci/plugins/casc/KubernetesCloudTest.java:[13,39] cannot find symbol
[ERROR]   symbol:   class TestConfiguration
[ERROR]   location: package org.jenkinsci.plugins.casc.misc
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```