### PR TITLE
Support java.util.List<? extends hudson.tools.ToolProperty<?>>

### DIFF
--- a/plugin/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
+++ b/plugin/src/main/java/org/jenkinsci/plugins/casc/Configurator.java
@@ -111,6 +111,9 @@ public abstract class Configurator<T> implements ExtensionPoint, ElementConfigur
                 if (actualType instanceof WildcardType) {
                     actualType = ((WildcardType) actualType).getUpperBounds()[0];
                 }
+                if(actualType instanceof ParameterizedType){
+                    actualType = ((ParameterizedType)actualType).getRawType();
+                }
                 if (!(actualType instanceof Class)) {
                     throw new IllegalStateException("Can't handle " + type);
                 }

--- a/plugin/src/test/java/org/jenkinsci/plugins/casc/core/MavenConfiguratorTest.java
+++ b/plugin/src/test/java/org/jenkinsci/plugins/casc/core/MavenConfiguratorTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.casc.core;
 
 import hudson.tasks.Maven;
+import hudson.tools.InstallSourceProperty;
 import jenkins.mvn.FilePathSettingsProvider;
 import jenkins.mvn.GlobalMavenConfig;
 import jenkins.mvn.SettingsProvider;
@@ -25,6 +26,8 @@ public class MavenConfiguratorTest {
         Assert.assertEquals(1, descriptor.getInstallations().length);
         Assert.assertEquals("/usr/share/maven", descriptor.getInstallations()[0].getHome());
 
+        InstallSourceProperty installSourceProperty = descriptor.getInstallations()[0].getProperties().get(InstallSourceProperty.class);
+        Assert.assertEquals("3.5.0", installSourceProperty.installers.get(Maven.MavenInstaller.class).id);
 
         final SettingsProvider provider = GlobalMavenConfig.get().getSettingsProvider();
         Assert.assertTrue(provider instanceof FilePathSettingsProvider);

--- a/plugin/src/test/resources/org/jenkinsci/plugins/casc/core/MavenConfiguratorTest.yml
+++ b/plugin/src/test/resources/org/jenkinsci/plugins/casc/core/MavenConfiguratorTest.yml
@@ -6,3 +6,8 @@ tool:
     installations:
       - name: maven
         home: /usr/share/maven
+        properties:
+          - installSourceProperty:
+              installers:
+              - mavenInstaller:
+                  id: '3.5.0'


### PR DESCRIPTION
Tried to declare the following:
```yaml
tool:
  maven:
    installations:
    - name: maven
      properties:
      - installSourceProperty:
          installers:
          - mavenInstaller:
              id: '3.5.0'
```

Got the following Exception:
```
INFO: Setting class hudson.tasks.Maven$MavenInstallation.name = maven
error: java.lang.IllegalStateException: Can't handle java.util.List<? extends hudson.tools.ToolProperty<?>>
```

Fixed it and added this configuration to the `MavenConfiguratorTest`
