### PR TITLE
Explain the need for configuration-as-code-support

### DIFF
--- a/docs/seed-jobs.md
+++ b/docs/seed-jobs.md
@@ -4,6 +4,8 @@ Configuration is not just about setting up jenkins master, it's also about creat
 For this purpose, we delegate to the popular [job-dsl-plugin](https://wiki.jenkins.io/display/JENKINS/Job+DSL+Plugin)
 and run a job-dsl script to create an initial set of jobs.
 
+Be aware that you also need [configuration-as-code-support](https://plugins.jenkins.io/configuration-as-code-support) besides [configuration-as-code](https://plugins.jenkins.io/configuration-as-code) plugin already installed, otherwise the `jobs` root element cannot be parsed.
+
 Typical usage is to rely on a multi-branch, or organization folder job type, so further jobs will be dynamically
 created. So a multi-branch seed job will prepare a master to be fully configured for CI/CD targeting a repository
 or organization.


### PR DESCRIPTION
Without `configuration-as-code-support` installed, the example shown for seeding jobs does not work which might confuse new users.