### PR TITLE
exclude descriptors which have nothing to configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [SECURITY-929] Don't dump sensitive data in logs when configuring value
 - use BulkChange to avoid repeated calls to save()
 - list available attributes when unknown found in yaml to help diagnose mistakes
+- log a warning when descriptor with unexpected design is detected
 
 ## 1.1
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -352,7 +352,7 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
         if (!config.isEmpty()) {
             final String invalid = StringUtils.join(config.keySet(), ',');
             final String message = "Invalid configuration elements for type " + getTarget() + " : " + invalid + ".\n"
-                    + "Available attributes : " + StringUtils.join(getAttributes().stream().map(Attribute::getName).collect(Collectors.toList()), ',');
+                    + "Available attributes : " + StringUtils.join(getAttributes().stream().map(Attribute::getName).collect(Collectors.toList()), ", ");
             context.warning(config, message);
             switch (context.getUnknown()) {
                 case reject:

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
@@ -4,6 +4,7 @@ import hudson.model.Descriptor;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.BaseConfigurator;
 import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.Configurator;
 import io.jenkins.plugins.casc.RootElementConfigurator;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
@@ -19,6 +20,7 @@ import javax.annotation.CheckForNull;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -72,8 +74,17 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
                 .filter(d -> d.getCategory() == category)
                 .filter(d -> d.getGlobalConfigPage() != null)
                 .map(d -> new DescriptorConfigurator(d))
+                .filter(GlobalConfigurationCategoryConfigurator::reportDescriptorWithoutSetters)
                 .map(c -> new Attribute<GlobalConfigurationCategory, Object>(c.getName(), c.getTarget()).setter(NOP))
                 .collect(Collectors.toSet());
+    }
+
+    public static boolean reportDescriptorWithoutSetters(Configurator c) {
+        if (c.describe().isEmpty()) {
+            logger.warning(c.getTarget().getName() +
+                    " has a global view but CasC didn't detected any configurable attribute; see: https://jenkins.io/redirect/casc-requirements/");
+        }
+        return true;
     }
 
     @CheckForNull


### PR DESCRIPTION
warning in logs might help end-user report issues to relevant plugins with guidance on our expectations. But I wonder this is a bit too rude against jenkins codebase. Especially jenkins-core has few descriptors to have such design issue, because they are actually delegates for attributes stored in `Jenkins`  class:

  - [ ]  jenkins.model.MasterBuildConfiguration (Jenkins#numExecutors, Jenkins#labelString)
  - [ ]  jenkins.model.GlobalQuietPeriodConfiguration (Jenkins#quietPeriod)
  - [ ]  jenkins.model.GlobalSCMRetryCountConfiguration (Jenkins#scmCheckoutRetryCount)
  - [ ]  hudson.views.ViewsTabBar$GlobalConfigurationImpl (Jenkins#viewsTabBar)
  - [ ]  hudson.views.MyViewsTabBar$GlobalConfigurationImpl (Jenkins#myViewsTabBar)
  - [ ]  hudson.views.GlobalDefaultViewConfiguration (Jenkins#primaryView)
  - [ ]  jenkins.model.GlobalProjectNamingStrategyConfiguration (Jenkins#projectNamingStrategy)
  - [ ]  jenkins.model.GlobalNodePropertiesConfiguration (Jenkins#globalNodeProperties)
  - [ ]  jenkins.model.GlobalPluginConfiguration => pluginManager
  - [ ]  jenkins.management.AdministrativeMonitorsConfiguration => AdministrativeMonitor disable
  - [ ]  hudson.model.UsageStatistics (Jenkins#noUsageStatistics)
  - [ ]  jenkins.model.GlobalCloudConfiguration (Jenkins#clouds)
 
Maybe it would make more sense to find a proper way for those to declare they act as delegates, so we can discover it. 
