### PR TITLE
Followup fix #225 - Credentials are not logged in plain text

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
@@ -83,7 +83,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                         if (configurator == null) throw new IllegalStateException("No configurator implementation to manage "+k);
                         args[i] = configurator.configure(value);
                     }
-                    logger.info("Setting " + target + "." + names[i] + " = " + value);
+                    logger.info("Setting " + target + "." + names[i] + " = " + (value.isSensitiveData() ? "****" : value));
                 } else if (t.isPrimitive()) {
                     args[i] = Defaults.defaultValue(t);
                 }


### PR DESCRIPTION
The fix of #225 didn't work, credentials are still logged in plain text on log.