### PR TITLE
Added a bit of info about plugin root dir and shrinkwrap. For #243

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -102,7 +102,10 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                 plugins.add(new PluginToInstall(entry.getKey(), entry.getValue().asScalar().getValue()));
             }
         }
+
         File shrinkwrap = new File(jenkins.getRootDir(), "plugins.txt");
+        logger.log(java.util.logging.Level.CONFIG, String.format("Using shrinkwrap file: '%s'", shrinkwrap.getAbsoluteFile()));
+
         Map<String, PluginToInstall> shrinkwrapped = new HashMap<>();
         if (shrinkwrap.exists()) {
             try {
@@ -132,7 +135,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
 
         final PluginManager pluginManager = getTargetComponent();
         if (!plugins.isEmpty()) {
-
+            logger.log(java.util.logging.Level.CONFIG, String.format("Using plugin root dir: '%s'", pluginManager.rootDir));
             boolean requireRestart = false;
             Set<String> installed = new HashSet<>();
 
@@ -172,7 +175,6 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                             }
                         }
                         installed.add(p.shortname);
-
                         final File jpi = new File(pluginManager.rootDir, p.shortname + ".jpi");
                         try (JarFile jar = new JarFile(jpi)) {
                             String dependencySpec = jar.getManifest().getMainAttributes().getValue("Plugin-Dependencies");


### PR DESCRIPTION
I think something is going on with the destination of the JPI files being written in a container...so print out those relevant informations during start.