### PR TITLE
Check and Apply REST APIs

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
@@ -29,7 +29,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * {@link Configurator} that uses Java Beans pattern to the target object.
+ * a General purpose abstract {@link Configurator} implementation.
+ * Target component is identified by implementing {@link #instance(Mapping)} then configuration is applied on
+ * {@link Attribute}s as defined by {@link #describe()}.
+ * This base implementation uses JavaBean convention to identify configurable attributes.
  *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
@@ -181,8 +184,8 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
 
     /**
      * Build or identify the target component this configurator has to handle based on the provided configuration node.
-     * @param mapping
-     * @return
+     * @param mapping configuration for target component. Implementation may consume some entries to create a fresh new instance.
+     * @return instance to be configured, but not yet fully configured, see {@link #configure(Mapping, Object, boolean)}
      * @throws ConfiguratorException
      */
     protected abstract T instance(Mapping mapping) throws ConfiguratorException;
@@ -205,7 +208,14 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
         return instance;
     }
 
-    protected void configure(Mapping config, T instance, boolean dryrun) throws ConfiguratorException {
+    /**
+     * Run configuration process on the target instance
+     * @param config configuration to apply. Can be partial if {@link #instance(Mapping)} did already used some entries
+     * @param instance target instance to configure
+     * @param dryrun only check configuration is valid regarding target component. Don't actually apply changes to jenkins master instance
+     * @throws ConfiguratorException something went wrong...
+     */
+    protected final void configure(Mapping config, T instance, boolean dryrun) throws ConfiguratorException {
         final Set<Attribute> attributes = describe();
         final ConfigurationAsCode casc = ConfigurationAsCode.get();
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/DataBoundConfigurator.java
@@ -110,7 +110,9 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
 
     @Override
     public T check(CNode config) throws ConfiguratorException {
-        return configure(config);
+        // As DataBound objets are replaced in jenkins model we can build one from configuration without side-effets
+        // BUT we don't invoke @PostConstruct methods which might un some post-build registration into jenkins APIs.
+        return super.configure(config);
     }
 
     private T tryConstructor(Constructor<T> constructor, Mapping config) throws ConfiguratorException {

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/DescriptorConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/DescriptorConfigurator.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.casc;
 import hudson.model.Descriptor;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.casc.model.CNode;
+import org.jenkinsci.plugins.casc.model.Mapping;
 
 import javax.annotation.CheckForNull;
 
@@ -47,9 +48,7 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor> impleme
     }
 
     @Override
-    public Descriptor configure(CNode config) throws ConfiguratorException {
-        configure(config.asMapping(), descriptor);
-        descriptor.save();
+    protected Descriptor instance(Mapping mapping) {
         return descriptor;
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
@@ -64,6 +64,14 @@ public interface ElementConfigurator<T> {
     @Nonnull
     T configure(CNode config) throws ConfiguratorException;
 
+    /**
+     * Run the same logic as {@link #configure(CNode)} in dry-run mode.
+     * Used to verify configuration is fine before being acutally applied to a live jenkins master.
+     * @param config
+     * @throws ConfiguratorException
+     */
+    T check(CNode config) throws ConfiguratorException;
+
 
     /**
      * Describe a component as a Configuration Nodes {@link CNode} to be exported as yaml.

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/ExtensionConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/ExtensionConfigurator.java
@@ -30,37 +30,13 @@ public class ExtensionConfigurator<T> extends BaseConfigurator<T> {
         return target;
     }
 
-
     @Override
-    public T configure(CNode c) throws ConfiguratorException {
+    protected T instance(Mapping mapping) throws ConfiguratorException {
         final ExtensionList<T> list = Jenkins.getInstance().getExtensionList(target);
         if (list.size() != 1) {
-            throw new IllegalStateException();
+            throw new ConfiguratorException("Expected a unique instance of extension "+target);
         }
-        final T o = list.get(0);
-
-        if (c instanceof Map) {
-            Mapping config = c.asMapping();
-            final Set<Attribute> attributes = describe();
-            for (Attribute attribute : attributes) {
-                final String name = attribute.getName();
-                if (config.containsKey(name)) {
-                    final Class k = attribute.getType();
-                    final Configurator configurator = Configurator.lookup(k);
-                    if (configurator == null) throw new IllegalStateException("No configurator implementation to manage "+ k);
-                    final CNode yaml = config.get(name);
-                    final Object value = configurator.configure(yaml);
-                    try {
-                        logger.info("Setting " + o + '.' + name + " = " + (yaml.isSensitiveData() ? "****" : value));
-                        attribute.setValue(o, value);
-                    } catch (Exception e) {
-                        throw new ConfiguratorException(this, "Failed to set attribute " + attribute, e);
-                    }
-                }
-            }
-        }
-
-        return o;
+        return (T) list.get(0);
     }
 
     @CheckForNull

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/GlobalConfigurationCategoryConfigurator.java
@@ -7,6 +7,7 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.casc.model.CNode;
+import org.jenkinsci.plugins.casc.model.Mapping;
 
 import javax.annotation.CheckForNull;
 import java.util.HashSet;
@@ -47,8 +48,7 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
     }
 
     @Override
-    public GlobalConfigurationCategory configure(CNode config) throws ConfiguratorException {
-        configure(config.asMapping(), category);
+    protected GlobalConfigurationCategory instance(Mapping mapping) {
         return category;
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/HeteroDescribableConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/HeteroDescribableConfigurator.java
@@ -85,6 +85,11 @@ public class HeteroDescribableConfigurator extends Configurator<Describable> {
         return (Describable) configurator.configure(subconfig);
     }
 
+    @Override
+    public Describable check(CNode config) throws ConfiguratorException {
+        return configure(config);
+    }
+
     private Class findDescribableBySymbol(CNode node, String shortname, List<Descriptor> candidates) {
 
         // Search for @Symbol annotation on Descriptor to match shortName

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/JenkinsConfigurator.java
@@ -31,12 +31,8 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
     }
 
     @Override
-    public Jenkins configure(CNode c) throws ConfiguratorException {
-        Mapping config = c.asMapping();
-        Jenkins jenkins = Jenkins.getInstance();
-
-        configure(config, jenkins);
-        return jenkins;
+    protected Jenkins instance(Mapping mapping) {
+        return getTargetComponent();
     }
 
     @Override

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/PrimitiveConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/PrimitiveConfigurator.java
@@ -34,6 +34,11 @@ public class PrimitiveConfigurator extends Configurator {
         return Stapler.lookupConverter(target).convert(target, config);
     }
 
+    @Override
+    public Object check(CNode config) throws ConfiguratorException {
+        return configure(config);
+    }
+
     @CheckForNull
     @Override
     public CNode describe(Object instance) {

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/SeedJobConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/SeedJobConfigurator.java
@@ -52,6 +52,12 @@ public class SeedJobConfigurator implements RootElementConfigurator<List<Generat
         return generated;
     }
 
+    @Override
+    public List<GeneratedItems> check(CNode config) throws ConfiguratorException {
+        // Any way to dry-run a job-dsl script ?
+        return Collections.emptyList();
+    }
+
     @CheckForNull
     @Override
     public CNode describe(List<GeneratedItems> instance) {

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/SelfConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/SelfConfigurator.java
@@ -30,6 +30,11 @@ public class SelfConfigurator extends BaseConfigurator<ConfigurationAsCode> impl
         return ConfigurationAsCode.get();
     }
 
+    @Override
+    protected ConfigurationAsCode instance(Mapping mapping) {
+        return getTargetComponent();
+    }
+
     @Nonnull
     @Override
     public Set<Attribute> describe() {
@@ -41,14 +46,6 @@ public class SelfConfigurator extends BaseConfigurator<ConfigurationAsCode> impl
         attributes.add(new Attribute("restricted", ConfigurationAsCode.Restricted.class));
         attributes.add(new Attribute("unknown", ConfigurationAsCode.Unknown.class));
         return attributes;
-    }
-
-    @Nonnull
-    @Override
-    public ConfigurationAsCode configure(CNode config) throws ConfiguratorException {
-        final ConfigurationAsCode c = getTargetComponent();
-        configure(config.asMapping(), c);
-        return c;
     }
 
     @CheckForNull

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
@@ -28,6 +28,7 @@ import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.BaseConfigurator;
 import org.jenkinsci.plugins.casc.ConfiguratorException;
 import org.jenkinsci.plugins.casc.model.CNode;
+import org.jenkinsci.plugins.casc.model.Mapping;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -56,11 +57,9 @@ public class AdminWhitelistRuleConfigurator extends BaseConfigurator<AdminWhitel
     }
 
     @Override
-    public AdminWhitelistRule configure(CNode config) throws ConfiguratorException {
+    protected AdminWhitelistRule instance(Mapping mapping) {
         Injector injector = Jenkins.getInstance().getInjector();
-        AdminWhitelistRule instance = injector.getInstance(AdminWhitelistRule.class);
-        configure(config.asMapping(), instance);
-        return instance;
+        return injector.getInstance(AdminWhitelistRule.class);
     }
 
     @Override

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/NoneSecurityRealmConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/NoneSecurityRealmConfigurator.java
@@ -35,6 +35,11 @@ public class NoneSecurityRealmConfigurator extends Configurator<SecurityRealm> {
         return SecurityRealm.NO_AUTHENTICATION;
     }
 
+    @Override
+    public SecurityRealm check(CNode config) {
+        return SecurityRealm.NO_AUTHENTICATION;
+    }
+
     @CheckForNull
     @Override
     public CNode describe(SecurityRealm instance) throws Exception {

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
@@ -6,6 +6,7 @@ import hudson.security.AuthorizationStrategy.Unsecured;
 import org.jenkinsci.plugins.casc.BaseConfigurator;
 import org.jenkinsci.plugins.casc.ConfiguratorException;
 import org.jenkinsci.plugins.casc.model.CNode;
+import org.jenkinsci.plugins.casc.model.Mapping;
 
 import javax.annotation.CheckForNull;
 
@@ -22,7 +23,7 @@ public class UnsecuredAuthorizationStrategyConfigurator extends BaseConfigurator
     }
 
     @Override
-    public Unsecured configure(CNode config) throws ConfiguratorException {
+    protected Unsecured instance(Mapping mapping) {
         return (Unsecured)AuthorizationStrategy.UNSECURED;
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
@@ -55,10 +55,8 @@ public class CredentialsRootConfigurator extends BaseConfigurator<GlobalCredenti
     }
 
     @Override
-    public GlobalCredentialsConfiguration configure(CNode config) throws ConfiguratorException {
-        final GlobalCredentialsConfiguration target = getTargetComponent();
-        configure(config.asMapping(), target);
-        return target;
+    public GlobalCredentialsConfiguration instance(Mapping mapping) {
+        return getTargetComponent();
     }
 
     @Override

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsProviderConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsProviderConfigurator.java
@@ -26,12 +26,9 @@ public class SystemCredentialsProviderConfigurator extends BaseConfigurator<Syst
         return SystemCredentialsProvider.class;
     }
 
-    @Nonnull
     @Override
-    public SystemCredentialsProvider configure(CNode config) throws ConfiguratorException {
-        final SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
-        configure(config.asMapping(), instance);
-        return instance;
+    protected SystemCredentialsProvider instance(Mapping mapping) {
+        return SystemCredentialsProvider.getInstance();
     }
 
     @Nonnull

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/globalmatrixauth/GlobalMatrixAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/globalmatrixauth/GlobalMatrixAuthorizationStrategyConfigurator.java
@@ -67,6 +67,12 @@ public class GlobalMatrixAuthorizationStrategyConfigurator extends Configurator<
         return gms;
     }
 
+    @Override
+    public GlobalMatrixAuthorizationStrategy check(CNode config) throws ConfiguratorException {
+        // FIXME
+        return null;
+    }
+
     @CheckForNull
     @Override
     public CNode describe(GlobalMatrixAuthorizationStrategy instance) {

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
@@ -58,6 +58,12 @@ public class ProjectMatrixAuthorizationStrategyConfigurator extends Configurator
     }
 
     @Override
+    public ProjectMatrixAuthorizationStrategy check(CNode config) throws ConfiguratorException {
+        // FIXME
+        return null;
+    }
+
+    @Override
     @SuppressFBWarnings(value = "DM_NEW_FOR_GETCLASS", justification = "We need a fully qualified type to do proper attribute binding")
     public Set<Attribute> describe() {
         return Collections.singleton(new Attribute<ProjectMatrixAuthorizationStrategy, GroupPermissionDefinition>("grantedPermissions", new HashSet<GroupPermissionDefinition>().getClass()));

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/rolebasedauth/RoleBasedAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/rolebasedauth/RoleBasedAuthorizationStrategyConfigurator.java
@@ -65,6 +65,12 @@ public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<Rol
         return new RoleBasedAuthorizationStrategy(grantedRoles);
     }
 
+    @Override
+    public RoleBasedAuthorizationStrategy check(CNode config) {
+        // FIXME
+        return null;
+    }
+
     @Nonnull
     private static RoleMap retrieveRoleMap(@Nonnull CNode config, @Nonnull String name, Configurator<RoleDefinition> configurator) throws ConfiguratorException {
         Mapping map = config.asMapping();

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -62,6 +62,11 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
     }
 
     @Override
+    protected PluginManager instance(Mapping mapping) {
+        return getTargetComponent();
+    }
+
+    @Override
     public PluginManager configure(CNode config) throws ConfiguratorException {
         Mapping map = config.asMapping();
         final Jenkins jenkins = Jenkins.getInstance();

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
@@ -23,9 +23,8 @@ public class UpdateSiteConfigurator extends BaseConfigurator<UpdateSite> {
     }
 
     @Override
-    public UpdateSite configure(CNode config) throws ConfiguratorException {
-        Mapping map = config.asMapping();
-        return new UpdateSite(map.getScalarValue("id"), map.getScalarValue("url"));
+    protected UpdateSite instance(Mapping mapping) throws ConfiguratorException {
+        return new UpdateSite(mapping.getScalarValue("id"), mapping.getScalarValue("url"));
     }
 
     @CheckForNull

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/yaml/YamlUtils.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/yaml/YamlUtils.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.casc.yaml;
 
 import org.jenkinsci.plugins.casc.ConfiguratorException;
+import org.kohsuke.accmod.Restricted;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.composer.Composer;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -28,8 +29,7 @@ public final class YamlUtils {
         for (YamlSource source : configs) {
             try (Reader r = source.read()) {
 
-                Composer composer = new Composer(new ParserImpl(new StreamReaderWithSource(source)), new Resolver());
-                final Node node =  composer.getSingleNode();
+                final Node node = read(source);
 
                 if (root == null) {
                     root = node;
@@ -42,6 +42,11 @@ public final class YamlUtils {
         }
 
         return root;
+    }
+
+    public static Node read(YamlSource source) throws IOException {
+        Composer composer = new Composer(new ParserImpl(new StreamReaderWithSource(source)), new Resolver());
+        return composer.getSingleNode();
     }
 
     private static void merge(Node root, Node node, String source) throws ConfiguratorException {


### PR DESCRIPTION
Introduce a REST API to check and apply a YAML configuration
extend ElementConfigurator to support a "dry-run" mode which we could also rely on for tooling