### PR TITLE
set plugin version to latest if it is not specified

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -112,8 +112,9 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                 final List<String> lines = FileUtils.readLines(shrinkwrap, UTF_8);
                 for (String line : lines) {
                     int i = line.indexOf(':');
-                    final String shortname = line.substring(0, i);
-                    shrinkwrapped.put(shortname, new PluginToInstall(shortname, line.substring(i+1)));
+                    final String shortname = i < 0 ? line : line.substring(0, i);
+                    final String version = i < 0 ? "latest" : line.substring(i+1);
+                    shrinkwrapped.put(shortname, new PluginToInstall(shortname, version));
                 }
             } catch (IOException e) {
                 throw new ConfiguratorException("failed to load plugins.txt shrinkwrap file", e);


### PR DESCRIPTION
As defined in https://github.com/jenkinsci/docker/blob/master/README.md#script-usage, plugins can be specified without versions.
This PR enables the PluginManagerConfigurator to handle listet plugins without an explicit version number. If no version is given, version is set to latest.