### PR TITLE
The download path for the plugin is computed incorrectly.

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -244,7 +244,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
             final int i = hostedPlugin.url.lastIndexOf(hostedPlugin.version);
             url = hostedPlugin.url.substring(0, i)
                     + p.version
-                    + hostedPlugin.url.substring(i + hostedPlugin.version.length() + 1);
+                    + hostedPlugin.url.substring(i + hostedPlugin.version.length());
         }
 
         JSONObject json = new JSONObject();


### PR DESCRIPTION
There is a missing '/' between the version I.E the download url would become 'http://my.update.site/jenkins/download/plugins/kubernetes/1.10.1kubernetes.hpi' instead of 'http://my.update.site/jenkins/download/plugins/kubernetes/1.10.1/kubernetes.hpi' which is correct.

A typical off-by-one error :) 