### PR TITLE
use JENKINS_HOME/jenkins.yaml as default location for config close

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -94,7 +94,7 @@ public class ConfigurationAsCode extends ManagementLink {
 
     public static final String CASC_JENKINS_CONFIG_PROPERTY = "casc.jenkins.config";
     public static final String CASC_JENKINS_CONFIG_ENV = "CASC_JENKINS_CONFIG";
-    public static final String DEFAULT_JENKINS_YAML_PATH = "./jenkins.yaml";
+    public static final String DEFAULT_JENKINS_YAML_PATH = Jenkins.getInstance().getRootDir() + "/jenkins.yaml";
     public static final String YAML_FILES_PATTERN = "glob:**.{yml,yaml,YAML,YML}";
 
     public static final Logger LOGGER = Logger.getLogger(ConfigurationAsCode.class.getName());


### PR DESCRIPTION
using process working dir "." as base for default configuration path is error prone