### PR TITLE
ConfigurationAsCode.getBundledCasCURIs was broken

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -99,7 +99,7 @@ public class ConfigurationAsCode extends ManagementLink {
 
     public static final String CASC_JENKINS_CONFIG_PROPERTY = "casc.jenkins.config";
     public static final String CASC_JENKINS_CONFIG_ENV = "CASC_JENKINS_CONFIG";
-    public static final String DEFAULT_JENKINS_YAML_PATH = Jenkins.getInstance().getRootDir() + "/jenkins.yaml";
+    public static final String DEFAULT_JENKINS_YAML_PATH = "jenkins.yaml";
     public static final String YAML_FILES_PATTERN = "glob:**.{yml,yaml,YAML,YML}";
 
     public static final Logger LOGGER = Logger.getLogger(ConfigurationAsCode.class.getName());
@@ -301,8 +301,9 @@ public class ConfigurationAsCode extends ManagementLink {
         }
 
         if (configParameter == null) {
-            if (Files.exists(Paths.get(DEFAULT_JENKINS_YAML_PATH))) {
-                configParameter = DEFAULT_JENKINS_YAML_PATH;
+            String fullPath = Jenkins.getInstance().getRootDir() + File.separator + DEFAULT_JENKINS_YAML_PATH;
+            if (Files.exists(Paths.get(fullPath))) {
+                configParameter = fullPath;
             }
         }
 


### PR DESCRIPTION
@oleg-nenashev’s feature in #250 seems to have been broken by @ndeloof’s change in #435. Observed by using CWP (1.2) to build a Docker image with a `casc` section—it is ignored by CaC (1.0-rc3), despite CWP apparently doing the right thing:

```
$ zipinfo /usr/share/jenkins/jenkins.war | fgrep yaml
drwxrwxr-x  2.0 unx        0 b- stor 18-Sep-11 17:03 WEB-INF/jenkins.yaml.d/
-rw-rw-r--  2.0 unx      209 bl defN 18-Sep-11 17:03 WEB-INF/jenkins.yaml.d/casc.yaml
```