### PR TITLE
Fix description typo

### DIFF
--- a/plugin/src/main/resources/index.jelly
+++ b/plugin/src/main/resources/index.jelly
@@ -3,5 +3,5 @@
   This view is used to render the installed plugins page.
 -->
 <div>
-  This plugin allows to to configure jenkins based on human-readable declarative configuration files.
+  This plugin allows configuration of Jenkins based on human-readable declarative configuration files.
 </div>


### PR DESCRIPTION
After installing the plugin, the description shown on the page
http://<jenkinsurl>/pluginManager/installed
had a small typo with two times "to".

Rephrased the description a bit.

# Please provide a link to issue you're working on if there's a relevant one
# Please also consider adding a line to CHANGELOG.md 
