### PR TITLE
SECURITY-1124

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/SystemCredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SystemCredentialsTest.java
@@ -59,7 +59,7 @@ public class SystemCredentialsTest {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         final ConfigurationContext context = new ConfigurationContext(registry);
         final CNode node = context.lookup(up.getClass()).describe(up, context);
-        assertEquals("1234", node.asMapping().getScalarValue("password"));
+        assertThat(node.asMapping().getScalarValue("password"), not(equals("1234")));
 
 
         List<CertificateCredentials> certs = CredentialsProvider.lookupCredentials(

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import hudson.Functions;
+import hudson.util.Secret;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Scalar;
 import io.jenkins.plugins.casc.model.Sequence;
@@ -167,6 +168,7 @@ public class Attribute<Owner, Type> {
 
 
     public void setValue(Owner target, Type value) throws Exception {
+        logger.info("Setting " + target + '.' + name + " = " + (getType() == Secret.class ? "****" : value));
         setter.setValue(target, value);
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.casc;
 import hudson.model.Describable;
 import hudson.model.Saveable;
 import hudson.util.PersistedList;
-import hudson.util.ReflectionUtils;
 import io.jenkins.plugins.casc.impl.attributes.DescribableAttribute;
 import io.jenkins.plugins.casc.impl.attributes.PersistedListAttribute;
 import io.jenkins.plugins.casc.model.CNode;
@@ -333,7 +332,6 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
 
                 if (!dryrun) {
                     try {
-                        logger.info("Setting " + instance + '.' + name + " = " + (sub.isSensitiveData() ? "****" : valueToSet));
                         ((Attribute) attribute).setValue(instance, valueToSet); // require type erasure to set Object vs ?
                     } catch (Exception ex) {
                         throw new ConfiguratorException(configurator, "Failed to set attribute " + attribute, ex);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/PrimitiveConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/PrimitiveConfigurator.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.casc.impl.configurators;
 
+import hudson.util.Secret;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.Configurator;
@@ -89,6 +90,9 @@ public class PrimitiveConfigurator implements Configurator {
         }
         if (instance instanceof Boolean) {
             return new Scalar((Boolean) instance);
+        }
+        if (instance instanceof Secret) {
+            return new Scalar(((Secret) instance).getEncryptedValue());
         }
         if (target.isEnum()) {
             return new Scalar((Enum) instance);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/CNode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/CNode.java
@@ -28,6 +28,8 @@ public interface CNode extends Cloneable {
         throw new ConfiguratorException("Item isn't a Scalar");
     }
 
+    /** @deprecated sensitive data are identified based on target attribute being a ${@link hudson.util.Secret} */
+    @Deprecated
     default boolean isSensitiveData() { return false; }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -70,10 +70,6 @@ public final class Scalar implements CNode, CharSequence {
         return value;
     }
 
-    public boolean isSensitiveData() {
-        return SecretSource.requiresReveal(value).isPresent();
-    }
-
     @Override
     public String toString() {
         return value;


### PR DESCRIPTION
avoid exposure of secret data in logs or export
as discussed with Security team, relies on `hudson.util.Secret` as a marker to identify sensitive data.