### PR TITLE
[JENKINS-53687] Raising the timeout to 3 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, "2.107.1"])
+buildPlugin(jenkinsVersions: [null, "2.107.1"], timeout: 180)


### PR DESCRIPTION
* So I got approval from @ewelinawilkosz on gitter to get committer access on JCasC so that my change here in Jenkinsfile is actually used (and not the Jenkinsfile from the `master` branch like it would be if I do not have commit access.
* Will need https://github.com/jenkins-infra/pipeline-library/pull/74 be merged to actually be used

[JENKINS-53687](https://issues.jenkins-ci.org/browse/JENKINS-53687)

Mostly aiming at debugging here. I would like to understand/see if the build is really fully stuck forever, or just crazy slow sometimes, hence reaching the 1 hour timeout.
