### PR TITLE
Fix #561: Document Artifactory deployer credentials

### DIFF
--- a/demos/artifactory/README.md
+++ b/demos/artifactory/README.md
@@ -5,7 +5,7 @@ Artifactory plugin configuration belongs under `unclassified` root element
 ## sample configuration
 
 ```yaml
-jenkins: 
+jenkins:
   [...]
 unclassified:
   [...]
@@ -14,6 +14,8 @@ unclassified:
     artifactoryServers:
       - serverId: artifactory
         artifactoryUrl: http://acme.com/artifactory
+        deployerCredentialsConfig:
+          credentialsId: 'artifactory'
         resolverCredentialsConfig:
           username: artifactory_user
           password: ${ARTIFACTORY_PASSWORD}


### PR DESCRIPTION
Updated the demo for Artifactory to include deployer credentials as well
as referring to a credentials ID.

I saw the implementation note, but it works for me on Jenkins 2.138.1.
