### PR TITLE
Do'nt recurse in subdirectories searching for yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix regression configuring ssh private key from a secret source
 - CLI command renamed as "reload-jcasc-configuration" to avoid conflict with core CLI
+- restore support for k8s ConfigMaps mounts (don't recurse in CASC_JENKINS_CONFIG directory)
 
 ## 1.2
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
@@ -27,25 +28,36 @@ public class ConfigurationAsCodeTest {
     public void init_test_from_accepted_sources() throws Exception {
         ConfigurationAsCode casc = new ConfigurationAsCode();
 
-        File exactFile = tempFolder.newFile("jenkins_tmp.yaml");
-        File file = tempFolder.newFile("jenkins_tmp2.yaml");
-        FileUtils.writeStringToFile(file, "test");
+        File exactFile = tempFolder.newFile("jenkins_1.yaml"); // expected
 
-        tempFolder.newFile("jenkins_tmp3.YAML");
-        tempFolder.newFile("jenkins_tmp4.YML");
-        tempFolder.newFile("jenkins_tmp5.yml");
-        tempFolder.newFolder("jenkins_folder.yml");
+        tempFolder.newFile("jenkins_2.YAML"); // expected, alternate extension
+        tempFolder.newFile("jenkins_3.YML");  // expected, alternate extension
+        tempFolder.newFile("jenkins_4.yml"); // expected, alternate extension
 
         // should be picked up
-        Path target = Paths.get("jenkins_tmp2.yaml");
-        Path newLink = Paths.get(tempFolder.getRoot().getAbsolutePath(), "symbolic_link_to_tmp2.yaml");
+        Path target = Paths.get("jenkins.tmp");
+        Path newLink = Paths.get(tempFolder.getRoot().getAbsolutePath(), "jenkins_5.yaml");
         Files.createSymbolicLink(newLink, target);
 
-        // should not be picked up
-        tempFolder.newFolder("jenkins_folder2.yaml");
+        // should *NOT* be picked up
+        tempFolder.newFolder("folder.yaml");
+
+        // Replicate a k8s ConfigMap mount :
+        // lrwxrwxrwx    1 root     root          19 Oct 15 16:43 jenkins_6.yaml -> ..data/jenkins_6.yaml
+        // lrwxrwxrwx    1 root     root          31 Oct 29 16:29 ..data -> ..2018_10_29_16_29_08.094515936
+        // drwxr-xr-x    2 root     root        4.0K Oct 29 16:29 ..2018_10_29_16_29_08.094515936
+
+        final File timestamp = tempFolder.newFolder("..2018_10_29_16_29_08.094515936");
+        new File(timestamp, "jenkins_6.yaml").createNewFile();
+        final Path data = Paths.get(tempFolder.getRoot().getAbsolutePath(), "..data");
+        Files.createSymbolicLink(data, timestamp.toPath());
+        Files.createSymbolicLink(Paths.get(tempFolder.getRoot().getAbsolutePath(), "jenkins_6.yaml"),
+                                 data.resolve("jenkins_6.yaml"));
+        
 
         assertThat(casc.configs(exactFile.getAbsolutePath()), hasSize(1));
-        assertThat(casc.configs(tempFolder.getRoot().getAbsolutePath()), hasSize(6));
+        final List<Path> foo = casc.configs(tempFolder.getRoot().getAbsolutePath());
+        assertThat(foo, hasSize(5));
     }
 
     @Test(expected = ConfiguratorException.class)


### PR DESCRIPTION
## Please describe what you did

Removes recursion in `CASC_JENKINS_CONFIG` folder which make k8s configmap support mostly impossible.

## Please provide a link to issue you're working on if there's a relevant one

https://github.com/jenkinsci/configuration-as-code-plugin/issues/626

## Do you provide a test-case to demonstrate feature actually works / issue is fixed ?

Added an explicit test for this specific usage.

## Please also consider adding a line to [CHANGELOG.md]

done

## We also welcome you to share a picture of a funny animal (not mandatory but encouraged)

![9dfff9c83f86fad0a1345ae239e9bb88](https://user-images.githubusercontent.com/132757/47803484-e5e69f80-dd32-11e8-8dde-499ded1fca98.jpg)

