### PR TITLE
Use a cache to resolve configurators

### DIFF
--- a/integrations/src/test/java/org/jenkinsci/plugins/casc/GlobalMatrixAuthorizationTest.java
+++ b/integrations/src/test/java/org/jenkinsci/plugins/casc/GlobalMatrixAuthorizationTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.casc;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.impl.DefaultConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.integrations.globalmatrixauth.GlobalMatrixAuthorizationStrategyConfigurator;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -27,19 +28,11 @@ public class GlobalMatrixAuthorizationTest {
 
     @Test
     public void shouldReturnCustomConfigurator() {
-        Configurator configurator = Configurator.lookup(GlobalMatrixAuthorizationStrategy.class);
+        Configurator configurator = ConfiguratorRegistry.get().lookup(GlobalMatrixAuthorizationStrategy.class);
         assertNotNull("Failed to find configurator for GlobalMatrixAuthorizationStrategy", configurator);
         assertEquals("Retrieved wrong configurator", GlobalMatrixAuthorizationStrategyConfigurator.class, configurator.getClass());
     }
-
-    @Test
-    public void shouldReturnCustomConfiguratorForBaseType() {
-        Configurator c = Configurator.lookupForBaseType(AuthorizationStrategy.class, "globalMatrix");
-        assertNotNull("Failed to find configurator for GlobalMatrixAuthorizationStrategy", c);
-        assertEquals("Retrieved wrong configurator", GlobalMatrixAuthorizationStrategyConfigurator.class, c.getClass());
-        Configurator.lookup(GlobalMatrixAuthorizationStrategy.class);
-    }
-
+    
     @Test
     @ConfiguredWithCode("GlobalMatrixStrategy.yml")
     public void checkCorrectlyConfiguredPermissions() throws Exception {

--- a/integrations/src/test/java/org/jenkinsci/plugins/casc/ProjectMatrixAuthorizationTest.java
+++ b/integrations/src/test/java/org/jenkinsci/plugins/casc/ProjectMatrixAuthorizationTest.java
@@ -3,6 +3,9 @@ package org.jenkinsci.plugins.casc;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.impl.DefaultConfiguratorRegistry;
+import org.jenkinsci.plugins.casc.impl.attributes.DescribableAttribute;
+import org.jenkinsci.plugins.casc.impl.configurators.HeteroDescribableConfigurator;
 import org.jenkinsci.plugins.casc.integrations.projectmatriaxauth.ProjectMatrixAuthorizationStrategyConfigurator;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -25,17 +28,9 @@ public class ProjectMatrixAuthorizationTest {
 
     @Test
     public void shouldReturnCustomConfigurator() {
-        Configurator configurator = Configurator.lookup(ProjectMatrixAuthorizationStrategy.class);
+        Configurator configurator = ConfiguratorRegistry.get().lookup(ProjectMatrixAuthorizationStrategy.class);
         assertNotNull("Failed to find configurator for GlobalMatrixAuthorizationStrategy", configurator);
         assertEquals("Retrieved wrong configurator", ProjectMatrixAuthorizationStrategyConfigurator.class, configurator.getClass());
-    }
-
-    @Test
-    public void shouldReturnCustomConfiguratorForBaseType() {
-        Configurator c = Configurator.lookupForBaseType(AuthorizationStrategy.class, "projectMatrix");
-        assertNotNull("Failed to find configurator for ProjectMatrixAuthorizationStrategy", c);
-        assertEquals("Retrieved wrong configurator", ProjectMatrixAuthorizationStrategyConfigurator.class, c.getClass());
-        Configurator.lookup(ProjectMatrixAuthorizationStrategy.class);
     }
 
     @Test

--- a/integrations/src/test/java/org/jenkinsci/plugins/casc/RoleStrategyTest.java
+++ b/integrations/src/test/java/org/jenkinsci/plugins/casc/RoleStrategyTest.java
@@ -9,6 +9,7 @@ import hudson.model.Item;
 import hudson.model.User;
 import hudson.security.AuthorizationStrategy;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.impl.DefaultConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.integrations.rolestrategy.RoleBasedAuthorizationStrategyConfigurator;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -36,19 +37,9 @@ public class RoleStrategyTest {
 
     @Test
     public void shouldReturnCustomConfigurator() {
-        Configurator c = Configurator.lookup(RoleBasedAuthorizationStrategy.class);
+        Configurator c = ConfiguratorRegistry.get().lookup(RoleBasedAuthorizationStrategy.class);
         assertNotNull("Failed to find configurator for RoleBasedAuthorizationStrategy", c);
         assertEquals("Retrieved wrong configurator", RoleBasedAuthorizationStrategyConfigurator.class, c.getClass());
-    }
-
-    @Test
-    @Issue("Issue #59")
-    public void shouldReturnCustomConfiguratorForBaseType() {
-        Configurator c = Configurator.lookupForBaseType(AuthorizationStrategy.class, "roleStrategy");
-        assertNotNull("Failed to find configurator for RoleBasedAuthorizationStrategy", c);
-        assertEquals("Retrieved wrong configurator", RoleBasedAuthorizationStrategyConfigurator.class, c.getClass());
-
-        Configurator.lookup(RoleBasedAuthorizationStrategy.class);
     }
 
     @Test

--- a/integrations/src/test/resources/org/jenkinsci/plugins/casc/RoleStrategy1.yml
+++ b/integrations/src/test/resources/org/jenkinsci/plugins/casc/RoleStrategy1.yml
@@ -1,7 +1,7 @@
 jenkins:
 
   authorizationStrategy:
-    roleStrategy:
+    roleBased:
       roles:
         global:
           - name: "admin"

--- a/integrations/src/test/resources/org/jenkinsci/plugins/casc/RoleStrategy2.yml
+++ b/integrations/src/test/resources/org/jenkinsci/plugins/casc/RoleStrategy2.yml
@@ -1,7 +1,7 @@
 jenkins:
 
   authorizationStrategy:
-    roleStrategy:
+    roleBased:
       roles:
         global:
           - name: "admin"

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/Attribute.java
@@ -166,8 +166,8 @@ public class Attribute<Owner, Type> {
         return getter.getValue(target);
     }
 
-    public CNode describe(Owner instance) throws ConfiguratorException {
-        final Configurator c = Configurator.lookup(type);
+    public CNode describe(Owner instance, ConfigurationContext context) throws ConfiguratorException {
+        final Configurator c = context.lookup(type);
         if (c == null) {
             return new Scalar("FAILED TO EXPORT " + instance.getClass().getName()+"#"+name +
                     ": No configurator found for type " + type);
@@ -181,11 +181,11 @@ public class Attribute<Owner, Type> {
                 Sequence seq = new Sequence();
                 if (o.getClass().isArray()) o = Arrays.asList((Object[]) o);
                 for (Object value : (Iterable) o) {
-                    seq.add(c.describe(value));
+                    seq.add(c.describe(value, context));
                 }
                 return seq;
             }
-            return c.describe(o);
+            return c.describe(o, context);
         } catch (Exception e) {
             // Don't fail the whole export, prefer logging this error
             final StringWriter w = new StringWriter();

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/BaseConfigurator.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * a General purpose abstract {@link Configurator} implementation.
+ * a General purpose abstract {@link Configurator} implementation based on introspection.
  * Target component is identified by implementing {@link #instance(Mapping, ConfigurationContext)} then configuration is applied on
  * {@link Attribute}s as defined by {@link #describe()}.
  * This base implementation uses JavaBean convention to identify configurable attributes.
@@ -277,7 +277,7 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
                 }
 
                 final Class k = attribute.getType();
-                final Configurator configurator = Configurator.lookupOrFail(k);
+                final Configurator configurator = context.lookupOrFail(k);
 
                 final Object valueToSet;
                 if (attribute.isMultiple()) {
@@ -320,12 +320,12 @@ public abstract class BaseConfigurator<T> extends Configurator<T> {
         }
     }
 
-    protected @Nonnull Mapping compare(T o1, T o2) throws Exception {
+    protected @Nonnull Mapping compare(T o1, T o2, ConfigurationContext context) throws Exception {
 
         Mapping mapping = new Mapping();
         for (Attribute attribute : getAttributes()) {
             if (attribute.equals(o1, o2)) continue;
-            mapping.put(attribute.getName(), attribute.describe(o1));
+            mapping.put(attribute.getName(), attribute.describe(o1, context));
         }
         return mapping;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/ConfigurationContext.java
@@ -5,7 +5,9 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.stapler.Stapler;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,13 +16,19 @@ import java.util.List;
  */
 @Restricted(Beta.class)
 // @Restricted(Beta.class)
-public class ConfigurationContext {
+public class ConfigurationContext implements ConfiguratorRegistry {
 
     private Deprecation deprecation = Deprecation.reject;
     private Restriction restriction = Restriction.reject;
     private Unknown unknown = Unknown.reject;
 
-    private List<Listener> listeners = new ArrayList<>();
+    private transient List<Listener> listeners = new ArrayList<>();
+
+    private transient final ConfiguratorRegistry registry;
+
+    public ConfigurationContext(ConfiguratorRegistry registry) {
+        this.registry = registry;
+    }
 
     public void addListener(Listener listener) {
         listeners.add(listener);
@@ -50,6 +58,27 @@ public class ConfigurationContext {
         this.unknown = unknown;
     }
 
+
+    // --- delegate methods for ConfigurationContext
+
+
+    @Override
+    @CheckForNull
+    public RootElementConfigurator lookupRootElement(String name) {
+        return registry.lookupRootElement(name);
+    }
+
+    @Override
+    @Nonnull
+    public Configurator lookupOrFail(Type type) throws ConfiguratorException {
+        return registry.lookupOrFail(type);
+    }
+
+    @Override
+    @CheckForNull
+    public Configurator lookup(Type type) {
+        return registry.lookup(type);
+    }
 
     /**
      * the model-introspection model to be applied by configuration-as-code.

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/ConfiguratorRegistry.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/ConfiguratorRegistry.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.plugins.casc;
+
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.Beta;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.lang.reflect.Type;
+
+/**
+ * A Registry to allow {@link Configurator}s retrieval.
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Restricted(Beta.class)
+public interface ConfiguratorRegistry {
+
+    /**
+     * Retrieve a {@link RootElementConfigurator} by it's yaml element (key) name.
+     * @param name
+     * @return <code>null</code> if we don't know any {@link RootElementConfigurator} for requested name
+     */
+    @CheckForNull
+    RootElementConfigurator lookupRootElement(String name);
+
+    /**
+     * Retrieve a {@link Configurator} for target type.
+     * @param type
+     * @return <code>null</code> if we don't know any {@link RootElementConfigurator} for requested type
+     */
+    @CheckForNull
+    Configurator lookup(Type type);
+
+    /**
+     * null-safe flavour of {@link #lookup(Type)}.
+     * @param type
+     * @throws ConfiguratorException if we don't know any {@link RootElementConfigurator} for requested type
+     */
+    @Nonnull
+    Configurator lookupOrFail(Type type) throws ConfiguratorException;
+
+    /**
+     * Retrieve default implementation from Jenkins
+     */
+    static ConfiguratorRegistry get() {
+        return Jenkins.getInstance().getExtensionList(ConfiguratorRegistry.class).get(0);
+    }
+}

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/ElementConfigurator.java
@@ -83,6 +83,6 @@ public interface ElementConfigurator<T> {
      * Only export attributes which are <b>not</b> set to default value.
      */
     @CheckForNull
-    CNode describe(T instance) throws Exception;
+    CNode describe(T instance, ConfigurationContext context) throws Exception;
 
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/AdminWhitelistRuleConfigurator.java
@@ -73,7 +73,7 @@ public class AdminWhitelistRuleConfigurator extends BaseConfigurator<AdminWhitel
 
     @CheckForNull
     @Override
-    public CNode describe(AdminWhitelistRule instance) {
+    public CNode describe(AdminWhitelistRule instance, ConfigurationContext context) {
         return null; // FIXME
     }
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/JenkinsConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/JenkinsConfigurator.java
@@ -62,12 +62,12 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
 
     @CheckForNull
     @Override
-    public CNode describe(Jenkins instance) throws Exception {
+    public CNode describe(Jenkins instance, ConfigurationContext context) throws Exception {
 
         // we can't generate a fresh new Jenkins object as constructor is mixed with init and check for `theInstance` singleton 
         Mapping mapping = new Mapping();
         for (Attribute attribute : getAttributes()) {
-            mapping.put(attribute.getName(), attribute.describe(instance));
+            mapping.put(attribute.getName(), attribute.describe(instance, context));
         }
         return mapping;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/MavenConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/MavenConfigurator.java
@@ -3,12 +3,14 @@ package org.jenkinsci.plugins.casc.core;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.tasks.Maven;
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.mvn.GlobalMavenConfig;
 import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.BaseConfigurator;
 import org.jenkinsci.plugins.casc.ConfigurationContext;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.impl.configurators.DescriptorConfigurator;
 import org.jenkinsci.plugins.casc.model.CNode;
 import org.jenkinsci.plugins.casc.model.Mapping;
 import org.kohsuke.accmod.Restricted;
@@ -41,8 +43,7 @@ public class MavenConfigurator extends BaseConfigurator<GlobalMavenConfig> {
     public Set<Attribute> describe() {
         final Set<Attribute> attributes = super.describe();
         final Descriptor descriptor = Jenkins.getInstance().getDescriptorOrDie(Maven.class);
-        final Configurator<Descriptor> task = Configurator.lookup(descriptor.getClass());
-        if (task == null) return attributes; // ?
+        final Configurator<Descriptor> task = new DescriptorConfigurator(descriptor);
 
         for (Attribute attribute : task.describe()) {
             attributes.add(new Attribute(attribute.getName(), attribute.getType())
@@ -55,7 +56,7 @@ public class MavenConfigurator extends BaseConfigurator<GlobalMavenConfig> {
 
     @CheckForNull
     @Override
-    public CNode describe(GlobalMavenConfig instance) throws Exception {
+    public CNode describe(GlobalMavenConfig instance, ConfigurationContext context) throws Exception {
         return null;
     }
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/NoneSecurityRealmConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/NoneSecurityRealmConfigurator.java
@@ -46,7 +46,7 @@ public class NoneSecurityRealmConfigurator extends Configurator<SecurityRealm> {
 
     @CheckForNull
     @Override
-    public CNode describe(SecurityRealm instance) throws Exception {
+    public CNode describe(SecurityRealm instance, ConfigurationContext context) throws Exception {
         return null;
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/core/UnsecuredAuthorizationStrategyConfigurator.java
@@ -32,7 +32,7 @@ public class UnsecuredAuthorizationStrategyConfigurator extends BaseConfigurator
 
     @CheckForNull
     @Override
-    public CNode describe(Unsecured instance) {
+    public CNode describe(Unsecured instance, ConfigurationContext context) {
         return null; // FIXME
     }
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/CredentialsRootConfigurator.java
@@ -57,10 +57,10 @@ public class CredentialsRootConfigurator extends BaseConfigurator<GlobalCredenti
 
     @CheckForNull
     @Override
-    public CNode describe(GlobalCredentialsConfiguration instance) throws Exception {
+    public CNode describe(GlobalCredentialsConfiguration instance, ConfigurationContext context) throws Exception {
         Mapping mapping = new Mapping();
         for (Attribute attribute : describe()) {
-            mapping.put(attribute.getName(), attribute.describe(Jenkins.getInstance()));
+            mapping.put(attribute.getName(), attribute.describe(Jenkins.getInstance(), context));
         }
         return mapping;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsProviderConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsProviderConfigurator.java
@@ -45,10 +45,10 @@ public class SystemCredentialsProviderConfigurator extends BaseConfigurator<Syst
 
     @CheckForNull
     @Override
-    public CNode describe(SystemCredentialsProvider instance) throws Exception {
+    public CNode describe(SystemCredentialsProvider instance, ConfigurationContext context) throws Exception {
         Mapping mapping = new Mapping();
         for (Attribute attribute : describe()) {
-            mapping.put(attribute.getName(), attribute.describe(instance));
+            mapping.put(attribute.getName(), attribute.describe(instance, context));
         }
         return mapping;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/DefaultConfiguratorRegistry.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/DefaultConfiguratorRegistry.java
@@ -1,0 +1,166 @@
+package org.jenkinsci.plugins.casc.impl;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.Configurable;
+import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorException;
+import org.jenkinsci.plugins.casc.ConfiguratorRegistry;
+import org.jenkinsci.plugins.casc.RootElementConfigurator;
+import org.jenkinsci.plugins.casc.impl.configurators.ConfigurableConfigurator;
+import org.jenkinsci.plugins.casc.impl.configurators.DataBoundConfigurator;
+import org.jenkinsci.plugins.casc.impl.configurators.DescriptorConfigurator;
+import org.jenkinsci.plugins.casc.impl.configurators.EnumConfigurator;
+import org.jenkinsci.plugins.casc.impl.configurators.ExtensionConfigurator;
+import org.jenkinsci.plugins.casc.impl.configurators.HeteroDescribableConfigurator;
+import org.jenkinsci.plugins.casc.impl.configurators.PrimitiveConfigurator;
+import org.jvnet.tiger_types.Types;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Stapler;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class DefaultConfiguratorRegistry implements ConfiguratorRegistry {
+
+    private final static Logger logger = Logger.getLogger(DefaultConfiguratorRegistry.class.getName());
+
+
+    @Override
+    @CheckForNull
+    public RootElementConfigurator lookupRootElement(String name) {
+        for (RootElementConfigurator c : RootElementConfigurator.all()) {
+            if (c.getName().equalsIgnoreCase(name)) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Looks for a configurator for exact type.
+     * @param type Type
+     * @return Configurator
+     * @throws ConfiguratorException Configurator is not found
+     */
+    @Override
+    @Nonnull
+    public Configurator lookupOrFail(Type type) throws ConfiguratorException {
+        try {
+            return cache.get(type);
+        } catch (ExecutionException e) {
+            throw (ConfiguratorException) e.getCause();
+        }
+    }
+
+    /**
+     * Looks for a configurator for exact type.
+     * @param type Type
+     * @return Configurator or {@code null} if it is not found
+     */
+    @Override
+    @CheckForNull
+    public Configurator lookup(Type type) {
+        try {
+            return cache.get(type);
+        } catch (ExecutionException e) {
+            return null;
+        }
+    }
+
+    private LoadingCache<Type, Configurator> cache = CacheBuilder.newBuilder()
+            .expireAfterAccess(10, TimeUnit.SECONDS)
+            .build(new CacheLoader<Type, Configurator>() {
+                @Override
+                public Configurator load(Type type) throws Exception {
+                    final Configurator configurator = internalLookup(type);
+                    if (configurator == null) throw new ConfiguratorException("Cannot find configurator for type " + type);
+                    return configurator;
+                }
+            });
+
+    private Configurator internalLookup(Type type) {
+        Class clazz = Types.erasure(type);
+
+        final Jenkins jenkins = Jenkins.getInstance();
+        final ExtensionList<Configurator> l = jenkins.getExtensionList(Configurator.class);
+        for (Configurator c : l) {
+            if (c.match(clazz)) {
+                // this type has a dedicated Configurator implementation
+                return c;
+            }
+        }
+
+        if (Collection.class.isAssignableFrom(clazz)) {
+            //TODO: Only try to cast if we can actually get the parameterized type
+            if (type instanceof ParameterizedType) {
+                ParameterizedType pt = (ParameterizedType) type;
+                Type actualType = pt.getActualTypeArguments()[0];
+                if (actualType instanceof WildcardType) {
+                    actualType = ((WildcardType) actualType).getUpperBounds()[0];
+                }
+                if(actualType instanceof ParameterizedType){
+                    actualType = ((ParameterizedType)actualType).getRawType();
+                }
+                if (!(actualType instanceof Class)) {
+                    throw new IllegalStateException("Can't handle " + type);
+                }
+                return lookup(actualType);
+            }
+        }
+
+        if (Configurable.class.isAssignableFrom(clazz)) {
+            return new ConfigurableConfigurator(clazz);
+        }
+
+        if (Descriptor.class.isAssignableFrom(clazz)) {
+            return new DescriptorConfigurator((Descriptor) jenkins.getExtensionList(clazz).get(0));
+        }
+
+        if (DataBoundConfigurator.getDataBoundConstructor(clazz) != null) {
+            return new DataBoundConfigurator(clazz);
+        }
+
+        if (Modifier.isAbstract(clazz.getModifiers()) && Describable.class.isAssignableFrom(clazz)) {
+            // this is a jenkins Describable component, with various implementations
+            return new HeteroDescribableConfigurator(clazz);
+        }
+
+        if (Extension.class.isAssignableFrom(clazz)) {
+            return new ExtensionConfigurator(clazz);
+        }
+
+        if (Stapler.lookupConverter(clazz) != null) {
+            return new PrimitiveConfigurator(clazz);
+        }
+
+        if (clazz.isEnum()) {
+            return new EnumConfigurator(clazz);
+        }
+
+        logger.warning("Configuration-as-Code can't handle type "+ type);
+        return null;
+    }
+
+
+}

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/ConfigurableConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/ConfigurableConfigurator.java
@@ -59,7 +59,7 @@ public class ConfigurableConfigurator<T extends Configurable> extends Configurat
 
     @CheckForNull
     @Override
-    public CNode describe(T instance) throws Exception {
+    public CNode describe(T instance, ConfigurationContext context) throws Exception {
         return instance.describe();
     }
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/DescriptorConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/DescriptorConfigurator.java
@@ -60,9 +60,9 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor> impleme
 
     @CheckForNull
     @Override
-    public CNode describe(Descriptor instance) throws Exception {
+    public CNode describe(Descriptor instance, ConfigurationContext context) throws Exception {
         final Descriptor ref = (Descriptor) target.newInstance();
-        return compare(instance, ref);
+        return compare(instance, ref, context);
     }
 
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/EnumConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/EnumConfigurator.java
@@ -50,7 +50,7 @@ public class EnumConfigurator<T extends Enum<T>> extends Configurator<T> {
 
     @CheckForNull
     @Override
-    public CNode describe(T instance) throws Exception {
+    public CNode describe(T instance, ConfigurationContext context) throws Exception {
         return new Scalar(instance.name());
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/ExtensionConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/ExtensionConfigurator.java
@@ -46,9 +46,9 @@ public class ExtensionConfigurator<T> extends BaseConfigurator<T> {
 
     @CheckForNull
     @Override
-    public CNode describe(T instance) throws Exception {
+    public CNode describe(T instance, ConfigurationContext context) throws Exception {
         final T ref = target.newInstance();
-        return compare(instance, ref);
+        return compare(instance, ref, context);
     }
 
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
@@ -78,20 +78,20 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
 
     @CheckForNull
     @Override
-    public CNode describe(GlobalConfigurationCategory instance) {
+    public CNode describe(GlobalConfigurationCategory instance, ConfigurationContext context) {
 
         final Mapping mapping = new Mapping();
         Jenkins.getInstance().getExtensionList(Descriptor.class).stream()
             .filter(d -> d.getCategory() == category)
             .filter(d -> d.getGlobalConfigPage() != null)
-            .forEach(d -> describe(d, mapping));
+            .forEach(d -> describe(d, mapping, context));
         return mapping;
     }
 
-    private void describe(Descriptor d, Mapping mapping) {
+    private void describe(Descriptor d, Mapping mapping, ConfigurationContext context) {
         final DescriptorConfigurator c = new DescriptorConfigurator(d);
         try {
-            final CNode node = c.describe(d);
+            final CNode node = c.describe(d, context);
             if (node != null) mapping.put(c.getName(), node);
         } catch (Exception e) {
             final StringWriter w = new StringWriter();

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/PrimitiveConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/PrimitiveConfigurator.java
@@ -48,7 +48,7 @@ public class PrimitiveConfigurator extends Configurator {
 
     @CheckForNull
     @Override
-    public CNode describe(Object instance) {
+    public CNode describe(Object instance, ConfigurationContext context) {
 
         if (instance == null) return null;
 
@@ -66,7 +66,7 @@ public class PrimitiveConfigurator extends Configurator {
     }
 
     @Override
-    public List<Configurator> getConfigurators() {
+    public List<Configurator> getConfigurators(ConfigurationContext context) {
         return Collections.EMPTY_LIST;
     }
 }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/SelfConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/impl/configurators/SelfConfigurator.java
@@ -40,8 +40,8 @@ public class SelfConfigurator extends BaseConfigurator<ConfigurationContext> imp
 
     @CheckForNull
     @Override
-    public CNode describe(ConfigurationContext instance) throws Exception {
-        return compare(instance, new ConfigurationContext());
+    public CNode describe(ConfigurationContext instance, ConfigurationContext context) throws Exception {
+        return compare(instance, new ConfigurationContext(null), context);
     }
 }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/globalmatrixauth/GlobalMatrixAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/globalmatrixauth/GlobalMatrixAuthorizationStrategyConfigurator.java
@@ -48,7 +48,7 @@ public class GlobalMatrixAuthorizationStrategyConfigurator extends Configurator<
     @Override
     public GlobalMatrixAuthorizationStrategy configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
         Mapping map = config.asMapping();
-        Configurator<GroupPermissionDefinition> permissionConfigurator = Configurator.lookupOrFail(GroupPermissionDefinition.class);
+        Configurator<GroupPermissionDefinition> permissionConfigurator = context.lookupOrFail(GroupPermissionDefinition.class);
         Map<Permission,Set<String>> grantedPermissions = new HashMap<>();
         for (CNode entry : map.get("grantedPermissions").asSequence()) {
             GroupPermissionDefinition gpd = permissionConfigurator.configure(entry, context);
@@ -76,7 +76,7 @@ public class GlobalMatrixAuthorizationStrategyConfigurator extends Configurator<
 
     @CheckForNull
     @Override
-    public CNode describe(GlobalMatrixAuthorizationStrategy instance) {
+    public CNode describe(GlobalMatrixAuthorizationStrategy instance, ConfigurationContext context) {
         // FIXME
         return null;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobConfigurator.java
@@ -51,7 +51,7 @@ public class SeedJobConfigurator implements RootElementConfigurator<List<Generat
     public List<GeneratedItems> configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
         JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
         final Sequence sources = config.asSequence();
-        final Configurator<ScriptSource> con = Configurator.lookup(ScriptSource.class);
+        final Configurator<ScriptSource> con = context.lookup(ScriptSource.class);
         List<GeneratedItems> generated = new ArrayList<>();
         for (CNode source : sources) {
             final String script;
@@ -77,7 +77,7 @@ public class SeedJobConfigurator implements RootElementConfigurator<List<Generat
 
     @CheckForNull
     @Override
-    public CNode describe(List<GeneratedItems> instance) {
+    public CNode describe(List<GeneratedItems> instance, ConfigurationContext context) {
         return null; // FIXME
     }
 

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/projectmatriaxauth/ProjectMatrixAuthorizationStrategyConfigurator.java
@@ -40,7 +40,7 @@ public class ProjectMatrixAuthorizationStrategyConfigurator extends Configurator
     public ProjectMatrixAuthorizationStrategy configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
         Mapping map = config.asMapping();
         Sequence o = map.get("grantedPermissions").asSequence();
-        Configurator<GroupPermissionDefinition> permissionConfigurator = Configurator.lookupOrFail(GroupPermissionDefinition.class);
+        Configurator<GroupPermissionDefinition> permissionConfigurator = context.lookupOrFail(GroupPermissionDefinition.class);
         Map<Permission,Set<String>> grantedPermissions = new HashMap<>();
         for(CNode entry : o) {
             GroupPermissionDefinition gpd = permissionConfigurator.configure(entry, context);
@@ -72,7 +72,7 @@ public class ProjectMatrixAuthorizationStrategyConfigurator extends Configurator
 
     @CheckForNull
     @Override
-    public CNode describe(ProjectMatrixAuthorizationStrategy instance) {
+    public CNode describe(ProjectMatrixAuthorizationStrategy instance, ConfigurationContext context) {
         // FIXME
         return null;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/rolestrategy/RoleBasedAuthorizationStrategyConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/integrations/rolestrategy/RoleBasedAuthorizationStrategyConfigurator.java
@@ -48,7 +48,7 @@ public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<Rol
     public RoleBasedAuthorizationStrategy configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
         //TODO: API should return a qualified type
         final Configurator<RoleDefinition> roleDefinitionConfigurator =
-                (Configurator<RoleDefinition>) Configurator.lookupOrFail(RoleDefinition.class);
+                (Configurator<RoleDefinition>) context.lookupOrFail(RoleDefinition.class);
 
         Mapping map = config.asMapping();
         Map<String, RoleMap> grantedRoles = new HashMap<>();
@@ -102,7 +102,7 @@ public class RoleBasedAuthorizationStrategyConfigurator extends Configurator<Rol
 
     @CheckForNull
     @Override
-    public CNode describe(RoleBasedAuthorizationStrategy instance) {
+    public CNode describe(RoleBasedAuthorizationStrategy instance, ConfigurationContext context) {
         // FIXME
         return null;
     }

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -92,7 +92,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
     private void configureProxy(Mapping map, Jenkins jenkins, ConfigurationContext context) throws ConfiguratorException {
         final CNode proxy = map.get("proxy");
         if (proxy != null) {
-            Configurator<ProxyConfiguration> pc = Configurator.lookup(ProxyConfiguration.class);
+            Configurator<ProxyConfiguration> pc = context.lookup(ProxyConfiguration.class);
             if (pc == null) throw new ConfiguratorException("ProxyConfiguration not well registered");
             ProxyConfiguration pcc = pc.configure(proxy, context);
             jenkins.proxy = pcc;
@@ -103,7 +103,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
         final CNode sites = map.get("sites");
         final UpdateCenter updateCenter = jenkins.getUpdateCenter();
         if (sites != null) {
-            Configurator<UpdateSite> usc = Configurator.lookup(UpdateSite.class);
+            Configurator<UpdateSite> usc = context.lookup(UpdateSite.class);
             List<UpdateSite> updateSites = new ArrayList<>();
             for (CNode data : sites.asSequence()) {
                 UpdateSite in = usc.configure(data, context);
@@ -328,17 +328,17 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
 
     @CheckForNull
     @Override
-    public CNode describe(PluginManager instance) throws Exception {
+    public CNode describe(PluginManager instance, ConfigurationContext context) throws Exception {
         final Mapping mapping = new Mapping();
-        final Configurator cp = Configurator.lookupOrFail(ProxyConfiguration.class);
+        final Configurator cp = context.lookupOrFail(ProxyConfiguration.class);
         final ProxyConfiguration proxy = Jenkins.getInstance().proxy;
         if (proxy != null) {
-            mapping.putIfNotNull("proxy", cp.describe(proxy));
+            mapping.putIfNotNull("proxy", cp.describe(proxy, context));
         }
         Sequence seq = new Sequence();
-        final Configurator cs = Configurator.lookupOrFail(UpdateSite.class);
+        final Configurator cs = context.lookupOrFail(UpdateSite.class);
         for (UpdateSite site : Jenkins.getInstance().getUpdateCenter().getSiteList()) {
-            seq.add(cs.describe(site));
+            seq.add(cs.describe(site, context));
         }
         mapping.putIfNotEmpry("sites", seq);
         return mapping;

--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/plugins/UpdateSiteConfigurator.java
@@ -33,7 +33,7 @@ public class UpdateSiteConfigurator extends BaseConfigurator<UpdateSite> {
 
     @CheckForNull
     @Override
-    public CNode describe(UpdateSite instance) throws Exception {
+    public CNode describe(UpdateSite instance, ConfigurationContext context) throws Exception {
         final Mapping mapping = new Mapping();
         // TODO would need to compare with hudson.model.UpdateCenter.createDefaultUpdateSite
         // so we return null if default update site is in use.

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/Attribute/schema.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/Attribute/schema.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core">
 <j:choose>
   <j:when test="${it.type.enum}">
     "type": "string",

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/ConfigurationAsCode/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" >
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout norefresh="true" type="one-column" title="${%about(app.VERSION)}">
 
   <l:main-panel>

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/ConfigurationAsCode/reference.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/ConfigurationAsCode/reference.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:contentType value="text/html;charset=UTF-8"/>
   <html><head>
   <style class='anchorjs'></style><link href='https://jenkins.io/assets/bower/bootstrap/css/bootstrap.min.css' media='screen' rel='stylesheet'/>

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/ConfigurationAsCode/schema.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/ConfigurationAsCode/schema.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:contentType value="application/json"/>
 {
   "$schema": "http://json-schema.org/draft-06/schema#",

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/Configurator/documentation.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/Configurator/documentation.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core">
 
   <div class='configurator'>
     <div id="${it.extensionPoint.simpleName}-${it.name}" class='configurator__name'>${it.name} <sup class='configurator-pointer'>CONFIGURATOR</sup></div>

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/Configurator/schema.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/Configurator/schema.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
     "${it.target.name}": {
       "type": "object",
       "properties": {

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/DescribableAttribute/schema.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/DescribableAttribute/schema.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core">
   "schema" : {
     "oneOf": [
   <j:forEach items="${app.getDescriptorList(it.type)}" var="d" varStatus="st">

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/ObsoleteConfigurationMonitor/message.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/ObsoleteConfigurationMonitor/message.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core">
 
   <div class="${it.css}">
     <form method="post" >

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobConfigurator/documentation.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobConfigurator/documentation.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core">
 
   <div class='configurator'>
     <div id="${it.extensionPoint.simpleName}-${it.name}" class='configurator__name'>${it.name}</div>

--- a/plugin/src/main/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobConfigurator/schema.jelly
+++ b/plugin/src/main/resources/org/jenkinsci/plugins/casc/integrations/jobdsl/SeedJobConfigurator/schema.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core">
     "${it.target.name}": {
       "type": "array",
       "items": {

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/BackwardCompatibilityTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/EssentialsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/EssentialsTest.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.casc;
 import hudson.ExtensionList;
 import jenkins.metrics.api.MetricsAccessKey;
 import jenkins.model.Jenkins;
-import org.hamcrest.collection.IsCollectionWithSize;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.junit.Rule;
@@ -13,7 +12,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsCollectionWithSize.*;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.java
@@ -4,7 +4,9 @@ import hudson.model.User;
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import hudson.security.HudsonPrivateSecurityRealm;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.casc.ConfigurationContext;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.jenkinsci.plugins.casc.model.CNode;
@@ -36,9 +38,10 @@ public class HudsonPrivateSecurityRealmConfiguratorTest {
         final FullControlOnceLoggedInAuthorizationStrategy authorizationStrategy = (FullControlOnceLoggedInAuthorizationStrategy) jenkins.getAuthorizationStrategy();
         assertTrue(authorizationStrategy.isAllowAnonymousRead());
 
-
-        final Configurator c = Configurator.lookupOrFail(HudsonPrivateSecurityRealm.class);
-        final CNode node = c.describe(securityRealm);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        final Configurator c = context.lookupOrFail(HudsonPrivateSecurityRealm.class);
+        final CNode node = c.describe(securityRealm, context);
         final Mapping user = node.asMapping().get("users").asSequence().get(0).asMapping();
         assertEquals("admin", user.getScalarValue("id"));
     }

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/core/JenkinsConfiguratorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/core/JenkinsConfiguratorTest.java
@@ -5,7 +5,6 @@ import hudson.model.TaskListener;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import hudson.security.HudsonPrivateSecurityRealm;
-import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.DescribableList;
@@ -13,17 +12,14 @@ import jenkins.model.Jenkins;
 import org.hamcrest.CoreMatchers;
 import org.jenkinsci.plugins.casc.Attribute;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -53,7 +49,8 @@ public class JenkinsConfiguratorTest {
     @Test
     @Issue("Issue #60")
     public void shouldHaveAuthStrategyConfigurator() throws Exception {
-        Configurator c = Configurator.lookup(Jenkins.class);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(Jenkins.class);
         Attribute attr = c.getAttribute("authorizationStrategy");
         assertNotNull(attr);
         // Apparently Java always thinks that labmdas are equal

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/credentials/SystemCredentialsTest.java
@@ -6,7 +6,8 @@ import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfigurationContext;
+import org.jenkinsci.plugins.casc.ConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.impl.configurators.DataBoundConfigurator;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.EnvVarsRule;
@@ -22,10 +23,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -47,6 +45,7 @@ public class SystemCredentialsTest {
             .around(log)
             .around(new JenkinsConfiguredWithCodeRule());
 
+
     @Test
     @ConfiguredWithCode("SystemCredentialsTest.yml")
     public void configure_system_credentials() throws Exception {
@@ -58,7 +57,10 @@ public class SystemCredentialsTest {
         assertThat(ups, hasSize(1));
         final UsernamePasswordCredentials up = ups.get(0);
         assertThat(up.getPassword().getPlainText(), equalTo("1234"));
-        final CNode node = Configurator.lookup(up.getClass()).describe(up);
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final ConfigurationContext context = new ConfigurationContext(registry);
+        final CNode node = context.lookup(up.getClass()).describe(up, context);
         assertEquals("1234", node.asMapping().getScalarValue("password"));
 
 

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.casc.impl.configurators;
 
 import org.jenkinsci.plugins.casc.ConfigurationContext;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.model.CNode;
 import org.jenkinsci.plugins.casc.model.Mapping;
 import org.junit.Rule;
@@ -30,7 +31,8 @@ public class DataBoundConfiguratorTest {
         config.put("bar", "true");
         config.put("qix", "123");
         config.put("zot", "DataBoundSetter");
-        final Foo configured = (Foo) Configurator.lookup(Foo.class).configure(config, new ConfigurationContext());
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final Foo configured = (Foo) registry.lookup(Foo.class).configure(config, new ConfigurationContext(registry));
         assertEquals("foo", configured.foo);
         assertEquals(true, configured.bar);
         assertEquals(123, configured.qix);
@@ -43,8 +45,10 @@ public class DataBoundConfiguratorTest {
     public void exportYaml() throws Exception {
         Foo foo = new Foo("foo", true, 42);
         foo.setZot("zot");
-        final Configurator c = Configurator.lookup(Foo.class);
-        final CNode node = c.describe(foo);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final Configurator c = registry.lookup(Foo.class);
+        final ConfigurationContext context = new ConfigurationContext(registry);
+        final CNode node = c.describe(foo, context);
         assertNotNull(node);
         assertTrue(node instanceof Mapping);
         Mapping map = (Mapping) node;

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/impl/configurators/PrimitiveConfiguratorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/impl/configurators/PrimitiveConfiguratorTest.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.casc.impl.configurators;
 import hudson.model.Node;
 import org.jenkinsci.plugins.casc.ConfigurationContext;
 import org.jenkinsci.plugins.casc.Configurator;
+import org.jenkinsci.plugins.casc.ConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.model.Scalar;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,41 +26,44 @@ public class PrimitiveConfiguratorTest {
     @Rule
     public final EnvironmentVariables environment = new EnvironmentVariables();
 
-    public final ConfigurationContext context = new ConfigurationContext();
-
     @Test
     public void _boolean() throws Exception {
-        Configurator c = Configurator.lookup(boolean.class);
-        final Object value = c.configure(new Scalar("true"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(boolean.class);
+        final Object value = c.configure(new Scalar("true"), new ConfigurationContext(registry));
         assertTrue((Boolean) value);
     }
 
     @Test
     public void _int() throws Exception {
-        Configurator c = Configurator.lookup(int.class);
-        final Object value = c.configure(new Scalar("123"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(int.class);
+        final Object value = c.configure(new Scalar("123"), new ConfigurationContext(registry));
         assertEquals(123, (int) value);
     }
 
     @Test
     public void _Integer() throws Exception {
-        Configurator c = Configurator.lookup(Integer.class);
-        final Object value = c.configure(new Scalar("123"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(Integer.class);
+        final Object value = c.configure(new Scalar("123"), new ConfigurationContext(registry));
         assertTrue(123 == ((Integer) value).intValue());
     }
 
     @Test
     public void _string() throws Exception {
-        Configurator c = Configurator.lookup(String.class);
-        final Object value = c.configure(new Scalar("abc"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(String.class);
+        final Object value = c.configure(new Scalar("abc"), new ConfigurationContext(registry));
         assertEquals("abc", value);
     }
 
     @Test
     public void _enum() throws Exception {
         // Jenkins do register a StaplerConverter for it.
-        Configurator<Node.Mode> c = Configurator.lookupOrFail(Node.Mode.class);
-        final Node.Mode value = c.configure(new Scalar("NORMAL"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator<Node.Mode> c = registry.lookupOrFail(Node.Mode.class);
+        final Node.Mode value = c.configure(new Scalar("NORMAL"), new ConfigurationContext(registry));
         assertEquals(Node.Mode.NORMAL, value);
 
     }
@@ -67,8 +71,9 @@ public class PrimitiveConfiguratorTest {
     @Test
     public void _enum2() throws Exception {
         // No explicit converter set by jenkins
-        Configurator<TimeUnit> c = Configurator.lookupOrFail(TimeUnit.class);
-        final TimeUnit value = c.configure(new Scalar("DAYS"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator<TimeUnit> c = registry.lookupOrFail(TimeUnit.class);
+        final TimeUnit value = c.configure(new Scalar("DAYS"), new ConfigurationContext(registry));
         assertEquals(TimeUnit.DAYS, value);
 
     }
@@ -76,31 +81,35 @@ public class PrimitiveConfiguratorTest {
     @Test
     public void _Integer_env() throws Exception {
         environment.set("ENV_FOR_TEST", "123");
-        Configurator c = Configurator.lookup(Integer.class);
-        final Object value = c.configure(new Scalar("${ENV_FOR_TEST}"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(Integer.class);
+        final Object value = c.configure(new Scalar("${ENV_FOR_TEST}"), new ConfigurationContext(registry));
         assertTrue(123 == ((Integer) value).intValue());
     }
 
     @Test
     public void _string_env() throws Exception {
         environment.set("ENV_FOR_TEST", "abc");
-        Configurator c = Configurator.lookup(String.class);
-        final Object value = c.configure(new Scalar("${ENV_FOR_TEST}"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(String.class);
+        final Object value = c.configure(new Scalar("${ENV_FOR_TEST}"), new ConfigurationContext(registry));
         assertEquals("abc", value);
     }
 
     @Test
     public void _string_env_default() throws Exception {
         environment.set("NOT_THERE", "abc");
-        Configurator c = Configurator.lookup(String.class);
-        final Object value = c.configure(new Scalar("${ENV_FOR_TEST:-unsecured-token}"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(String.class);
+        final Object value = c.configure(new Scalar("${ENV_FOR_TEST:-unsecured-token}"), new ConfigurationContext(registry));
         assertEquals("unsecured-token", value);
     }
 
     @Test
     public void _int_env_default() throws Exception {
-        Configurator c = Configurator.lookup(Integer.class);
-        final Object value = c.configure(new Scalar("${ENV_FOR_TEST:-123}"), context);
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        Configurator c = registry.lookup(Integer.class);
+        final Object value = c.configure(new Scalar("${ENV_FOR_TEST:-123}"), new ConfigurationContext(registry));
         assertEquals(123, value);
     }
 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/impl/configurators/SelfConfiguratorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/impl/configurators/SelfConfiguratorTest.java
@@ -1,8 +1,6 @@
 package org.jenkinsci.plugins.casc.impl.configurators;
 
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.casc.ConfigurationAsCode;
-import org.jenkinsci.plugins.casc.ConfigurationContext;
 import org.jenkinsci.plugins.casc.ConfiguratorException;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
@@ -1,18 +1,12 @@
 package org.jenkinsci.plugins.casc.misc;
 
 import org.jenkinsci.plugins.casc.ConfigurationAsCode;
-import org.junit.Assert;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author lanwen (Kirill Merkushev)

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfiguratorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/plugins/PluginManagerConfiguratorTest.java
@@ -3,12 +3,15 @@ package org.jenkinsci.plugins.casc.plugins;
 import hudson.Plugin;
 import org.jenkinsci.plugins.casc.ConfigurationAsCode;
 import org.jenkinsci.plugins.casc.ConfigurationContext;
+import org.jenkinsci.plugins.casc.ConfiguratorRegistry;
 import org.jenkinsci.plugins.casc.misc.ConfiguredWithCode;
 import org.jenkinsci.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.jenkinsci.plugins.casc.model.CNode;
 import org.jenkinsci.plugins.casc.model.Mapping;
 import org.jenkinsci.plugins.casc.model.Sequence;
-import org.junit.*;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.yaml.snakeyaml.nodes.Node;
 
 import java.io.IOException;
@@ -25,8 +28,6 @@ public class PluginManagerConfiguratorTest {
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
 
-    public final ConfigurationContext context = new ConfigurationContext();
-
     @Test
     @Ignore //TODO: This needs to be re-enabled once we can actually dynamically load plugins
     @ConfiguredWithCode("PluginManagerConfiguratorTest.yml")
@@ -39,7 +40,9 @@ public class PluginManagerConfiguratorTest {
     @Test
     public void describeDefaultConfig() throws Exception {
         final PluginManagerConfigurator root = getPluginManagerConfigurator();
-        final CNode node = root.describe(root.getTargetComponent(context));
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        final CNode node = root.describe(root.getTargetComponent(context), context);
         assertNotNull(node);
         assertTrue(node instanceof Mapping);
         final Object sites = ((Mapping) node).get("sites");
@@ -57,7 +60,9 @@ public class PluginManagerConfiguratorTest {
     @ConfiguredWithCode("ProxyConfigTest.yml")
     public void describeProxyConfig() throws Exception {
         final PluginManagerConfigurator root = getPluginManagerConfigurator();
-        final CNode configNode = root.describe(root.getTargetComponent(context));
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        final CNode configNode = root.describe(root.getTargetComponent(context), context);
         ((Mapping) configNode).remove("sites");
         final String yamlConfig = toYamlString(configNode);
         assertEquals(String.join("\n",


### PR DESCRIPTION
will avoid running same lookup for each and every comparable type. 
Especially considering we want to run check before and configuration is applied