### PR TITLE
Updates docs / fixes consistency after release of 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ jenkins:
     (...)
 
   nodes:
-    slave:
-      name: "static-slave"
-      remoteFS: "/home/jenkins"
-      launcher: "jnlp"
+    - permanent:
+        name: "static-slave"
+        remoteFS: "/home/jenkins"
+        launcher:
+          jnlp:
 
   slaveAgentPort: 50000
   agentProtocols:
@@ -116,7 +117,8 @@ unclassified:
   mailer:
     adminAddress: admin@acme.org
     replyToAddress: do-not-reply@acme.org
-    smtpHost: smtp.acme.org
+    # Note that this does not work right now
+    #smtpHost: smtp.acme.org
     smtpPort: 4441
 credentials:
   system:

--- a/demos/build_agents/README.md
+++ b/demos/build_agents/README.md
@@ -8,17 +8,18 @@ Build agents configuration belongs (currently) under `jenkins` root element
 jenkins:
   (...)
   nodes:
-    - dumb:
+    - permanent:
         labelString: "linux docker test"
         mode: NORMAL
         name: "utility-node"
         remoteFS: "/home/user1"
         launcher:
           jnlp:
-    - dumb:
+    - permanent:
         labelString: "linux docker test"
         mode: NORMAL
         name: "utility-node-2"
+        numExecutors: 4
         remoteFS: "/home/user2"
         launcher:
           SSHLauncher:

--- a/demos/jenkins/jenkins.yaml
+++ b/demos/jenkins/jenkins.yaml
@@ -80,5 +80,6 @@ unclassified:
   mailer:
     adminAddress: admin@acme.org
     replyToAddress: do-not-reply@acme.org
-    smtpHost: smtp.acme.org
+    # Note that this does not work right now
+    #smtpHost: smtp.acme.org
     smtpPort: 4441

--- a/demos/kubernetes-helm/README.md
+++ b/demos/kubernetes-helm/README.md
@@ -5,16 +5,6 @@
 Jenkins can be installed in Kubernetes using [`helm`](https://github.com/helm/helm).
 The latest stable helm chart can be found [`here`](https://github.com/helm/charts/tree/master/stable/jenkins).
 
-To have the latest Version of JCASC installed we need to enable Jenkins to make use of the [`Experimental Update Center`](https://jenkins.io/doc/developer/publishing/releasing-experimental-updates/).
-
-The [`Official Jenkins Docker image`](https://github.com/jenkinsci/docker/blob/master/Dockerfile#L60) allows you to specify the experimental update center configuration using ENV variables:  
-
-```
-ENV JENKINS_UC https://updates.jenkins.io
-ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
-ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
-```
-
 Now grab a copy of the helm chart [`values file`](https://github.com/helm/charts/blob/master/stable/jenkins/values.yaml) and adjust the Master part a little bit:
 
 ```yaml
@@ -31,20 +21,8 @@ Master:
   Memory: "1024Mi"
 
   InitContainerEnv:
-    - name: JENKINS_UC
-      value: https://updates.jenkins.io
-    - name: JENKINS_UC_EXPERIMENTAL
-      value: https://updates.jenkins.io/experimental
-    - name: JENKINS_INCREMENTALS_REPO_MIRROR
-      value: https://repo.jenkins-ci.org/incrementals
 
   ContainerEnv:
-    - name: JENKINS_UC
-      value: https://updates.jenkins.io
-    - name: JENKINS_UC_EXPERIMENTAL
-      value: https://updates.jenkins.io/experimental
-    - name: JENKINS_INCREMENTALS_REPO_MIRROR
-      value: https://repo.jenkins-ci.org/incrementals
     # Tell the plugin where to find its config. The '..data'
     # part is needed for now due to this bug:
     # https://github.com/jenkinsci/configuration-as-code-plugin/issues/425
@@ -60,7 +38,9 @@ Master:
     - workflow-job:latest
     - credentials-binding:latest
     - git:latest
-    - configuration-as-code:0.11-alpha
+    - configuration-as-code:1.0
+    # You might also need this for a couple of third-party plugins (e.g. for setting credentials)
+    - configuration-as-code-support:1.0
 
 Persistence:
   volumes:

--- a/demos/kubernetes-helm/values.yml
+++ b/demos/kubernetes-helm/values.yml
@@ -14,33 +14,8 @@ Master:
   AdminPassword: "formetoknowforyoutofindout"
   Cpu: "200m"
   Memory: "1024Mi"
-  # These are the necesarry environment variables to enable the experimental update center
   ContainerEnv:
-    - name: JENKINS_UC
-      value: https://updates.jenkins.io
-    - name: JENKINS_UC_EXPERIMENTAL
-      value: https://updates.jenkins.io/experimental
-    - name: JENKINS_INCREMENTALS_REPO_MIRROR
-      value: https://repo.jenkins-ci.org/incrementals
-  # These are the necesarry environment variables to enable the experimental update center    
   InitContainerEnv:
-    - name: JENKINS_UC
-      value: https://updates.jenkins.io
-    - name: JENKINS_UC_EXPERIMENTAL
-      value: https://updates.jenkins.io/experimental
-    - name: JENKINS_INCREMENTALS_REPO_MIRROR
-      value: https://repo.jenkins-ci.org/incrementals
-
-  # List of plugins to be install during Jenkins master start
-  # mind the last plugin in the list now ;)
-  InstallPlugins:
-      - kubernetes:latest
-      - kubernetes-credentials:latest
-      - workflow-aggregator:latest
-      - workflow-job:latest
-      - credentials-binding:latest
-      - git:latest
-      - configuration-as-code:0.10-alpha
 
 # Set min/max heap here if needed with:
 # JavaOpts: "-Xms512m -Xmx512m"
@@ -52,6 +27,7 @@ Master:
 #   -Dcom.sun.management.jmxremote.ssl=false
 # JMXPort: 4000
 # List of plugins to be install during Jenkins master start
+# mind the last plugin in the list now ;)
   InstallPlugins:
       - kubernetes:latest
       - kubernetes-credentials:latest
@@ -59,7 +35,9 @@ Master:
       - workflow-job:latest
       - credentials-binding:latest
       - git:latest
-      - configuration-as-code:0.10-alpha
+      - configuration-as-code:1.0
+      # You might also need this for a couple of third-party plugins (e.g. for setting credentials)
+      - configuration-as-code-support:1.0
 
       # - saml:1.0.5
       # - docker-custom-build-environment:latest

--- a/demos/mailer/README.md
+++ b/demos/mailer/README.md
@@ -11,7 +11,8 @@ unclassified:
   mailer:
     adminAddress: admin@acme.org
     replyToAddress: do-not-reply@acme.org
-    smtpHost: smtp.acme.org
+    # Note that this does not work right now
+    #smtpHost: smtp.acme.org
     smtpPort: 4441
     charset: UTF-8
     useSsl: false


### PR DESCRIPTION
I just set up a Jenkins instance using the helm chart and CASC 1.0.

Great plugin!

This PR just cuts of some rough edges in the docs that slowed me down on my way to a running Jenkins with CASC.

*  Plugin version: 1.0
* Jenkins version: 2.141
* Operating system: Official docker container, using helm chart on kubernetes.
