### PR TITLE
Remove NoExternalUse from YamlUtils

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.casc.yaml;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.model.Mapping;
 import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.accmod.restrictions.Beta;
 import org.yaml.snakeyaml.composer.Composer;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-@Restricted(NoExternalUse.class)
+@Restricted(Beta.class)
 public final class YamlUtils {
 
     public static Node merge(List<YamlSource> configs) throws ConfiguratorException {


### PR DESCRIPTION
I'm trying to use YamlUtils as part of a flow transforming YAML into
Describables, and it's kind of hard when `YamlUtils` is
`Restricted(NoExternalUse.class)`. =)

cc @ndeloof 