### PR TITLE
add id to multibranch pipeline jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ jobs:
       multibranchPipelineJob('configuration-as-code') {
           branchSources {
               git {
+                  id = 'configuration-as-code'
                   remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
               }
           }

--- a/plugin/src/test/resources/org/jenkinsci/plugins/casc/SeedJobTest.yml
+++ b/plugin/src/test/resources/org/jenkinsci/plugins/casc/SeedJobTest.yml
@@ -3,6 +3,7 @@ jobs:
       multibranchPipelineJob('configuration-as-code') {
           branchSources {
               git {
+                  id = 'configuration-as-code'
                   remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
               }
           }


### PR DESCRIPTION
The multibranch pipeline jobs only work correctly if the job has a unique id (#339). This PR adds an id to the job descriptions.