### PR TITLE
Add support for Vault AppRole authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## 1.4 (not released yet)
+- Add support for Vault appRole authentication method
 
 ## 1.3
 

--- a/README.md
+++ b/README.md
@@ -232,8 +232,10 @@ can be used as:
 
 Prerequisites:
 
-- The environment variable `CASC_VAULT_PW` must be present, if token is not used. (Vault password.)
-- The environment variable `CASC_VAULT_USER` must be present, if token is not used. (Vault username.)
+- The environment variable `CASC_VAULT_PW` must be present, if token is not used and appRole/Secret is not used. (Vault password.)
+- The environment variable `CASC_VAULT_USER` must be present, if token is not used and appRole/Secret is not used. (Vault username.)
+- The environment variable `CASC_VAULT_APPROLE` must be present, if token is not used and U/P not used. (Vault AppRole ID.)
+- The environment variable `CASC_VAULT_APPROLE_SECRET` must be present, it token is not used and U/P not used. (Value AppRole Secret ID.)
 - The environment variable `CASC_VAULT_TOKEN` must be present, if U/P is not used. (Vault token.)
 - The environment variable `CASC_VAULT_PATH` must be present. (Vault key path. For example, `/secrets/jenkins`.)
 - The environment variable `CASC_VAULT_URL` must be present. (Vault url, including port number.)

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -47,8 +47,12 @@ public class VaultSecretSource extends SecretSource {
         String vaultUrl = getVariable("CASC_VAULT_URL", prop);
         String vaultMount = getVariable("CASC_VAULT_MOUNT", prop);
         String vaultToken = getVariable("CASC_VAULT_TOKEN", prop);
+        String vaultAppRole = getVariable("CASC_VAULT_APPROLE", prop);
+        String vaultAppRoleSecret = getVariable("CASC_VAULT_APPROLE_SECRET", prop);
 
-        if(((vaultPw != null && vaultUsr != null) || vaultToken != null) && vaultPth != null && vaultUrl != null) {
+        if(((vaultPw != null && vaultUsr != null) || 
+            vaultToken != null || 
+            (vaultAppRole != null && vaultAppRoleSecret != null)) && vaultPth != null && vaultUrl != null) {
             LOGGER.log(Level.FINE, "Attempting to connect to Vault: {0}", vaultUrl);
             try {
                 VaultConfig config = new VaultConfig().address(vaultUrl).build();
@@ -58,6 +62,9 @@ public class VaultSecretSource extends SecretSource {
                 if (vaultToken != null) {
                     token = vaultToken;
                     LOGGER.log(Level.FINE, "Using supplied token to access Vault");
+                } else if (vaultAppRole != null && vaultAppRoleSecret != null) {
+                    token = vault.auth().loginByAppRole(vaultAppRole, vaultAppRoleSecret).getAuthClientToken();
+                    LOGGER.log(Level.FINE, "Login to Vault using AppRole/SecretID successful");
                 } else {
                     token = vault.auth().loginByUserPass(vaultUsr, vaultPw, vaultMount).getAuthClientToken();
                     LOGGER.log(Level.FINE, "Login to Vault using U/P successful");


### PR DESCRIPTION
This PR fixes #632, adding support for Vault AppRole authentication instead of having to pass a token or user/password parameters.

I've not had the opportunity to try compiling or testing these changes as I don't currently have a working java development environment. 

@ndeloof, @ewelinawilkosz please can you review these changes ? Do you have a CI process that will compile PRs or do I need to try and get my dev environment working before you accept this PR ?