### PR TITLE
Update in-memory emptyDirVolume key name for kubernetes demo

### DIFF
--- a/demos/kubernetes/README.md
+++ b/demos/kubernetes/README.md
@@ -60,7 +60,7 @@ jenkins:
                 resourceLimitMemory: "2Gi"
             volumes:
               - emptyDirVolume:
-                  inMemory: false
+                  memory: false
                   mountPath: "/tmp"
             idleMinutes: "1"
             activeDeadlineSeconds: "120"

--- a/demos/kubernetes/adv_config.yml
+++ b/demos/kubernetes/adv_config.yml
@@ -40,7 +40,7 @@ data:
                     resourceLimitMemory: "2Gi"
                 volumes:
                   - emptyDirVolume:
-                      inMemory: false
+                      memory: false
                       mountPath: "/tmp"
                 idleMinutes: "1"
                 activeDeadlineSeconds: "120"


### PR DESCRIPTION
It seems that the [Kubernetes plugin](https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes/EmptyDirVolume.java#L45) has changed the key/attribute name for this property and therefore when trying this demo sample, you get an error about it.