### PR TITLE
'bitbucketServerUrl' deprecated in job-dsl

### DIFF
--- a/demos/jobs/bitbucket.yml
+++ b/demos/jobs/bitbucket.yml
@@ -10,7 +10,8 @@ jobs:
         // "Projects"
         organizations {
           bitbucket {
-            bitbucketServerUrl("https://$BITBUCKET_URL")
+            // DEPRECATED : bitbucketServerUrl("https://$BITBUCKET_URL")
+            serverUrl("https://$BITBUCKET_URL")
             repoOwner("OWN")
             credentialsId("bitbucket-http")
 


### PR DESCRIPTION
A warning displays that `bitbucketServerUrl` is marked as deprecated in jenkins starting log. 
It has been replaced by `serverUrl` as seen in the job-dsl api-viewer : 

bitbucketServerUrl :
```
http://$JENKINS_URL/plugin/job-dsl/api-viewer/index.html#path/organizationFolder-organizations-bitbucket-bitbucketServerUrl
```
serverUrl :
```
http://$JENKINS_URL/plugin/job-dsl/api-viewer/index.html#path/organizationFolder-organizations-bitbucket-serverUrl
```