### PR TITLE
Some Backward compatibility

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -7,6 +7,7 @@ import org.jenkinsci.plugins.casc.model.Sequence;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,11 +35,15 @@ public class Attribute<Owner, Type> {
     private Setter<Owner, Type> setter;
     private Getter<Owner, Type> getter;
 
+    protected List<String> aliases;
+
     public Attribute(String name, Class type) {
         this.name = name;
         this.type = type;
         this.getter = this::_getValue;
         this.setter = this::_setValue;
+        this.aliases = new ArrayList<>();
+        this.aliases.add(name);
     }
 
     @Override
@@ -77,6 +82,11 @@ public class Attribute<Owner, Type> {
         return this;
     }
 
+    public Attribute<Owner, Type> alias(String alias) {
+        this.aliases.add(alias);
+        return this;
+    }
+
     public Attribute<Owner, Type> getter(Getter<Owner, Type> getter) {
         this.getter = getter;
         return this;
@@ -88,6 +98,10 @@ public class Attribute<Owner, Type> {
 
     public Getter<Owner, Type> getGetter() {
         return getter;
+    }
+
+    public List<String> getAliases() {
+        return aliases;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
@@ -145,7 +145,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
 
     public String getName() {
         final Descriptor d = getDescriptor();
-        return DescribableAttribute.getSymbolName(d, getExtensionPoint(), getTarget());
+        return DescribableAttribute.getPreferredSymbol(d, getExtensionPoint(), getTarget());
     }
 
     private Descriptor getDescriptor() {

--- a/src/main/java/org/jenkinsci/plugins/casc/DescribableAttribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/DescribableAttribute.java
@@ -6,6 +6,7 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,14 +47,11 @@ public class DescribableAttribute<Owner, Type> extends Attribute<Owner, Type> {
         if (d != null) {
             List<String> symbols = new ArrayList<>();
             // explicit @Symbol annotation on descriptor
-            // last value on descriptor is the preferred one
-            // see hudson.slaves.DumbSlave.DescriptorImpl for sample
+            // first is the preferred one as by Symbol contract
+            // "The first one is used as the primary identifier for reverse-mapping."
             Symbol s = d.getClass().getAnnotation(Symbol.class);
             if (s != null) {
-                final String[] values = s.value();
-                for (int i = values.length-1; i >= 0 ; i--) {
-                    symbols.add(values[i]);
-                }
+                symbols.addAll(Arrays.asList(s.value()));
             }
 
             // extension type Foo is implemented as SomeFoo. => "some"

--- a/src/main/java/org/jenkinsci/plugins/casc/model/CNode.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/model/CNode.java
@@ -27,4 +27,10 @@ public interface CNode {
 
     default boolean isSensitiveData() { return false; }
 
+    /**
+     * Indicate the source (file, line number) this specific configuration node comes from.
+     * This is used to offer relevant diagnostic messages
+     */
+    String source();
+
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/model/Mapping.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/model/Mapping.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 public final class Mapping extends HashMap<String, CNode> implements CNode {
 
     public static final Mapping EMPTY = new Mapping();
+    private String source;
 
     @Override
     public Type getType() {
@@ -44,5 +45,14 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
 
     public String getScalarValue(String key) throws ConfiguratorException {
         return get(key).asScalar().getValue();
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @Override
+    public String source() {
+        return source;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/model/Scalar.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/model/Scalar.java
@@ -15,6 +15,12 @@ public final class Scalar implements CNode, CharSequence {
     private String value;
     private Tag tag;
     private boolean raw;
+    private String source;
+
+    public Scalar(String value, String source) {
+        this(value);
+        this.source = source;
+    }
 
     public Scalar(String value) {
         this.value = value;
@@ -120,4 +126,9 @@ public final class Scalar implements CNode, CharSequence {
     public CharSequence subSequence(int start, int end) {
         return value.subSequence(start, end);
     }
+
+    public String source() {
+        return source;
+    }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/model/Sequence.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/model/Sequence.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
  */
 public final class Sequence extends ArrayList<CNode> implements CNode {
 
+    private String source;
+
     public Sequence() {
     }
 
@@ -25,4 +27,12 @@ public final class Sequence extends ArrayList<CNode> implements CNode {
         return this;
     }
 
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @Override
+    public String source() {
+        return source;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/casc/yaml/ModelConstructor.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/yaml/ModelConstructor.java
@@ -7,13 +7,17 @@ import org.jenkinsci.plugins.casc.model.Sequence;
 import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.error.Mark;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -31,9 +35,15 @@ public class ModelConstructor extends Constructor {
     private final static Construct ConstructScalar = new AbstractConstruct() {
         @Override
         public Object construct(Node node) {
-            return new Scalar(((ScalarNode) node).getValue());
+            final String value = ((ScalarNode) node).getValue();
+            return new Scalar(value, getSource(node));
         }
     };
+
+    private static String getSource(Node node) {
+        final Mark mark = node.getStartMark();
+        return mark.getName() + " (line "+ (mark.getLine()+ 1) + ")";
+    }
 
     @Override
     protected Object constructScalar(ScalarNode node) {
@@ -50,7 +60,8 @@ public class ModelConstructor extends Constructor {
     /**
      * Enforce Map keys are only Scalars and can be used as {@link String} keys in {@link Mapping}
      */
-    protected void constructMapping2ndStep(MappingNode node, final Map<Object, Object> mapping) {
+    protected void constructMapping2ndStep(MappingNode node, final Map mapping) {
+        ((Mapping) mapping).setSource(getSource(node));
         super.constructMapping2ndStep(node,
                 new AbstractMapDecorator(mapping) {
             @Override
@@ -71,4 +82,9 @@ public class ModelConstructor extends Constructor {
         return new Sequence(initSize);
     }
 
+    @Override
+    protected void constructSequenceStep2(SequenceNode node, Collection collection) {
+        ((Sequence) collection).setSource(getSource(node));
+        super.constructSequenceStep2(node, collection);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.java
@@ -28,6 +28,7 @@ public class BackwardCompatibilityTest {
         assertNotNull(j.jenkins.getNode("foo"));
         assertNotNull(j.jenkins.getNode("bar"));
         assertNotNull(j.jenkins.getNode("qix"));
+        // require 2.109+ assertNotNull(j.jenkins.getNode("zot"));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.java
@@ -1,0 +1,33 @@
+package org.jenkinsci.plugins.casc;
+
+import hudson.model.Node;
+import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
+import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class BackwardCompatibilityTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("BackwardCompatibilityTest.yml")
+    public void shloud_accept_legacy_symbols_on_descriptors() throws Exception {
+
+        final List<Node> nodes = j.jenkins.getNodes();
+        System.out.println(nodes);
+        assertNotNull(j.jenkins.getNode("foo"));
+        assertNotNull(j.jenkins.getNode("bar"));
+        assertNotNull(j.jenkins.getNode("qix"));
+    }
+
+}

--- a/src/test/resources/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.yml
@@ -1,0 +1,8 @@
+jenkins:
+  nodes:
+    - slave:
+        name: "foo"
+    - dumb:
+        name: "bar"
+    - DumbSlave:
+        name: "qix"

--- a/src/test/resources/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.yml
@@ -6,3 +6,6 @@ jenkins:
         name: "bar"
     - DumbSlave:
         name: "qix"
+# require 2.109+
+#    - agent:
+#        name: "zot"


### PR DESCRIPTION
This introduce aliasses for configuration element names which are accepted in addition to "preferred name" and reported with a warning as obsolete.
Will reduce the impact for a breaking change

TODO : 
track such obsolete configuration elements and report using some administrative monitor