### PR TITLE
improve plugin support

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -67,6 +67,21 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
         Mapping map = config.asMapping();
         final Jenkins jenkins = Jenkins.getInstance();
 
+        configureProxy(map, jenkins);
+
+        final UpdateCenter updateCenter = configureUpdateSites(map, jenkins);
+
+        final PluginManager pluginManager = configurePlugins(map, jenkins, updateCenter);
+
+        try {
+            jenkins.save();
+        } catch (IOException e) {
+            throw new ConfiguratorException("failed to save Jenkins configuration", e);
+        }
+        return pluginManager;
+    }
+
+    private void configureProxy(Mapping map, Jenkins jenkins) throws ConfiguratorException {
         final CNode proxy = map.get("proxy");
         if (proxy != null) {
             Configurator<ProxyConfiguration> pc = Configurator.lookup(ProxyConfiguration.class);
@@ -74,7 +89,9 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
             ProxyConfiguration pcc = pc.configure(proxy);
             jenkins.proxy = pcc;
         }
+    }
 
+    private UpdateCenter configureUpdateSites(Mapping map, Jenkins jenkins) throws ConfiguratorException {
         final CNode sites = map.get("sites");
         final UpdateCenter updateCenter = jenkins.getUpdateCenter();
         if (sites != null) {
@@ -93,7 +110,10 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                 throw new ConfiguratorException("failed to reconfigure updateCenter.sites", e);
             }
         }
+        return updateCenter;
+    }
 
+    private PluginManager configurePlugins(Mapping map, Jenkins jenkins, UpdateCenter updateCenter) throws ConfiguratorException {
         Queue<PluginToInstall> plugins = new LinkedList<>();
         final CNode required = map.get("required");
         if (required != null) {
@@ -102,34 +122,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
             }
         }
 
-        File shrinkwrap = new File(jenkins.getRootDir(), "plugins.txt");
-        logger.log(java.util.logging.Level.CONFIG, String.format("Using shrinkwrap file: '%s'", shrinkwrap.getAbsoluteFile()));
-
-        Map<String, PluginToInstall> shrinkwrapped = new HashMap<>();
-        if (shrinkwrap.exists()) {
-            try {
-                final List<String> lines = FileUtils.readLines(shrinkwrap, UTF_8);
-                for (String line : lines) {
-                    int i = line.indexOf(':');
-                    final String shortname = line.substring(0, i);
-                    shrinkwrapped.put(shortname, new PluginToInstall(shortname, line.substring(i+1)));
-                }
-            } catch (IOException e) {
-                throw new ConfiguratorException("failed to load plugins.txt shrinkwrap file", e);
-            }
-
-            // Check if required plugin list has been updated, in which case the shrinkwrap file is obsolete
-            boolean outdated = false;
-            for (PluginToInstall plugin : plugins) {
-                final PluginToInstall other = shrinkwrapped.get(plugin.shortname);
-                if (other == null || !other.equals(plugin)) {
-                    // plugins was added or version updates, so shrinkwrap isn't relevant anymore
-                    outdated = true;
-                    break;
-                }
-            }
-            if (!outdated) plugins.addAll(shrinkwrapped.values());
-        }
+        File shrinkwrap = readShrinkwrapFile(jenkins, plugins);
 
 
         final PluginManager pluginManager = getTargetComponent();
@@ -156,43 +149,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                     requireRestart |= (plugin != null);
 
                     boolean downloaded = false;
-                    String url;
-                    UpdateSite updateSite;
-                    if (!Character.isDigit(p.version.charAt(0))) {
-                        // This is not a version number
-                        // We also support plain download URL for custom plugins
-                        url = p.version;
-                        updateSite = updateCenter.getSite(UpdateCenter.PREDEFINED_UPDATE_SITE_ID);
-                        if (updateSite == null)
-                            throw new ConfiguratorException("Can't install " + p + ": no default update site");
-
-                    } else {
-                        updateSite = updateCenter.getSite(p.site);
-                        if (updateSite == null)
-                            throw new ConfiguratorException("Can't install " + p + ": unknown update site " + p.site);
-
-                        // FIXME update sites don't give us metadata about hosted plugins but "latest"
-                        // see https://issues.jenkins-ci.org/browse/INFRA-1696
-                        // So here we search update site for plugin (latest version)
-                        // and we baked specific version URL based on it.
-
-                        final UpdateSite.Plugin hostedPlugin = updateSite.getPlugin(p.shortname);
-                        if (hostedPlugin == null)
-                            throw new ConfiguratorException("Can't install " + p + ": " + p.site + " does not host requested plugin");
-
-                        final int i = hostedPlugin.url.lastIndexOf(hostedPlugin.version);
-                        url = hostedPlugin.url.substring(0, i)
-                                + p.version
-                                + hostedPlugin.url.substring(i + hostedPlugin.version.length() + 1);
-                    }
-
-                    JSONObject json = new JSONObject();
-                    json.accumulate("name", p.shortname);
-                    json.accumulate("version", p.version);
-                    json.accumulate("url", url);
-                    json.accumulate("dependencies", new JSONArray());
-
-                    final UpdateSite.Plugin installable = updateSite.new Plugin(updateSite.getId(), json);
+                    final UpdateSite.Plugin installable = getPluginMetadata(updateCenter, p);
                     try {
                         logger.fine("Installing plugin: "+p.shortname);
                         final UpdateCenter.UpdateCenterJob job = installable.deploy(false).get();
@@ -232,22 +189,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                     logger.fine("Done installing plugins");
                 }
             }
