### PR TITLE
Allow loading of jobdsl from file.

### DIFF
--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobTest.java
@@ -26,5 +26,8 @@ public class SeedJobTest {
         final TopLevelItem test = jenkins.getItem("configuration-as-code");
         assertNotNull(test);
         assertTrue(test instanceof WorkflowMultiBranchProject);
+        final TopLevelItem test2 = jenkins.getItem("configuration-as-code2");
+        assertNotNull(test2);
+        assertTrue(test2 instanceof WorkflowMultiBranchProject);
     }
 }

--- a/plugin/src/test/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobTest.yml
+++ b/plugin/src/test/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobTest.yml
@@ -8,3 +8,4 @@ jobs:
               }
           }
       }
+  - ${file:src/test/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/multibranch.groovy}

--- a/plugin/src/test/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/multibranch.groovy
+++ b/plugin/src/test/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/multibranch.groovy
@@ -1,0 +1,10 @@
+package org.jenkinsci.plugins.casc.integrations.jobdsl
+
+multibranchPipelineJob('configuration-as-code2') {
+    branchSources {
+        git {
+            id = 'configuration-as-code'
+            remote('https://github.com/jenkinsci/configuration-as-code-plugin.git')
+        }
+    }
+}


### PR DESCRIPTION
This commit allows you to use `${file:<path>}` for your job dsl. Much easier to maintain and figure out than inline groovy in yaml.