### PR TITLE
add terraform demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix regression configuring ssh private key from a secret source
 - CLI command renamed as "reload-jcasc-configuration" to avoid conflict with core CLI
+- add terraform demo
 
 ## 1.2
 

--- a/demos/terraform/README.md
+++ b/demos/terraform/README.md
@@ -1,0 +1,13 @@
+# example of how to configure terraform plugin 
+
+to test it from root of the current repository:
+```
+export CASC_JENKINS_CONFIG=$(PWD)/demos/terraform/jenkins.yaml
+mvn hpi:run
+```
+
+You need to install the following plugins to make it work (you can do it before using the export):
+- job DSL
+- job configuration-as-code support
+- SSH credentials
+- job configuration-as-code 

--- a/demos/terraform/jenkins.yaml
+++ b/demos/terraform/jenkins.yaml
@@ -1,0 +1,36 @@
+jenkins:
+  systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code Plugin\n\n"
+
+tool:
+  terraforminstallation:
+    installations:
+      - name: terraform
+        home: ""
+        properties:
+          - installSource:
+              installers:
+                - terraformInstaller:
+                    id: '0.11.9-linux-amd64'
+
+jobs:
+  - script: >
+      job("terraform-job") {
+        description()
+        keepDependencies(false)
+        disabled(false)
+        concurrentBuild(false)
+        wrappers {
+           terraformBuildWrapper {
+              variables("") 
+              terraformInstallation("terraform")
+              doGetUpdate(true)
+              doNotApply(false)
+              doDestroy(false)
+              config {
+                 value("inline")
+                 inlineConfig("")
+                 fileConfig("")
+              }
+           }
+        }
+      }


### PR DESCRIPTION
## Please provide a link to issue you're working on if there's a relevant one
## Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)

Version of at least Jenkins 2.73 is needed to run Job DSL plugin that's why the pom.xml would need to be updated.