### PR TITLE
Fix #551: Document credentials in global pipeline libraries

### DIFF
--- a/demos/workflow-cps-global-lib/README.md
+++ b/demos/workflow-cps-global-lib/README.md
@@ -1,11 +1,11 @@
-# configure global libraries plugin
+# Configure global libraries plugin
 
 Global Pipeline Libraries plugin configuration belongs under `unclassified` root element
 
-## sample configuration
+## Sample configuration
 
 ```yaml
-jenkins: 
+jenkins:
   [...]
 unclassified:
   globalLibraries:
@@ -16,4 +16,21 @@ unclassified:
             scm:
               git:
                 remote: "https://github.com/jenkins-infra/pipeline-library.git"
+```
+
+## Using credentials
+
+```yaml
+jenkins:
+  [...]
+unclassified:
+  globalLibraries:
+    libraries:
+      - name: 'internal-pipeline-library'
+        retriever:
+          modernSCM:
+            scm:
+              git:
+                remote: 'git@github.com:furry-octo-lamp-inc/pipeline-library.git'
+                credentialsId: 'reimagined-parakeet-ssh'
 ```


### PR DESCRIPTION
Give an example of how to provide credentials when using a global
pipeline library in a private repository.