-            logger.fine("Writing shrinkwrap file: "+shrinkwrap);
-            try (PrintWriter w = new PrintWriter(shrinkwrap, UTF_8.name())) {
-                for (PluginWrapper pw : pluginManager.getPlugins()) {
-                    if (pw.getShortName().equals("configuration-as-code")) continue;
-                    String from = UpdateCenter.PREDEFINED_UPDATE_SITE_ID;
-                    for (UpdateSite site : jenkins.getUpdateCenter().getSites()) {
-                        if (site.getPlugin(pw.getShortName()) != null) {
-                            from = site.getId();
-                            break;
-                        }
-                    }
-                    w.println(pw.getShortName() + ':' + pw.getVersionNumber().toString() + '@' + from);
-                }
-            } catch (IOException e) {
-                throw new ConfiguratorException("failed to write plugins.txt shrinkwrap file", e);
-            }
+            writeShrinkwrapFile(jenkins, shrinkwrap, pluginManager);
 
             if (requireRestart) {
                 try {
@@ -257,13 +199,105 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                 }
             }
         }
-
-        try {
-            jenkins.save();
-        } catch (IOException e) {
-            throw new ConfiguratorException("failed to save Jenkins configuration", e);
-        }
         return pluginManager;
+    }
+
+    /**
+     * Resolve specific plugin and version metadata and download URL.
+     * Update sites doesn't give us metadata about hosted plugins, but "latest" version. So here we workaround this by
+     * searching update site for plugin shortname and we bake specific version's URL based on this URL, assuming this
+     * will be the same but version part in the path. This is a bit fragile but we don't have a better way so far.
+     * see <a href="https://issues.jenkins-ci.org/browse/INFRA-1696">INFRA-1696</a> for status
+     *
+     * @param updateCenter
+     * @param p
+     * @return
+     * @throws ConfiguratorException
+     */
+    private UpdateSite.Plugin getPluginMetadata(UpdateCenter updateCenter, PluginToInstall p) throws ConfiguratorException {
+        String url;
+        UpdateSite updateSite;
+        if (!Character.isDigit(p.version.charAt(0))) {
+            // This is not a version number
+            // We also support plain download URL for custom plugins
+            url = p.version;
+            updateSite = updateCenter.getSite(UpdateCenter.PREDEFINED_UPDATE_SITE_ID);
+            if (updateSite == null)
+                throw new ConfiguratorException("Can't install " + p + ": no default update site");
+
+        } else {
+            updateSite = updateCenter.getSite(p.site);
+            if (updateSite == null)
+                throw new ConfiguratorException("Can't install " + p + ": unknown update site " + p.site);
+
+            final UpdateSite.Plugin hostedPlugin = updateSite.getPlugin(p.shortname);
+            if (hostedPlugin == null)
+                throw new ConfiguratorException("Can't install " + p + ": " + p.site + " does not host requested plugin");
+
+            final int i = hostedPlugin.url.lastIndexOf(hostedPlugin.version);
+            url = hostedPlugin.url.substring(0, i)
+                    + p.version
+                    + hostedPlugin.url.substring(i + hostedPlugin.version.length() + 1);
+        }
+
+        JSONObject json = new JSONObject();
+        json.accumulate("name", p.shortname);
+        json.accumulate("version", p.version);
+        json.accumulate("url", url);
+        json.accumulate("dependencies", new JSONArray());
+
+        return updateSite.new Plugin(updateSite.getId(), json);
+    }
+
+    private File readShrinkwrapFile(Jenkins jenkins, Queue<PluginToInstall> plugins) throws ConfiguratorException {
+        File shrinkwrap = new File(jenkins.getRootDir(), "plugins.txt");
+        logger.log(java.util.logging.Level.CONFIG, String.format("Using shrinkwrap file: '%s'", shrinkwrap.getAbsoluteFile()));
+
+        Map<String, PluginToInstall> shrinkwrapped = new HashMap<>();
+        if (shrinkwrap.exists()) {
+            try {
+                final List<String> lines = FileUtils.readLines(shrinkwrap, UTF_8);
+                for (String line : lines) {
+                    int i = line.indexOf(':');
+                    final String shortname = line.substring(0, i);
+                    shrinkwrapped.put(shortname, new PluginToInstall(shortname, line.substring(i+1)));
+                }
+            } catch (IOException e) {
+                throw new ConfiguratorException("failed to load plugins.txt shrinkwrap file", e);
+            }
+
+            // Check if required plugin list has been updated, in which case the shrinkwrap file is obsolete
+            boolean outdated = false;
+            for (PluginToInstall plugin : plugins) {
+                final PluginToInstall other = shrinkwrapped.get(plugin.shortname);
+                if (other == null || !other.equals(plugin)) {
+                    // plugins was added or version updates, so shrinkwrap isn't relevant anymore
+                    outdated = true;
+                    break;
+                }
+            }
+            if (!outdated) plugins.addAll(shrinkwrapped.values());
+        }
+        return shrinkwrap;
+    }
+
+    private void writeShrinkwrapFile(Jenkins jenkins, File shrinkwrap, PluginManager pluginManager) throws ConfiguratorException {
+        logger.fine("Writing shrinkwrap file: "+shrinkwrap);
+        try (PrintWriter w = new PrintWriter(shrinkwrap, UTF_8.name())) {
+            for (PluginWrapper pw : pluginManager.getPlugins()) {
+                if (pw.getShortName().equals("configuration-as-code")) continue;
+                String from = UpdateCenter.PREDEFINED_UPDATE_SITE_ID;
+                for (UpdateSite site : jenkins.getUpdateCenter().getSites()) {
+                    if (site.getPlugin(pw.getShortName()) != null) {
+                        from = site.getId();
+                        break;
+                    }
+                }
+                w.println(pw.getShortName() + ':' + pw.getVersionNumber().toString() + '@' + from);
+            }
+        } catch (IOException e) {
+            throw new ConfiguratorException("failed to write plugins.txt shrinkwrap file", e);
+        }
     }
 
     @Override

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -13,6 +13,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.BaseConfigurator;
 import org.jenkinsci.plugins.casc.Configurator;
