### PR TITLE
update site need to be fully populated for us to install plugins

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -117,7 +117,11 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
             for (CNode data : sites.asSequence()) {
                 UpdateSite in = usc.configure(data, context);
                 if (in.isDue()) {
-                    in.updateDirectly(DownloadService.signatureCheck);
+                    try {
+                        in.updateDirectlyNow(DownloadService.signatureCheck);
+                    } catch (IOException e) {
+                        throw new ConfiguratorException("failed to download metadata for update site " + in.getId(), e);
+                    }
                 }
                 updateSites.add(in);
             }


### PR DESCRIPTION
## Please describe what you did

As we install plugins, we need sites to have valid metadata so we look for plugins. `updateNow` runs asynchronously so we might end searching for plugin on an empty update site.

## We also welcome you to share a picture of a funny animal (not mandatory but encouraged)

![banana-with-funny-duck-face](https://user-images.githubusercontent.com/132757/47798167-1a089300-dd28-11e8-8853-bc835ed4605e.jpg)
