### PR TITLE
Remove duplicate "Reload" button

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -22,10 +22,6 @@
 
         <p>${%Last time applied :}<i:formatDate value="${it.lastTimeLoaded}" type="both" dateStyle="medium" timeStyle="long"/></p>
 
-        <f:form method="post" action="reload" name="reload">
-          <f:submit name="reload" value="${%Reload}"/>
-        </f:form>
-
       </j:otherwise>
     </j:choose>
 


### PR DESCRIPTION
The legacy "Reload" buttton has been kept whereas a new "Reload existing configuration" has been put into the action section.
Both are linked to the same action.
This PR simply removes the first button.
