### PR TITLE
generated json schema is invalid

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/Attribute/schema.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/Attribute/schema.jelly
@@ -37,7 +37,8 @@
         "format": "uint64"
       </j:case>
       <j:default>
-        "type": "#/definitions/${it.type.name}"
+        "type":  "object",
+        "ref": "#/definitions/${it.type.name}"
       </j:default>
     </j:switch>
   </j:otherwise>


### PR DESCRIPTION
fix #638

generate nested object properties as 
```json
  "type":  "object", 
  "ref": "#/definitions/FQCN"
```