### PR TITLE
Use JENKINS_HOME for shrinkwrap if present

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -27,7 +27,15 @@ import javax.annotation.CheckForNull;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
@@ -94,9 +102,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                 plugins.add(new PluginToInstall(entry.getKey(), entry.getValue().asScalar().getValue()));
             }
         }
-        
-        Optional<String> jenkinsRoot = Optional.ofNullable(System.getProperty("JENKINS_HOME", System.getenv("JENKINS_HOME")));
-        File shrinkwrap = new File(jenkinsRoot.orElse("."), "plugins.txt");
+        File shrinkwrap = new File(jenkins.getRootDir(), "plugins.txt");
         Map<String, PluginToInstall> shrinkwrapped = new HashMap<>();
         if (shrinkwrap.exists()) {
             try {

--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -27,15 +27,7 @@ import javax.annotation.CheckForNull;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.jar.JarFile;
 import java.util.logging.Logger;
@@ -102,8 +94,9 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                 plugins.add(new PluginToInstall(entry.getKey(), entry.getValue().asScalar().getValue()));
             }
         }
-
-        File shrinkwrap = new File("./plugins.txt");
+        
+        Optional<String> jenkinsRoot = Optional.ofNullable(System.getProperty("JENKINS_HOME", System.getenv("JENKINS_HOME")));
+        File shrinkwrap = new File(jenkinsRoot.orElse("."), "plugins.txt");
         Map<String, PluginToInstall> shrinkwrapped = new HashMap<>();
         if (shrinkwrap.exists()) {
             try {


### PR DESCRIPTION
I'm running into issues using docker-compose and the plugin installation feature, i think this might be the issue that the plugin does not look the right place for the plugins.txt file. So i added a feature to use the JENKINS_HOME environment variable or property first. If that fails...it should revert to old behaviour. 