### PR TITLE
Suggest user to install configuration-as-code-support if not installed

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfigurator.java
@@ -99,6 +99,15 @@ public class HeteroDescribableConfigurator<T extends Describable> implements Con
         return configure(config, context);
     }
 
+
+    /**
+     *
+     * @return true if the support plugin is installed, false otherwise.
+     */
+    private boolean _hasSupportPluginInstalled() {
+        return Jenkins.getInstance().getPlugin("configuration-as-code-support") != null;
+    }
+
     private Class<T> findDescribableBySymbol(CNode node, String shortname, List<Descriptor> candidates) {
 
         // Search for @Symbol annotation on Descriptor to match shortName
@@ -116,7 +125,9 @@ public class HeteroDescribableConfigurator<T extends Describable> implements Con
                 }
             }
         }
-        throw new IllegalArgumentException("No "+target.getName()+ " implementation found for "+shortname);
+        final String errSupport = !_hasSupportPluginInstalled() ? "\nPossible solution: Try to install 'configuration-as-code-support' plugin" : "";
+        final String msg = "No "+target.getName()+ " implementation found for "+shortname;
+        throw new IllegalArgumentException(String.format("%s%s", msg, errSupport));
     }
 
     @Override

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/MissingConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/MissingConfiguratorTest.java
@@ -1,0 +1,20 @@
+package io.jenkins.plugins.casc.impl.configurators;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MissingConfiguratorTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @ConfiguredWithCode(value = "MissingConfiguratorTest.yml", expected = IllegalArgumentException.class,
+            message = "Possible solution: Try to install 'configuration-as-code-support' plugin")
+    @Test
+    public void testThrowsSuggestion() throws Exception {
+        //No config check needed, should fail with IllegalArgumentException
+        //We're purposely trying to configure a plugin for which there is no configurator
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/ConfiguredWithCode.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/ConfiguredWithCode.java
@@ -21,4 +21,6 @@ public @interface ConfiguredWithCode {
     String[] value();
 
     Class<? extends Throwable> expected() default Test.None.class;
+
+    String message() default "";
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
@@ -1,6 +1,8 @@
 package io.jenkins.plugins.casc.misc;
 
 import io.jenkins.plugins.casc.ConfigurationAsCode;
+import org.apache.commons.lang.StringUtils;
+import org.hamcrest.core.StringContains;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Arrays;
@@ -30,6 +32,14 @@ public class JenkinsConfiguredWithCodeRule extends JenkinsRule {
             } catch (Throwable t) {
                 if (!configuredWithCode.expected().isInstance(t)) {
                     throw new AssertionError("Unexpected exception ", t);
+                } else {
+                    if(!StringUtils.isBlank(configuredWithCode.message())) {
+                        boolean match = new StringContains(configuredWithCode.message()).matches(t.getMessage());
+                        if(!match) {
+                            throw new AssertionError("Exception did not contain the expected string: "
+                                    +configuredWithCode.message() + "\nMesssage was:\n" + t.getMessage());
+                        }
+                    }
                 }
             }
         }

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/MissingConfiguratorTest.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/MissingConfiguratorTest.yml
@@ -1,0 +1,11 @@
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+       - id: admin
+         password: ${adminpw:-passw0rd}
+  authorizationStrategy:
+    globalMatrix:
+      grantedPermissions:
+        - "Overall/Administer:authenticated"


### PR DESCRIPTION
Right, after having a couple of talks with collegaues, i think it would make sense to inform the users of possible solutions, if said user forgot to include the support plugin, which is almost required at this point for minimal functionality. 

WDYT? Should we include suggestions in exception to help users? Let me know. Close this if it has no interest.