### PR TITLE
feat: make keys generated by DescriptorConfigurator lower camel case.

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
@@ -13,6 +13,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.Optional;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * Define a Configurator for a Descriptor
@@ -32,6 +33,7 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor> impleme
         this.name = resolveName(descriptor);
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return name;

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.casc.impl.configurators;
 
+import com.google.common.base.CaseFormat;
 import hudson.model.Descriptor;
 import io.jenkins.plugins.casc.BaseConfigurator;
 import io.jenkins.plugins.casc.ConfigurationContext;
@@ -10,6 +11,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import java.util.Optional;
 import javax.annotation.CheckForNull;
 
 /**
@@ -27,15 +29,7 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor> impleme
     public DescriptorConfigurator(Descriptor descriptor) {
         this.descriptor = descriptor;
         this.target = descriptor.getClass();
-        final Symbol symbol = descriptor.getClass().getAnnotation(Symbol.class);
-        if (symbol != null) {
-            this.name = symbol.value()[0];
-        } else {
-            final String cl = descriptor.getKlass().toJavaClass().getSimpleName();
-            // TODO extract Descriptor parameter type, ie DescriptorImpl extends Descriptor<XX> -> XX
-            // so that if cl = fooXX we get natural name "foo"
-            this.name = cl.toLowerCase();
-        }
+        this.name = resolveName(descriptor);
     }
 
     @Override
@@ -65,5 +59,14 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor> impleme
         return compare(instance, ref, context);
     }
 
-
+    private String resolveName(Descriptor descriptor) {
+        return Optional.ofNullable(descriptor.getClass().getAnnotation(Symbol.class))
+                .map(s -> s.value()[0])
+                .orElseGet(() -> {
+                    /* TODO: extract Descriptor parameter type such that DescriptorImpl extends Descriptor<XX> returns XX.
+                     * Then, if `baseClass == fooXX` we get natural name `foo`.
+                     */
+                    return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, descriptor.getKlass().toJavaClass().getSimpleName());
+                });
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
@@ -1,0 +1,76 @@
+package io.jenkins.plugins.casc.impl.configurators;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import hudson.Extension;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.GlobalConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class DescriptorConfiguratorTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("DescriptorConfiguratorTest_camelCase.yml")
+    public void configurator_shouldConfigureItselfWhenUsingCamelCase() {
+        FooBar descriptor = (FooBar) j.jenkins.getDescriptorOrDie(FooBar.class);
+        assertThat(descriptor.getFoo(), equalTo("foo"));
+        assertThat(descriptor.getBar(), equalTo("bar"));
+    }
+
+    @Test
+    @ConfiguredWithCode("DescriptorConfiguratorTest_lowerCase.yml")
+    public void configurator_shouldConfigureItselfWhenUsingLoweCase() {
+        FooBar descriptor = (FooBar) j.jenkins.getDescriptorOrDie(FooBar.class);
+        assertThat(descriptor.getFoo(), equalTo("foo"));
+        assertThat(descriptor.getBar(), equalTo("bar"));
+    }
+
+    @Extension
+    public static class FooBar extends GlobalConfiguration {
+        private String foo;
+        private String bar;
+
+        public FooBar() {
+        }
+
+        @DataBoundConstructor
+        public FooBar(String foo, String bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+
+        @Nonnull
+        public String getFoo() {
+            return foo;
+        }
+
+        @DataBoundSetter
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        @Nonnull
+        public String getBar() {
+            return bar;
+        }
+
+        @DataBoundSetter
+        public void setBar(String bar) {
+            this.bar = bar;
+        }
+    }
+
+}

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
@@ -1,0 +1,5 @@
+---
+unclassified:
+  fooBar:
+    foo: "foo"
+    bar: "bar"

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_lowerCase.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_lowerCase.yml
@@ -1,0 +1,5 @@
+---
+unclassified:
+  foobar:
+    foo: "foo"
+    bar: "bar"


### PR DESCRIPTION
## Please provide a link to issue you're working on if there's a relevant one
## Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
Currently, when generating keys for a `Descriptor` we first try to retrieve the one defined in the `Symbol` annotation, and if it is not found we just retrieve the simple name for the `Class` and do `toLoweCase()`. This results in YAML keys that are hard to read and not following with `Java` conventions. My change would in turn do the following: 
- For a given class named `MyVeryLongClassName`, the key would now be `myVeryLongClassName` instead of `myverylongclassname`.
This is just a proposal, but I think it makes the user experience better and more consistent across the board.