### PR TITLE
Updated pom with searchable name

### DIFF
--- a/support/pom.xml
+++ b/support/pom.xml
@@ -10,7 +10,8 @@
 
   <artifactId>configuration-as-code-support</artifactId>
   <packaging>hpi</packaging>
-  <description>Custom configurator to support third-party plugins</description>
+  <description>Custom configurator to support third-party plugins for the Configuration as Code plugin</description>
+  <name>Configuration as Code Support Plugin</name>
   <!-- This is an incubator for code we expect to get hosted by target plugins -->
 
   <properties>


### PR DESCRIPTION
Right, i've done this because a colleague had issues finding the support plugin. And rightly so, the name is not really seachable, you have to search for `configuration-as-code` and not `configuration as code`. I've created this PR to solve that issue. 

Also updated description for the plugin. 