### PR TITLE
support read-only PersistedList attributes

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.casc;
 
 import hudson.model.Descriptor;
-import javafx.collections.transformation.SortedList;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.casc.model.CNode;
 import org.jenkinsci.plugins.casc.model.Mapping;
@@ -10,11 +9,14 @@ import org.kohsuke.stapler.ClassDescriptor;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
-import java.lang.reflect.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -220,8 +222,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
             final String[] names = ClassDescriptor.loadParameterNames(constructor);
             for (int i = 0; i < parameters.length; i++) {
                 final Parameter p = parameters[i];
-
-                final Attribute a = detectActualType(names[i], p.getParameterizedType());
+                final Attribute a = detectActualType(names[i], TypePair.of(p));
                 if (a == null) continue;
                 attributes.add(a);
             }
@@ -247,7 +248,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
         final Object[] args = new Object[parameters.length];
         for (int i = 0; i < parameters.length; i++) {
             final Parameter p = parameters[i];
-            final Attribute a = detectActualType(names[i], p.getParameterizedType());
+            final Attribute a = detectActualType(names[i], TypePair.of(p));
             args[i] = a.getValue(instance);
             if (args[i] == null && p.getType().isPrimitive()) {
                 args[i] = defaultValue(p.getType());

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -1,8 +1,6 @@
 package org.jenkinsci.plugins.casc;
 
 import hudson.Extension;
-import hudson.slaves.Cloud;
-import hudson.slaves.NodeProperty;
 import jenkins.model.Jenkins;
 import jenkins.security.s2m.AdminWhitelistRule;
 import org.jenkinsci.plugins.casc.model.CNode;
@@ -44,11 +42,6 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
     @Override
     public Set<Attribute> describe() {
         final Set<Attribute> attributes = super.describe();
-
-        attributes.add(new PersistedListAttribute<Jenkins, Cloud>("clouds", Cloud.class)
-            .getter(target -> target.clouds));
-        attributes.add(new PersistedListAttribute<Jenkins, NodeProperty>("nodeProperties", NodeProperty.class));
-        attributes.add(new PersistedListAttribute<Jenkins, NodeProperty>("globalNodeProperties", NodeProperty.class));
 
         // Add remoting security, all legwork will be done by a configurator
         attributes.add(new Attribute<Jenkins, AdminWhitelistRule>("remotingSecurity", AdminWhitelistRule.class)


### PR DESCRIPTION
close #308


@batmat I guess this is why you can't use 
```yaml
  artifactManager:
      artifactManagerFactories
```
with this patch [getArtifactManagerFactories](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/ArtifactManagerConfiguration.java#L58) will be considered as a configurable attribute (even we don't have a setter for it)
