### PR TITLE
Credentials are reset after CasC is reloaded

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
@@ -1,21 +1,28 @@
 package io.jenkins.plugins.casc;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
-import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
+import javax.annotation.CheckForNull;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class CredentialsTest {
@@ -39,6 +46,33 @@ public class CredentialsTest {
         assertEquals("ssh private key used to connect ssh slaves", creds2.get(0).getDescription());
     }
 
+    @ConfiguredWithCode("GlobalCredentials.yml")
+    @Test
+    public void testGlobalScopedCredentialsAndManualCredentialsAfterReconfig() throws Throwable {
+        // Configuration has been done
+
+        // Let's register manual credentials
+        String credentialsId = UUID.randomUUID().toString();
+        Credentials newCreds = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                credentialsId,
+                "description,",
+                "user",
+                "password"
+        );
+        SystemCredentialsProvider.getInstance().getDomainCredentialsMap().get(Domain.global()).add(newCreds);
+
+        // Checks they are correctly referenced
+        StandardUsernamePasswordCredentials foundCreds = getCredentialsById(credentialsId);
+        assertNotNull("Credentials are correctly referenced", foundCreds);
+
+        // Let's relaunch the config-as-code
+        j.before();
+
+        // Check the manual credentials are still there
+        foundCreds = getCredentialsById(credentialsId);
+        assertNotNull("Credentials are still there", foundCreds);
+    }
 
     @ConfiguredWithCode("CredentialsWithDomain.yml")
     @Test
@@ -48,6 +82,24 @@ public class CredentialsTest {
         assertEquals("user1", creds.get(0).getId());
         assertEquals("Administrator", creds.get(0).getUsername());
         assertEquals("secret", creds.get(0).getPassword().getPlainText());
+    }
+
+    @CheckForNull
+    private StandardUsernamePasswordCredentials getCredentialsById(String credentialsId) {
+        List<StandardUsernamePasswordCredentials> credList = CredentialsProvider.lookupCredentials(
+                StandardUsernamePasswordCredentials.class,
+                Jenkins.getInstanceOrNull(),
+                null,
+                Collections.emptyList()
+        );
+        StandardUsernamePasswordCredentials foundCreds = null;
+        for (StandardUsernamePasswordCredentials credentials : credList) {
+            if (StringUtils.equals(credentialsId, credentials.getId())) {
+                foundCreds = credentials;
+                break;
+            }
+        }
+        return foundCreds;
     }
 
 }


### PR DESCRIPTION
This PR shows that there is an issue with the credentials entries when reloading the configuration as code.

Scenario:

1. in Jenkins 2.121.3 and CasC 1.0
2. some credentials are generated by the CasC files
3. in the resulting instance, we manually add some credential entries
4. we restart Jenkins and/or reload the CasC

Expected result:

* the manually created credential entries are still there

Actual result:

* the manually created credential entries are done

I'm not sure how this issue could be tackled and I'm seeking for help.