### PR TITLE
clone yaml input and check before actually applying configuration

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
@@ -5,11 +5,8 @@ import hudson.plugins.jira.JiraProjectProperty.DescriptorImpl;
 import hudson.plugins.jira.JiraSite;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
 
 import static org.junit.Assert.assertEquals;
 

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/RoleStrategy1.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/RoleStrategy1.yml
@@ -60,11 +60,9 @@ jenkins:
         mode: NORMAL
         name: "agent1"
         remoteFS: "/home/user1"
-        launcher:
-          jnlp:
+        launcher: jnlp
     - dumb:
         mode: NORMAL
         name: "agent2"
         remoteFS: "/home/user1"
-        launcher:
-          jnlp:
+        launcher: jnlp

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/RoleStrategy2.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/RoleStrategy2.yml
@@ -33,11 +33,9 @@ jenkins:
         mode: NORMAL
         name: "agent1"
         remoteFS: "/home/user1"
-        launcher:
-          jnlp:
+        launcher: jnlp
     - dumb:
         mode: NORMAL
         name: "agent2"
         remoteFS: "/home/user1"
-        launcher:
-          jnlp:
+        launcher: jnlp

--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -243,7 +243,7 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
      * @param context
      * @throws ConfiguratorException something went wrong...
      */
-    protected final void configure(Mapping config, T instance, boolean dryrun, ConfigurationContext context) throws ConfiguratorException {
+    protected void configure(Mapping config, T instance, boolean dryrun, ConfigurationContext context) throws ConfiguratorException {
         final Set<Attribute<T,?>> attributes = describe();
         for (Attribute<T,?> attribute : attributes) {
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -286,12 +286,18 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
                 if (attribute.isMultiple()) {
                     List<Object> values = new ArrayList<>();
                     for (CNode o : sub.asSequence()) {
-                        Object value = configurator.configure(o, context);
+                        Object value =
+                                dryrun ?
+                                        configurator.check(o, context):
+                                        configurator.configure(o, context);
                         values.add(value);
                     }
                     valueToSet= values;
                 } else {
-                    valueToSet = configurator.configure(sub, context);
+                    valueToSet =
+                            dryrun ?
+                                    configurator.check(sub, context):
+                                    configurator.configure(sub, context);
                 }
 
                 if (!dryrun) {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -517,7 +517,7 @@ public class ConfigurationAsCode extends ManagementLink {
     private void configureWith(Mapping entries) throws ConfiguratorException {
         // Check input before actually applying changes,
         // so we don't let master in a weird state after some ConfiguratorException has been thrown
-        final Mapping clone = (Mapping) entries.clone();
+        final Mapping clone = entries.clone();
         checkWith(clone);
 
         final ObsoleteConfigurationMonitor monitor = ObsoleteConfigurationMonitor.get();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/SelfConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/SelfConfigurator.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.casc.impl.configurators;
 import hudson.Extension;
 import io.jenkins.plugins.casc.BaseConfigurator;
 import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.RootElementConfigurator;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
@@ -36,6 +37,11 @@ public class SelfConfigurator extends BaseConfigurator<ConfigurationContext> imp
     @Override
     protected ConfigurationContext instance(Mapping mapping, ConfigurationContext context) {
         return context;
+    }
+
+    protected void configure(Mapping config, ConfigurationContext instance, boolean dryrun, ConfigurationContext context) throws ConfiguratorException {
+        // ConfigurationContext has to be configured _even_ for dry-run as it determine CasC behaviour
+        super.configure(config, instance, false, context);
     }
 
     @CheckForNull

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/CNode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/CNode.java
@@ -10,7 +10,7 @@ import org.kohsuke.accmod.restrictions.Beta;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Restricted(Beta.class)
-public interface CNode {
+public interface CNode extends Cloneable {
 
     enum Type { MAPPING, SEQUENCE, SCALAR }
 
@@ -35,5 +35,4 @@ public interface CNode {
      * This is used to offer relevant diagnostic messages
      */
     Source getSource();
-
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/CNode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/CNode.java
@@ -35,4 +35,6 @@ public interface CNode extends Cloneable {
      * This is used to offer relevant diagnostic messages
      */
     Source getSource();
+
+    CNode clone();
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
@@ -66,4 +66,5 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
     public Source getSource() {
         return source;
     }
+
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
@@ -67,4 +67,10 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
         return source;
     }
 
+    @Override
+    public Mapping clone() {
+        final Mapping clone = new Mapping();
+        entrySet().stream().forEach(e -> clone.put(e.getKey(), e.getValue().clone()));
+        return clone;
+    }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -108,4 +108,15 @@ public final class Scalar implements CNode, CharSequence {
         return source;
     }
 
+    @Override
+    public CNode clone() {
+        return new Scalar(this);
+    }
+
+    private Scalar(Scalar it) {
+        this.value = it.value;
+        this.format = it.format;
+        this.raw = it.raw;
+        this.source = it.source;
+    }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Sequence.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Sequence.java
@@ -39,4 +39,11 @@ public final class Sequence extends ArrayList<CNode> implements CNode {
     public Source getSource() {
         return source;
     }
+
+    @Override
+    public Sequence clone() {
+        final Sequence clone = new Sequence();
+        stream().map(CNode::clone).forEach(clone::add);
+        return clone;
+    }
 }


### PR DESCRIPTION
proposed fix for https://github.com/jenkinsci/configuration-as-code-plugin/issues/77

before applying configuration, CasC do clone the input and execute a dry-run "check" to detect blocking configuration issues.