### PR TITLE
Fix NPE with clone

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
@@ -70,7 +70,7 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
     @Override
     public Mapping clone() {
         final Mapping clone = new Mapping();
-        entrySet().stream().forEach(e -> clone.put(e.getKey(), e.getValue().clone()));
+        entrySet().stream().forEach(e -> clone.put(e.getKey(), e.getValue() == null ? null : e.getValue().clone()));
         return clone;
     }
 }


### PR DESCRIPTION
This fixes an issue introduced in RC1. For example a basic Credentials configuration would not work without this change: 

``` 
jenkins:
  systemMessage: Test
credentials:
  system:
    domainCredentials:
      - credentials:
          - usernamePassword: 
              scope:    SYSTEM
              id:       github-user
              username: ReleasePraqma
              # The key 'github' resolved from a docker secret defined in docker-compose.yml
              password: lols
          - basicSSHUserPrivateKey: 
              scope: SYSTEM
              id: agent-private-key
              username: agentuser
              passphrase:  hahah
              description: "ssh private key used to connect ssh slaves"
              privateKeySource:
                directEntry: 
                  privateKey: sp0ds9d+skkfjf
``` 
This PR fixes this issue.