### PR TITLE
🚧[#676] Test case for GitLab useAuthenticatedEndpoint

### DIFF
--- a/demos/gitlab/README.md
+++ b/demos/gitlab/README.md
@@ -16,6 +16,7 @@ credentials:
               description: "Gitlab Token"
 unclassified:
   gitlabconnectionconfig:
+    useAuthenticatedEndpoint: false
     connections:
     - apiTokenId: gitlab_token
       clientBuilderId: "autodetect"

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -365,7 +365,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>gitlab-plugin</artifactId>
-      <version>1.5.9</version>
+      <!-- TODO: To be replaced with 1.5.12 final once available -->
+      <version>1.5.12-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GitLabConfigurationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GitLabConfigurationTest.java
@@ -10,10 +10,12 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -26,7 +28,7 @@ public class GitLabConfigurationTest {
 
     @Test
     @ConfiguredWithCode("GitLabTest.yml")
-    public void configure_gitlab_api_token() throws Exception {
+    public void configure_gitlab_api_token() {
         SystemCredentialsProvider systemCreds = SystemCredentialsProvider.getInstance();
         List<DomainCredentials> domainCredentials = systemCreds.getDomainCredentials();
         assertEquals(1, domainCredentials.size());
@@ -38,9 +40,10 @@ public class GitLabConfigurationTest {
         assertEquals("qwertyuiopasdfghjklzxcvbnm", apiToken.getApiToken().getPlainText());
         assertEquals("Gitlab Token", apiToken.getDescription());
     }
+
     @Test
     @ConfiguredWithCode("GitLabTest.yml")
-    public void configure_gitlab_connection() throws Exception {
+    public void configure_gitlab_connection() {
         final GitLabConnectionConfig gitLabConnections = j.jenkins.getDescriptorByType(GitLabConnectionConfig.class);
         assertEquals(1, gitLabConnections.getConnections().size());
         final GitLabConnection gitLabConnection = gitLabConnections.getConnections().get(0);
@@ -51,5 +54,13 @@ public class GitLabConfigurationTest {
         assertEquals(20, gitLabConnection.getConnectionTimeout());
         assertEquals(10, gitLabConnection.getReadTimeout());
         assertTrue(gitLabConnection.isIgnoreCertificateErrors());
+    }
+
+    @Test
+    @ConfiguredWithCode("GitLabTest.yml")
+    @Issue("https://github.com/jenkinsci/configuration-as-code-plugin/issues/676")
+    public void configure_gitlab_useAuthenticatedEndpoint() {
+        final GitLabConnectionConfig gitLabConnections = j.jenkins.getDescriptorByType(GitLabConnectionConfig.class);
+        assertFalse(gitLabConnections.isUseAuthenticatedEndpoint());
     }
 }

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GitLabTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GitLabTest.yml
@@ -9,6 +9,7 @@ credentials:
               description: "Gitlab Token"
 unclassified:
   gitlabconnectionconfig:
+    useAuthenticatedEndpoint: false
     connections:
     - apiTokenId: gitlab_token
       clientBuilderId: "autodetect"


### PR DESCRIPTION
It's was broken up to gitlab-plugin 1.5.12 - #676. Corresponding PR - https://github.com/jenkinsci/gitlab-plugin/pull/866

**Work in progress - DO NOT MERGE**. It works with locally build gitlab-plugin 1.5.12-SNPASHOT. I will update this PR once 1.5.12 is released (unfortunately 1.5.11 was released a few days ago...)