### PR TITLE
More descriptive output in YamlSource related errors

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlSource.java
@@ -43,7 +43,6 @@ public class YamlSource<T> {
         return source.toString();
     }
 
-
     public static final YamlReader<String> READ_FROM_URL = config -> {
         final URL url = URI.create(config).toURL();
         return new InputStreamReader(url.openStream(), UTF_8);
@@ -58,4 +57,8 @@ public class YamlSource<T> {
         return new InputStreamReader(req.getInputStream(), UTF_8);
     };
 
+    @Override
+    public String toString() {
+        return "YamlSource: " + source;
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlSourceTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlSourceTest.java
@@ -1,0 +1,34 @@
+package io.jenkins.plugins.casc.yaml;
+
+import java.io.InputStream;
+import java.io.StringBufferInputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class YamlSourceTest {
+
+    @Test
+    public void shouldHaveInformativeToStringForUrlSource() throws MalformedURLException {
+        //given
+        String testUrl = "http://example.com/foo/bar";
+        //and
+        YamlSource<String> yamlSource = YamlSource.of(new URL(testUrl));
+        //expect
+        assertEquals("YamlSource: " + testUrl, yamlSource.toString());
+    }
+
+    @Test
+    public void shouldUseToStringOfSourceInToStringForInputStream() {
+        //given
+        StringBufferInputStream testInputStream = new StringBufferInputStream("IS content");
+        String testInputStreamToString = testInputStream.toString();
+        //and
+        YamlSource<InputStream> yamlSource = YamlSource.of(testInputStream);
+        //expect
+        assertEquals("YamlSource: " + testInputStreamToString, yamlSource.toString());
+    }
+}


### PR DESCRIPTION
Previously the errors were hard to diagnose:
ConfiguratorException: Failed to read io.jenkins.plugins.casc.yaml.YamlSource@5730c6
...
NoRouteToHostException: No route to host (Host unreachable)

With this change applied it's clearly visible what URL caused a problem.
It should work for every source that has sensible toString()
implementation.

## Please provide a link to issue you're working on if there's a relevant one
## Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/README.md)
