### PR TITLE
Fix  #248 - Make SystemCredentialsProviderConfigurator extension optional

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsProviderConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsProviderConfigurator.java
@@ -18,7 +18,7 @@ import java.util.Set;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-@Extension
+@Extension(optional = true)
 public class SystemCredentialsProviderConfigurator extends BaseConfigurator<SystemCredentialsProvider> {
 
     @Override


### PR DESCRIPTION
Just because Credentials Plugin is an optional dependency.

See #248 
