### PR TITLE
Update simple-theme-plugin demo to syntax of 0.5 release

### DIFF
--- a/demos/simple-theme-plugin/README.md
+++ b/demos/simple-theme-plugin/README.md
@@ -5,8 +5,13 @@
 ```yaml
 unclassified:
   simple-theme-plugin:
-    cssUrl: "https://cdn.rawgit.com/afonsof/jenkins-material-theme/gh-pages/dist/material-blue.css"
-    cssRules: ""
-    jsUrl: ""
-    faviconUrl: "https://vignette.wikia.nocookie.net/deadpool/images/6/64/Favicon.ico"
+    elements:
+      - cssUrl:
+          url: "https://example.bogus/test.css"
+      - cssText:
+          text: ".testcss { color: red }"
+      - jsUrl:
+          url: "https://example.bogus/test.js"
+      - faviconUrl:
+          url: "https://vignette.wikia.nocookie.net/deadpool/images/6/64/Favicon.ico"
 ```


### PR DESCRIPTION
I did a bit of configuration refactoring before releaseing the simple-theme-plugin 0.5, so the final syntax is a bit different then the initial commit. This now matches my unit test:

- https://github.com/jenkinsci/simple-theme-plugin/blob/master/src/test/resources/org/jenkinsci/plugins/simpletheme/ConfigurationAsCode.yml
- https://github.com/jenkinsci/simple-theme-plugin/blob/master/src/test/java/org/jenkinsci/plugins/simpletheme/ConfigurationAsCodeTest.java
