### PR TITLE
catch illegal arg exception when using ui form

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -219,6 +219,8 @@ public class ConfigurationAsCode extends ManagementLink {
             return FormValidation.okWithMarkup("The configuration can be applied");
         } catch (ConfiguratorException e) {
             return FormValidation.error(e, e.getCause().getMessage());
+        } catch (IllegalArgumentException e) {
+            return FormValidation.error(e, e.getCause().getMessage());
         }
     }
 


### PR DESCRIPTION
what was originally attempted in https://github.com/jenkinsci/configuration-as-code-plugin/pull/612
this keeps the UI form _(/configuration-as-code)_, still functioning when submitting an invalid
