### PR TITLE
some cleanup in logs

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/ConfigurationAsCode.java
@@ -426,7 +426,7 @@ public class ConfigurationAsCode extends ManagementLink {
                 } catch (ConfiguratorException e) {
                     throw new ConfiguratorException(
                             configurator,
-                            format("error configuring <%s> with <%s> configurator", entry.getKey(), configurator.getName()), e
+                            format("error configuring '%s' with %s configurator", entry.getKey(), configurator.getClass()), e
                     );
                 }
             }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
@@ -60,9 +60,12 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                     new Object[] {target, dataBoundConstructor} );
             object = tryConstructor((Constructor<T>) dataBoundConstructor, config);
         } catch (ConfiguratorException ex) {
+            final Set<Constructor<T>> altConstructors = LegacyDataBoundConstructorProvider.getLegacyDataBoundConstructors(target);
+            if (altConstructors.isEmpty()) throw ex;
+
             logger.log(Level.INFO, "Default databound constructor cannot be applied, " +
-                    "will consult with Legacy DataBoundConstructor providers", ex);
-            for (Constructor constructor : LegacyDataBoundConstructorProvider.getLegacyDataBoundConstructors(target)) {
+                "will consult with Legacy DataBoundConstructor providers", ex);
+            for (Constructor constructor : altConstructors) {
                 if (constructor == dataBoundConstructor) {
                     continue; // Already tried it
                 }
@@ -80,9 +83,9 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                     break;
                 }
             }
-        }
-        if (object == null) {
-            throw new ConfiguratorException("Failed to find a compatible constructor for target " + target);
+            if (object == null) {
+                throw new ConfiguratorException("Failed to find a compatible constructor for target " + target);
+            }
         }
 
         final Set<Attribute> attributes = describe();

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/PrimitiveConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/PrimitiveConfigurator.java
@@ -31,7 +31,7 @@ public class PrimitiveConfigurator extends Configurator {
 
     @Override
     public Object configure(CNode config) throws ConfiguratorException {
-        return Stapler.lookupConverter(target).convert(target, config.asScalar().getValue());
+        return Stapler.lookupConverter(target).convert(target, config);
     }
 
     @CheckForNull

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/model/Scalar.java
@@ -65,6 +65,15 @@ public final class Scalar implements CNode, CharSequence {
     }
 
     public String getValue() {
+        return value;
+    }
+
+    public boolean isSensitiveData() {
+        return SecretSource.requiresReveal(value).isPresent();
+    }
+
+    @Override
+    public String toString() {
         String s = value;
         Optional<String> r = SecretSource.requiresReveal(value);
         if(r.isPresent()) {
@@ -91,15 +100,6 @@ public final class Scalar implements CNode, CharSequence {
             }
         }
         return s;
-    }
-
-    public boolean isSensitiveData() {
-        return SecretSource.requiresReveal(value).isPresent();
-    }
-
-    @Override
-    public String toString() {
-        return value;
     }
 
     @Override

--- a/plugin/src/test/resources/org/jenkinsci/plugins/casc/SystemCredentialsTest.yml
+++ b/plugin/src/test/resources/org/jenkinsci/plugins/casc/SystemCredentialsTest.yml
@@ -6,7 +6,8 @@ credentials:
           description: "test.com domain"
           specifications:
             - hostnameSpecification:
-                includes: "*.test.com"
+                includes:
+                  - "*.test.com"
         credentials:
           - usernamePassword:
               scope:    SYSTEM


### PR DESCRIPTION
don't log attempts to use alternate constructor when we don't have any
on error, log configurator implementation, not name (which use to be == configured element name), to offer some concrete diagnostic on what's going on under the hood