### PR TITLE
[JENKINS-51469] Add Essentials configuration to CasC tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,14 @@
       <version>3.0.0</version>
     </dependency>
 
+    <!-- Used by Essentials -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>metrics</artifactId>
+      <version>3.1.2.12</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/test/java/org/jenkinsci/plugins/casc/EssentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/EssentialsTest.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.casc;
+
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
+import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EssentialsTest {
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("EssentialsTest.yml")
+    public void essentialsTest() throws Exception {
+        final Jenkins jenkins = Jenkins.getInstance();
+        assertEquals("Welcome to Jenkins Essentials!", jenkins.getSystemMessage());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/casc/EssentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/EssentialsTest.java
@@ -1,12 +1,21 @@
 package org.jenkinsci.plugins.casc;
 
+import hudson.ExtensionList;
+import jenkins.metrics.api.MetricsAccessKey;
 import jenkins.model.Jenkins;
+import org.hamcrest.collection.IsCollectionWithSize;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class EssentialsTest {
     @Rule
@@ -17,5 +26,26 @@ public class EssentialsTest {
     public void essentialsTest() throws Exception {
         final Jenkins jenkins = Jenkins.getInstance();
         assertEquals("Welcome to Jenkins Essentials!", jenkins.getSystemMessage());
+
+        final ExtensionList<MetricsAccessKey.DescriptorImpl> metricsDescriptors = ExtensionList.lookup(MetricsAccessKey.DescriptorImpl.class);
+        assertNotNull(metricsDescriptors);
+        assertThat(metricsDescriptors, hasSize(1));
+
+        MetricsAccessKey.DescriptorImpl metricsDescriptor = metricsDescriptors.get(0);
+
+        final List<MetricsAccessKey> accessKeys = metricsDescriptor.getAccessKeys();
+        assertThat(accessKeys, hasSize(1));
+
+        MetricsAccessKey accessKey = accessKeys.get(0);
+        assertThat(accessKey.getKey(), is("evergreen"));
+        assertThat(accessKey.getDescription(), is("Key for evergreen health-check"));
+        assertThat(accessKey.isCanHealthCheck(), is(true));
+        assertThat(accessKey.isCanPing(), is(false));
+        assertThat(accessKey.isCanPing(), is(false));
+        assertThat(accessKey.isCanThreadDump(), is(false));
+        assertThat(accessKey.isCanMetrics(), is(false));
+        assertThat(accessKey.getOrigins(), is("*"));
+
+        //metricsDescriptor.g
     }
 }

--- a/src/test/resources/org/jenkinsci/plugins/casc/EssentialsTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/EssentialsTest.yml
@@ -1,0 +1,13 @@
+---
+jenkins:
+  systemMessage: "Welcome to Jenkins Essentials!"
+  numExecutors: 0
+  metricsaccesskey:
+    accessKeys:
+      - key: "evergreen"
+        description: "Key for evergreen health-check"
+        canHealthCheck: true
+        canPing: false
+        canThreadDump: false
+        canMetrics: false
+        origins: "*"

--- a/src/test/resources/org/jenkinsci/plugins/casc/EssentialsTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/EssentialsTest.yml
@@ -1,13 +1,18 @@
 ---
+# NOTE: THIS FILE IS A COPY OF THE ONE USED IN JENKINS ESSENTIALS
+# DO NOT JUST ADAPT IF SOMETHING HAS TO CHANGE, PLEASE PING THE ESSENTIALS TEAM
+# IF THIS HAPPENS. Thanks!
 jenkins:
   systemMessage: "Welcome to Jenkins Essentials!"
   numExecutors: 0
+
+unclassified:
   metricsaccesskey:
     accessKeys:
-      - key: "evergreen"
-        description: "Key for evergreen health-check"
+      - key:            "evergreen"
+        description:    "Key for evergreen health-check"
         canHealthCheck: true
-        canPing: false
-        canThreadDump: false
-        canMetrics: false
-        origins: "*"
+        canPing:        false
+        canThreadDump:  false
+        canMetrics:     false
+        origins:        "*"


### PR DESCRIPTION
This PR is based off `configuration-as-code-0.5-alpha` on purpose.
On my machine, `mvn clean verify` is successful.

But if I update (i.e. merge or rebase) on latest `master` it fails. 

It fails with the following error:

```
[SEVERE][2018-05-22 08:37:32] Failed ConfigurationAsCode.init (from jenkins.InitReactorRunner$1 onTaskFailed)
java.lang.Error: java.lang.reflect.InvocationTargetException
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1068)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
	... 8 more
Caused by: org.jenkinsci.plugins.casc.ConfiguratorException: jenkins: error configuring <jenkins> with <jenkins> configurator
	at org.jenkinsci.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:339)
	at org.jenkinsci.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:280)
	at org.jenkinsci.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:252)
	at org.jenkinsci.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:155)
	at org.jenkinsci.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:134)
	... 13 more
Caused by: org.jenkinsci.plugins.casc.ConfiguratorException: Invalid configuration elements for type class hudson.model.Hudson : metricsaccesskey
	at org.jenkinsci.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:200)
	at org.jenkinsci.plugins.casc.JenkinsConfigurator.configure(JenkinsConfigurator.java:44)
	at org.jenkinsci.plugins.casc.JenkinsConfigurator.configure(JenkinsConfigurator.java:24)
	at org.jenkinsci.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:335)
	... 17 more
```

