### PR TITLE
Remove warning by default

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
@@ -81,7 +81,7 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
 
     public static boolean reportDescriptorWithoutSetters(Configurator c) {
         if (c.describe().isEmpty()) {
-            logger.warning(c.getTarget().getName() +
+            logger.fine(c.getTarget().getName() +
                     " has a global view but CasC didn't detect any configurable attribute; see: https://jenkins.io/redirect/casc-requirements/");
         }
         return true;


### PR DESCRIPTION
I think this log does make a lot of sense if one is a Jenkins developer checking what classes/plugins need fixing.

But this warning is probably not actionable by end users, and this is generating a lot of logs with current Jenkins cores and plugins available given a lot of fixes have yet to land.

So I'm lowering this so that it's still present, but one (developer) can enable it if needed.
I think this will probably be fine to put it back to INFO or WARNING much later when we think we have fixed everything and want to watch the latest remaining bad descriptors.

This change is a followup of https://github.com/jenkinsci/configuration-as-code-plugin/pull/587

On Evergreen backend, this has litterally generated hundreds of lines:
![image](https://user-images.githubusercontent.com/223853/48444221-94f39400-e793-11e8-91fb-c7280d663437.png)

Thanks a lot!