### PR TITLE
simple issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+**Never report security issues in github, follow the instruction from [Jenkins Security](https://jenkins.io/security/) to report it on [Jenkins Jira](https://issues.jenkins-ci.org)**
+
+Please make sure to provide following information in your issue description
+
+- [ ] Jenkins version
+- [ ] Plugin version
+- [ ] OS
+


### PR DESCRIPTION
I know we have a contribution guide but I know it's easy to skip reading that one when creating issue, for whatever reason. 
What do you think about introducing that template? as simple as possible, non-agressive I hope