### PR TITLE
Adding a test for a custom AMIType for an EC2 cloud template

### DIFF
--- a/integrations/src/test/java/org/jenkinsci/plugins/casc/EC2CloudTest.java
+++ b/integrations/src/test/java/org/jenkinsci/plugins/casc/EC2CloudTest.java
@@ -1,8 +1,10 @@
 package org.jenkinsci.plugins.casc;
 
 import hudson.model.labels.LabelAtom;
+import hudson.plugins.ec2.AMITypeData;
 import hudson.plugins.ec2.AmazonEC2Cloud;
 import hudson.plugins.ec2.SlaveTemplate;
+import hudson.plugins.ec2.UnixData;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -46,5 +48,34 @@ public class EC2CloudTest {
         assertTrue(ec2Cloud.canProvision(new LabelAtom("test")));
     }
 
+    @Test
+    @ConfiguredWithCode("EC2CloudAMIType.yml")
+    public void configure_ec2_cloud_with_custom_ami_type() throws Exception {
+        final AmazonEC2Cloud ec2Cloud = (AmazonEC2Cloud) Jenkins.getInstance().getCloud("ec2-ec2");
+        assertNotNull(ec2Cloud);
+
+        assertTrue(ec2Cloud.isUseInstanceProfileForCredentials());
+        final List<SlaveTemplate> templates = ec2Cloud.getTemplates();
+        assertThat(templates, hasSize(1));
+        final SlaveTemplate slaveTemplate = templates.get(0);
+        assertThat(slaveTemplate.getAmi(), equalTo("ami-0c6bb742864ffa3f3"));
+
+        assertThat(slaveTemplate.getLabelString(), containsString("test"));
+        assertThat(slaveTemplate.getLabelString(), containsString("yey"));
+
+        assertThat(slaveTemplate.getLabelSet(), is(notNullValue()));
+
+        // fails here without mode specified
+        assertTrue(ec2Cloud.canProvision(new LabelAtom("test")));
+
+        // Checks that the AMI type is Unix and configured
+        AMITypeData amiType = slaveTemplate.getAmiType();
+        assertTrue(amiType.isUnix());
+        assertTrue(amiType instanceof UnixData);
+        UnixData unixData = (UnixData) amiType;
+        assertThat(unixData.getRootCommandPrefix(), equalTo("sudo"));
+        assertThat(unixData.getSlaveCommandPrefix(), equalTo("sudo -u jenkins"));
+        assertThat(unixData.getSshPort(), equalTo("61120"));
+    }
 
 }

--- a/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2CloudAMIType.yml
+++ b/integrations/src/test/resources/org/jenkinsci/plugins/casc/EC2CloudAMIType.yml
@@ -1,0 +1,26 @@
+---
+jenkins:
+  clouds:
+    - amazonEC2:
+        cloudName: "ec2"
+        instanceCapStr: 20
+        # this shouldn't be needed, since without explicit creds this should already be used
+        # but let's be explicit to avoid issues.
+        useInstanceProfileForCredentials: true
+        # Reminder: the following key has multiple lines
+        privateKey: "${PRIVATE_KEY}"
+        templates:
+          - description: "Auto configured EC2 Agent, yay again"
+            zone: "us-east-1"
+            ami: "ami-0c6bb742864ffa3f3"
+            labelString: "test yey"
+            type: "T2Xlarge"
+            securityGroups: "some-group"
+            remoteFS: "/home/ec2-user"
+            remoteAdmin: "ec2-user"
+            mode: "NORMAL"
+            amiType:
+              unixData:
+                rootCommandPrefix: "sudo"
+                slaveCommandPrefix: "sudo -u jenkins"
+                sshPort: "61120"


### PR DESCRIPTION
Adding this test which shows how to configure a custom AMIType for an EC2 cloud template.