### PR TITLE
cleanup introspection logic to determine multi-value attribute type

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/DockerCloudTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/DockerCloudTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc;
 
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
+import com.nirima.jenkins.plugins.docker.strategy.DockerOnceRetentionStrategy;
 import hudson.model.Label;
 import io.jenkins.docker.connector.DockerComputerAttachConnector;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -30,6 +31,8 @@ public class DockerCloudTest {
         final DockerTemplate template = docker.getTemplate("jenkins/slave");
         checkTemplate(template, "docker-agent", "jenkins", "/home/jenkins/agent", "10",
                 new String[] { "hello:/hello", "world:/world"}, "hello=world\nfoo=bar");
+        assertTrue(template.getRetentionStrategy() instanceof DockerOnceRetentionStrategy);
+        assertEquals(1, ((DockerOnceRetentionStrategy) template.getRetentionStrategy()).getIdleMinutes());
     }
 
     @Test

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/DockerCloudTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/DockerCloudTest.yml
@@ -20,3 +20,5 @@ jenkins:
               attach:
                 user: "jenkins"
             instanceCapStr: "10"
+            retentionStrategy:
+              idleMinutes: 1

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -11,8 +11,6 @@ import io.jenkins.plugins.casc.impl.attributes.DescribableAttribute;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import jenkins.model.Jenkins;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.Beta;
 import org.kohsuke.stapler.ClassDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Stapler;
@@ -208,7 +206,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
             final String[] names = ClassDescriptor.loadParameterNames(constructor);
             for (int i = 0; i < parameters.length; i++) {
                 final Parameter p = parameters[i];
-                final Attribute a = detectActualType(names[i], TypePair.of(p));
+                final Attribute a = createAttribute(names[i], TypePair.of(p));
                 if (a == null) continue;
                 attributes.add(a);
             }
@@ -234,7 +232,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
         final Object[] args = new Object[parameters.length];
         for (int i = 0; i < parameters.length; i++) {
             final Parameter p = parameters[i];
-            final Attribute a = detectActualType(names[i], TypePair.of(p));
+            final Attribute a = createAttribute(names[i], TypePair.of(p));
             args[i] = Stapler.CONVERT_UTILS.convert(a.getValue(instance), a.getType());
             if (args[i] == null && p.getType().isPrimitive()) {
                 args[i] = defaultValue(p.getType());


### PR DESCRIPTION
logic to introspect parameterized type is only ran on multi-valued attributes

## Please provide a link to issue you're working on if there's a relevant one

https://github.com/jenkinsci/configuration-as-code-plugin/issues/639

