### PR TITLE
[JENKINS-52275] Add a test demonstrating EC2 configuration and issue with setting labels 

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -234,6 +234,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ec2</artifactId>
+      <version>1.39</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/integrations/src/test/java/org/jenkinsci/plugins/casc/EC2CloudTest.java
+++ b/integrations/src/test/java/org/jenkinsci/plugins/casc/EC2CloudTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.casc;
 
+import hudson.model.labels.LabelAtom;
 import hudson.plugins.ec2.AmazonEC2Cloud;
 import hudson.plugins.ec2.SlaveTemplate;
 import jenkins.model.Jenkins;
@@ -12,6 +13,8 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertNotNull;
@@ -36,6 +39,11 @@ public class EC2CloudTest {
 
         assertThat(slaveTemplate.getLabelString(), containsString("test"));
         assertThat(slaveTemplate.getLabelString(), containsString("yey"));
+
+        assertThat(slaveTemplate.getLabelSet(), is(notNullValue()));
+
+        // fails here without mode specified
+        assertTrue(ec2Cloud.canProvision(new LabelAtom("test")));
     }
 
 

--- a/integrations/src/test/java/org/jenkinsci/plugins/casc/EC2CloudTest.java
+++ b/integrations/src/test/java/org/jenkinsci/plugins/casc/EC2CloudTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.casc;
+
+import hudson.plugins.ec2.AmazonEC2Cloud;
+import hudson.plugins.ec2.SlaveTemplate;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
+import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class EC2CloudTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("EC2Cloud.yml")
+    public void configure_ec2_cloud() throws Exception {
+        final AmazonEC2Cloud ec2Cloud = (AmazonEC2Cloud) Jenkins.getInstance().getCloud("ec2-ec2");
+        assertNotNull(ec2Cloud);
+
+        assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertThat(templates, hasSize(1));
+        final SlaveTemplate slaveTemplate = templates.get(0);
+        assertThat(slaveTemplate.getAmi(), equalTo("ami-0c6bb742864ffa3f3"));
+
+        assertThat(slaveTemplate.getLabelString(), containsString("test"));
+        assertThat(slaveTemplate.getLabelString(), containsString("yey"));
+    }
+
+
+}

--- a/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
+++ b/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
@@ -13,7 +13,7 @@ jenkins:
         templates:
           - description: "Auto configured EC2 Agent, yay again"
             ami: "ami-0c6bb742864ffa3f3"
-            labels: "test yey"
+            labelString: "test yey"
             type: "T2Xlarge"
             # FIXME: create dedicated secu group?
             securityGroups: "jenkins-22-and-8080-and-50000-from-anywhere"

--- a/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
+++ b/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
@@ -15,7 +15,7 @@ jenkins:
             ami: "ami-0c6bb742864ffa3f3"
             labelString: "test yey"
             type: "T2Xlarge"
-            # FIXME: create dedicated secu group?
-            securityGroups: "jenkins-22-and-8080-and-50000-from-anywhere"
+            securityGroups: "some-group"
             remoteFS: "/home/ec2-user"
             remoteAdmin: "ec2-user"
+            mode: "NORMAL"

--- a/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
+++ b/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
@@ -1,10 +1,9 @@
 ---
 jenkins:
   clouds:
-    - AmazonEC2Cloud:
+    - amazonEC2:
         cloudName: "ec2"
         instanceCapStr: 20
-        zone: "us-east-1"
         # this shouldn't be needed, since without explicit creds this should already be used
         # but let's be explicit to avoid issues.
         useInstanceProfileForCredentials: true
@@ -12,6 +11,7 @@ jenkins:
         privateKey: "${PRIVATE_KEY}"
         templates:
           - description: "Auto configured EC2 Agent, yay again"
+            zone: "us-east-1"
             ami: "ami-0c6bb742864ffa3f3"
             labelString: "test yey"
             type: "T2Xlarge"

--- a/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
+++ b/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2Cloud.yml
@@ -1,0 +1,21 @@
+---
+jenkins:
+  clouds:
+    - AmazonEC2Cloud:
+        cloudName: "ec2"
+        instanceCapStr: 20
+        zone: "us-east-1"
+        # this shouldn't be needed, since without explicit creds this should already be used
+        # but let's be explicit to avoid issues.
+        useInstanceProfileForCredentials: true
+        # Reminder: the following key has multiple lines
+        privateKey: "${PRIVATE_KEY}"
+        templates:
+          - description: "Auto configured EC2 Agent, yay again"
+            ami: "ami-0c6bb742864ffa3f3"
+            labels: "test yey"
+            type: "T2Xlarge"
+            # FIXME: create dedicated secu group?
+            securityGroups: "jenkins-22-and-8080-and-50000-from-anywhere"
+            remoteFS: "/home/ec2-user"
+            remoteAdmin: "ec2-user"


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-52275

This works almost entirely.
The current code fails while checking it can get the `labels` back.
For some reason, the labels seems to get set, but is not stored.

And I can confirm that doesn't work in the UI, since I wrote this
test after wondering why everything seemed fine, but that field
stayed empty on the UI.