### PR TITLE
Rename reload command #592

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/cli/ReloadJCascConfigurationCommand.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/cli/ReloadJCascConfigurationCommand.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
  */
 @Extension
 @Restricted(NoExternalUse.class)
-public class ReloadConfigurationCommand extends CLICommand {
+public class ReloadJCascConfigurationCommand extends CLICommand {
 
     @Override
     public String getShortDescription() {


### PR DESCRIPTION
Refactor name of jenkins cli reload command.

Casing of class name is chosen to have Jenkins autogenerate proper hyphenation of name in cli overview.

Signed-off-by: Johan Abildskov <randomsort@gmail.com>

## Please provide a link to issue you're working on if there's a relevant one
## Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/README.md)
