### PR TITLE
Added test for the Credentials integration

### DIFF
--- a/demos/credentials/README.md
+++ b/demos/credentials/README.md
@@ -12,8 +12,7 @@ credentials:
           description: "test.com domain"
           specifications:
             - hostnameSpecification:
-                includes:
-                  - "*.test.com"
+                includes: "*.test.com"
         credentials:
           - usernamePassword:
               scope:    SYSTEM

--- a/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.casc;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class CredentialsTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @ConfiguredWithCode("GlobalCredentials.yml")
+    @Test
+    public void testGlobalScopedCredentials() {
+        List<StandardUsernamePasswordCredentials> creds = CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class,Jenkins.getInstanceOrNull(), null, Collections.emptyList());
+        assertThat(creds.size(), is(1));
+        assertEquals("user1", creds.get(0).getId());
+        assertEquals("Administrator", creds.get(0).getUsername());
+        assertEquals("secretPassword", creds.get(0).getPassword().getPlainText());
+
+        List<BasicSSHUserPrivateKey> creds2 = CredentialsProvider.lookupCredentials(BasicSSHUserPrivateKey.class,Jenkins.getInstanceOrNull(), null, Collections.emptyList());
+        assertThat(creds2.size(), is(1));
+        assertEquals("agentuser", creds2.get(0).getUsername());
+        assertEquals("password", creds2.get(0).getPassphrase().getPlainText());
+        assertEquals("ssh private key used to connect ssh slaves", creds2.get(0).getDescription());
+    }
+
+
+    @ConfiguredWithCode("CredentialsWithDomain.yml")
+    @Test
+    public void testDomainScopedCredentials() {
+        List<StandardUsernamePasswordCredentials> creds = CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class,Jenkins.getInstanceOrNull(), null, Collections.emptyList());
+        assertThat(creds.size(), is(1));
+        assertEquals("user1", creds.get(0).getId());
+        assertEquals("Administrator", creds.get(0).getUsername());
+        assertEquals("secret", creds.get(0).getPassword().getPlainText());
+    }
+
+}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/CredentialsWithDomain.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/CredentialsWithDomain.yml
@@ -1,0 +1,17 @@
+jenkins:
+  systemMessage: Testing...
+credentials:
+  system:
+    domainCredentials:
+      - domain :
+          name: "test.com"
+          description: "test.com domain"
+          specifications:
+            - hostnameSpecification:
+                includes: "*.test.com"
+        credentials:
+          - usernamePassword:
+              scope:    SYSTEM
+              id:       user1
+              username: Administrator
+              password: secret

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalCredentials.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalCredentials.yml
@@ -1,0 +1,21 @@
+jenkins:
+  systemMessage: Testing
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - usernamePassword:
+              scope: SYSTEM
+              id: user1
+              username: Administrator
+              password: secretPassword
+          - basicSSHUserPrivateKey:
+              scope: SYSTEM
+              id: agent-private-key
+              username: agentuser
+              passphrase:  password
+              description: "ssh private key used to connect ssh slaves"
+              privateKeySource:
+                directEntry:
+                  privateKey: sp0ds9d+skkfjf


### PR DESCRIPTION
Created a small test for the Credentials integration. 
Discovered an error in the documentation for configuring includes in domains. It takes a string, not a list.