@@ -154,18 +155,43 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                     // if plugin is being _upgraded_, not just installed, we NEED to restart
                     requireRestart |= (plugin != null);
 
-                    // FIXME update sites don't give us metadata about hosted plugins but "latest"
-                    // So we need to assume the URL layout to bake download metadata
+                    boolean downloaded = false;
+                    String url;
+                    UpdateSite updateSite;
+                    if (!Character.isDigit(p.version.charAt(0))) {
+                        // This is not a version number
+                        // We also support plain download URL for custom plugins
+                        url = p.version;
+                        updateSite = updateCenter.getSite(UpdateCenter.PREDEFINED_UPDATE_SITE_ID);
+                        if (updateSite == null)
+                            throw new ConfiguratorException("Can't install " + p + ": no default update site");
+
+                    } else {
+                        updateSite = updateCenter.getSite(p.site);
+                        if (updateSite == null)
+                            throw new ConfiguratorException("Can't install " + p + ": unknown update site " + p.site);
+
+                        // FIXME update sites don't give us metadata about hosted plugins but "latest"
+                        // see https://issues.jenkins-ci.org/browse/INFRA-1696
+                        // So here we search update site for plugin (latest version)
+                        // and we baked specific version URL based on it.
+
+                        final UpdateSite.Plugin hostedPlugin = updateSite.getPlugin(p.shortname);
+                        if (hostedPlugin == null)
+                            throw new ConfiguratorException("Can't install " + p + ": " + p.site + " does not host requested plugin");
+
+                        final int i = hostedPlugin.url.lastIndexOf(hostedPlugin.version);
+                        url = hostedPlugin.url.substring(0, i)
+                                + p.version
+                                + hostedPlugin.url.substring(i + hostedPlugin.version.length() + 1);
+                    }
+
                     JSONObject json = new JSONObject();
                     json.accumulate("name", p.shortname);
                     json.accumulate("version", p.version);
-                    json.accumulate("url", "download/plugins/" + p.shortname + "/" + p.version + "/" + p.shortname + ".hpi");
+                    json.accumulate("url", url);
                     json.accumulate("dependencies", new JSONArray());
 
-                    boolean downloaded = false;
-                    UpdateSite updateSite = updateCenter.getSite(p.site);
-                    if (updateSite == null)
-                        throw new ConfiguratorException("Can't install " + p + ": no update site " + p.site);
                     final UpdateSite.Plugin installable = updateSite.new Plugin(updateSite.getId(), json);
                     try {
                         logger.fine("Installing plugin: "+p.shortname);
@@ -195,7 +221,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
                         downloaded = true;
                         continue install;
                     } catch (InterruptedException | ExecutionException ex) {
-                        logger.info("Failed to download plugin " + p.shortname + ':' + p.version + "from update site " + updateSite.getId());
+                        logger.info("Failed to download plugin " + p.shortname + ':' + p.version + " from " + p.site);
                     } catch (Throwable ex) {
                         throw new ConfiguratorException("Failed to download plugin " + p.shortname + ':' + p.version, ex);
                     }


### PR DESCRIPTION
I suggest you review commit separately, as 1844100 is about moving code into specialized methods, the actual changes to plugin logic are in d1532f5.
With those changes, yaml can set plugins as `foo : DOWNLOAD_URL` in addition to `foo: version`. This make it simpler to install some custom plugins, or workaround issue with the guess-download-from-updatesite logic. About the later, it now get download URL from UC metadata and replace version with the requested one, assuming UC uses a consistent download layout.