### PR TITLE
Change the plugin description appearing in the plugin management page

### DIFF
--- a/plugin/src/main/resources/index.jelly
+++ b/plugin/src/main/resources/index.jelly
@@ -3,5 +3,5 @@
   This view is used to render the installed plugins page.
 -->
 <div>
-  This plugin is a sample to explain how to write a Jenkins plugin.
+  This plugin allows to to configure jenkins based on human-readable declarative configuration files.
 </div>


### PR DESCRIPTION
The plugin description text was the default one. This PR simply replaces it by a real plugin description (taken from the main README.md)