### PR TITLE
Added scm connection to POM (github link)

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -85,5 +85,10 @@
       </plugin>
     </plugins>
   </build>
-
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/configuration-as-code-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/configuration-as-code-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/configuration-as-code-plugin</url>
+    <tag>${scmTag}</tag>
+  </scm>
 </project>

--- a/support/pom.xml
+++ b/support/pom.xml
@@ -65,5 +65,10 @@
 
     
   </dependencies>
-
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/configuration-as-code-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/configuration-as-code-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/configuration-as-code-plugin</url>
+    <tag>${scmTag}</tag>
+  </scm>
 </project>


### PR DESCRIPTION
Github link points to https://github.com/jenkinsci/configuration-as-code-plugin/configuration-as-code (as far as I know due to global <scm> from /pom.xml). I know it's minor and cosmetic change but will improve "feel"