### PR TITLE
Fix #386 Add possibility to use vaultToken instead of vault U/P

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ using the `:-` operator from `bash` is also available:
 
 **Prerequisites**
 
- - The environment variable `CASC_VAULT_PW` must be present (Vault password)
- - The environment variable `CASC_VAULT_USER` must be present (Vault username)
+ - The environment variable `CASC_VAULT_PW` must be present, if token is not used (Vault password)
+ - The environment variable `CASC_VAULT_USER` must be present, if token is not used (Vault username)
+ - The environment variable `CASC_VAULT_TOKEN` must be present, if U/P is not used (Vault token)
  - The environment variable `CASC_VAULT_PATH` must be present (Vault key path, I.E /secrets/jenkins)
  - The environment variable `CASC_VAULT_URL` must be present (Vault url, including port)
  - The environment variable `CASC_VAULT_MOUNT` is optional (Vault auth mount, I.E `ldap` or another username & password authentication type, defaults to `userpass`)
@@ -156,6 +157,7 @@ File should be in a Java Properties format
 ```properties
 CASC_VAULT_PW=PASSWORD
 CASC_VAULT_USER=USER
+CASC_VAULT_TOKEN=TOKEN
 CASC_VAULT_PATH=secret/jenkins/master
 CASC_VAULT_URL=https://vault.dot.com
 CASC_VAULT_MOUNT=ldap

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -50,7 +50,6 @@ public class VaultSecretSource extends SecretSource {
         String vaultMount = getVariable("CASC_VAULT_MOUNT", prop);
         String vaultToken = getVariable("CASC_VAULT_TOKEN", prop);
 
-        //if(vaultPw != null && vaultUsr != null && vaultPth != null && vaultUrl != null) {
         if(((vaultPw != null && vaultUsr != null) || vaultToken != null) && vaultPth != null && vaultUrl != null) {
             LOGGER.log(Level.FINE, "Attempting to connect to Vault: {0}", vaultUrl);
             try {


### PR DESCRIPTION
Add the possibility to use `CASC_VAULT_TOKEN` instead of `CASC_VAULT_USER` and `CASC_VAULT_PW` to get Vault'ed data