### PR TITLE
Filter nodes so we don't export cloud ones

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -57,6 +58,14 @@ public class Attribute<Owner, Type> {
         this.setter = this::_setValue;
         this.aliases = new ArrayList<>();
         this.aliases.add(name);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <O,T> Optional<Attribute<O,T>> get(Set<Attribute<O,?>> attributes, String name) {
+        return attributes.stream()
+                .filter(a -> a.name.equals(name))
+                .map(a -> (Attribute<O,T>) a)
+                .findFirst();
     }
 
     @Override


### PR DESCRIPTION
Based on [@jglick suggestion's](https://github.com/jenkinsci/configuration-as-code-plugin/pull/512#issuecomment-421140656)
Tested on top of https://github.com/jenkinsci/mock-slave-plugin/pull/10
Also close https://github.com/jenkinsci/configuration-as-code-plugin/issues/465
