### PR TITLE
don’t reveal secret in toString

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/PrimitiveConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/PrimitiveConfigurator.java
@@ -31,7 +31,7 @@ public class PrimitiveConfigurator extends Configurator {
 
     @Override
     public Object configure(CNode config) throws ConfiguratorException {
-        return Stapler.lookupConverter(target).convert(target, config);
+        return Stapler.lookupConverter(target).convert(target, config.asScalar().getValue());
     }
 
     @CheckForNull

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/model/Scalar.java
@@ -65,15 +65,6 @@ public final class Scalar implements CNode, CharSequence {
     }
 
     public String getValue() {
-        return value;
-    }
-
-    public boolean isSensitiveData() {
-        return SecretSource.requiresReveal(value).isPresent();
-    }
-
-    @Override
-    public String toString() {
         String s = value;
         Optional<String> r = SecretSource.requiresReveal(value);
         if(r.isPresent()) {
@@ -100,6 +91,15 @@ public final class Scalar implements CNode, CharSequence {
             }
         }
         return s;
+    }
+
+    public boolean isSensitiveData() {
+        return SecretSource.requiresReveal(value).isPresent();
+    }
+
+    @Override
+    public String toString() {
+        return value;
     }
 
     @Override

--- a/plugin/src/test/resources/org/jenkinsci/plugins/casc/SystemCredentialsTest.yml
+++ b/plugin/src/test/resources/org/jenkinsci/plugins/casc/SystemCredentialsTest.yml
@@ -6,8 +6,7 @@ credentials:
           description: "test.com domain"
           specifications:
             - hostnameSpecification:
-                includes:
-                  - "*.test.com"
+                includes: "*.test.com"
         credentials:
           - usernamePassword:
               scope:    SYSTEM


### PR DESCRIPTION
returning plain-text secret in `toString` introduce a risk to see this one dumped in logs or stacktrace at some point. We don't need it since we have `Scalar#getValue()` for this specific purpose.