### PR TITLE
Don't use PropertyDescriptor

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -221,11 +221,13 @@ public class Attribute<Owner, Type> {
             }
 
             // If this is a public final field, developers don't define getters as jelly can use them as-is
-            final Field field = FieldUtils.getField(clazz, name);
+            final Field field = FieldUtils.getField(clazz, name, true);
             if (field == null) {
                 throw new ConfiguratorException("Can't read attribute '" + name + "' from "+ target);
             }
+
             return (Type) field.get(target);
+
         } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
             throw new ConfiguratorException("Can't read attribute '" + name + "' from "+ target, e);
         }

--- a/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
@@ -54,7 +54,6 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
             final String name = StringUtils.uncapitalize(sm);
             LOGGER.log(Level.FINER, "Processing {0} property", name);
 
-            // FIXME move this all into cleaner logic to discover property type
             Type type = method.getGenericParameterTypes()[0];
             Attribute attribute = detectActualType(name, type);
             if (attribute == null) continue;

--- a/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
@@ -272,11 +272,10 @@ public abstract class Configurator<T> implements ExtensionPoint, ElementConfigur
     @Nonnull
     public List<Attribute> getAttributes() {
         return describe().stream()
-                .filter(Attribute::isDeprecated)
-                .filter(Attribute::isRestricted)
+                .filter(a -> !a.isRestricted())
+                .filter(a -> !a.isDeprecated())
                 .sorted(Comparator.comparing(a -> a.name))
                 .collect(Collectors.toList());
-
     }
 
     @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -62,7 +62,9 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
         attributes.add(new PersistedListAttribute<Jenkins, NodeProperty>("globalNodeProperties", NodeProperty.class));
 
         // Add remoting security, all legwork will be done by a configurator
-        attributes.add(new Attribute<Jenkins, AdminWhitelistRule>("remotingSecurity", AdminWhitelistRule.class).setter(NOOP));
+        attributes.add(new Attribute<Jenkins, AdminWhitelistRule>("remotingSecurity", AdminWhitelistRule.class)
+                .setter(NOOP)
+                .getter(j -> Jenkins.getInstance().getInjector().getInstance(AdminWhitelistRule.class) ));
 
         return attributes;
     }

--- a/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -74,7 +74,7 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
 
         // we can't generate a fresh new Jenkins object as constructor is mixed with init and check for `theInstance` singleton 
         Mapping mapping = new Mapping();
-        for (Attribute attribute : describe()) {
+        for (Attribute attribute : getAttributes()) {
             mapping.put(attribute.getName(), attribute.describe(instance));
         }
         return mapping;

--- a/src/main/resources/org/jenkinsci/plugins/casc/Attribute/schema.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/casc/Attribute/schema.jelly
@@ -3,8 +3,8 @@
 <j:choose>
   <j:when test="${it.type.enum}">
     "type": "string",
-    "enum": [
-<j:forEach items="${it.type.values()}" var="v" varStatus="st">
+    "enum": [ 
+<j:forEach items="${it.type.getEnumConstants()}" var="v" varStatus="st">
     "${v}"<j:if test="${!st.last}">,</j:if>
 </j:forEach>
     ]

--- a/src/main/resources/org/jenkinsci/plugins/casc/DescribableAttribute/schema.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/casc/DescribableAttribute/schema.jelly
@@ -3,7 +3,7 @@
   "schema" : {
     "oneOf": [
   <j:forEach items="${app.getDescriptorList(it.type)}" var="d" varStatus="st">
-    <j:invokeStatic className="org.jenkinsci.plugins.casc.DescribableAttribute" method="getSymbolName" var="symbol">
+    <j:invokeStatic className="org.jenkinsci.plugins.casc.DescribableAttribute" method="getPreferredSymbol" var="symbol">
       <j:arg value="${d}" type="hudson.model.Descriptor"/>
       <j:arg value="${d.klass.toJavaClass()}"/>
       <j:arg value="${it.type}"/>

--- a/src/test/java/org/jenkinsci/plugins/casc/DocumentationGenerationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/DocumentationGenerationTest.java
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.casc;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class DocumentationGenerationTest {
+}

--- a/src/test/java/org/jenkinsci/plugins/casc/JenkinsConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/JenkinsConfigTest.java
@@ -23,5 +23,6 @@ public class JenkinsConfigTest {
     @Test
     public void loadFromCASC_JENKINS_CONFIG() {
         assertEquals("configuration as code - JenkinsConfigTest", Jenkins.getInstance().getSystemMessage());
+        assertEquals(10, Jenkins.getInstance().getQuietPeriod());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/casc/TestCrumbIssuerConfigurator.java
+++ b/src/test/java/org/jenkinsci/plugins/casc/TestCrumbIssuerConfigurator.java
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.casc;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class TestCrumbIssuerConfigurator {
+}

--- a/src/test/resources/org/jenkinsci/plugins/casc/JenkinsConfigTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/casc/JenkinsConfigTest.yml
@@ -1,2 +1,3 @@
 jenkins:
   systemMessage: "configuration as code - JenkinsConfigTest"
+  quietPeriod: 10


### PR DESCRIPTION
close https://github.com/jenkinsci/configuration-as-code-plugin/issues/293

jenkins.model.Jenkins#getQuietPeriod -> int
jenkins.model.Jenkins#setQuietPeriod -> Integer

don't use PropertyDescriptor but plain Method with name matching to be more flexible on data types.

Also include fixes for documentation/schema generation