### PR TITLE
Always apply configuration as a full yaml set

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/cli/ApplyConfigurationCommand.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/cli/ApplyConfigurationCommand.java
@@ -28,7 +28,7 @@ public class ApplyConfigurationCommand extends CLICommand {
             return -1;
         }
 
-        ConfigurationAsCode.get().configureWith(Collections.singletonList(new YamlSource<InputStream>(stdin, YamlSource.READ_FROM_INPUTSTREAM)));
+        ConfigurationAsCode.get().configureWith(new YamlSource<InputStream>(stdin, YamlSource.READ_FROM_INPUTSTREAM));
         return 0;
     }
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/cli/CheckConfigurationCommand.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/cli/CheckConfigurationCommand.java
@@ -27,7 +27,7 @@ public class CheckConfigurationCommand extends CLICommand {
             return -1;
         }
 
-        ConfigurationAsCode.get().checkWith(Collections.singletonList(new YamlSource<InputStream>(stdin, YamlSource.READ_FROM_INPUTSTREAM)));
+        ConfigurationAsCode.get().checkWith(new YamlSource<InputStream>(stdin, YamlSource.READ_FROM_INPUTSTREAM));
         return 0;
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
@@ -32,7 +32,7 @@ public class JenkinsConfiguredWithCodeRule extends JenkinsRule {
                     .collect(Collectors.toList());
 
             try {
-                ConfigurationAsCode.get().configure(configs.toArray(new String[configs.size()]));
+                ConfigurationAsCode.get().configure(configs);
             } catch (Throwable t) {
                 if (!configuredWithCode.expected().isInstance(t)) {
                     throw new AssertionError("Unexpected exception ", t);


### PR DESCRIPTION
When configuration is applied, it can't just be considered as a "partial" configuration : it only make sense in regard to other yaml files (as there may be overrides and conflicts).