### PR TITLE
Run configuration before jobs are loaded.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
@@ -111,7 +111,7 @@ public class ConfigurationAsCode extends ManagementLink {
      *
      * @throws Exception when the file provided cannot be found or parsed
      */
-    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void init() throws Exception {
         get().configure();
     }


### PR DESCRIPTION
This is to prevent plugins using `after = InitMilestone.JOB_LOADED` not being able to find configuration set by JCasC