### PR TITLE
add mention of default parameter substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ jobs:
 ## How to provide initial secrets for Configuration-as-Code
 
 Currently you can provide initial secrets to Configuration-as-Code that all rely on <key,value>
-substitution of strings in configuration. Just like in Jenkins: `${some_var}`. We can provide these initial secrets in
-the following ways:
+substitution of strings in configuration. Just like in Jenkins: `${some_var}`. Default variable substitution
+using the `:-` operator from `bash` is also available:
+`key: ${VALUE:-defaultvalue}` will evaluate to `defaultvalue` if `$VALUE` is unset. We can provide these initial secrets in the following ways:
 
  - Using environment variables
  - Using docker-secrets, where files on path `/run/secrets/${KEY}` will be replaced by `${KEY}` in configuration


### PR DESCRIPTION
Following up on https://github.com/jenkinsci/configuration-as-code-plugin/issues/156#issuecomment-404943524

Somehow this isn't working quite right for me right now but it might be a setup issue. Because of that - and my lack of familiarity with the codebase -  not sure if this is the same implementation as https://docs.docker.com/compose/compose-file/#variable-substitution and bash - where there's the difference between `${VALUE:-defaultvalue}` and `${VALUE-defaultvalue}` as unset and empty are treated differently.