### PR TITLE
[JENKINS-51284] [JEP-305] Make CasC incrementals-ready

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-3</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,12 @@
   </parent>
   <groupId>io.jenkins</groupId>
   <artifactId>configuration-as-code</artifactId>
-  <version>0.6-alpha-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <properties>
+        <revision>0.6-alpha</revision>
+        <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
@@ -41,7 +43,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   <packaging>hpi</packaging>
 
   <properties>
-        <revision>0.6-alpha</revision>
-        <changelist>-SNAPSHOT</changelist>
+    <revision>0.6-alpha</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.4</version>
+    <version>3.10</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins</groupId>


### PR DESCRIPTION
[JENKINS-51284](https://issues.jenkins-ci.org/browse/JENKINS-51284)

Makes CasC consumable as an Essentials plugin.

@ewelinawilkosz 
@reviewbybees esp. @jglick @ndeloof 