### PR TITLE
add vsphere test

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -233,7 +233,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>vsphere-cloud</artifactId>
-      <version>2.18</version>
+      <version>2.19-20181211.110830-1</version>
       <scope>test</scope>
     </dependency>
 

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -230,6 +230,13 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>vsphere-cloud</artifactId>
+      <version>2.18</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- required to satisfy upper bound dependencies -->
 
     <dependency>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/VsphereCloudTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/VsphereCloudTest.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.casc;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class VsphereCloudTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("vSphereCloudTest.yml")
+    public void configure_vsphere_cloud() throws Exception {
+    }
+}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/vSphereCloudTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/vSphereCloudTest.yml
@@ -1,0 +1,45 @@
+jenkins:
+  clouds:
+    - vSphere:
+        instanceCap: 2147483647
+        maxOnlineSlaves: 0
+        templates:
+          - cloneNamePrefix: "windows_docker"
+            cluster: "data"
+            datastore: "datastore-01"
+            folder: "someFolder"
+            forceVMLaunch: true
+            guestInfoProperties:
+              - name: "AGENT_JNLP_URL"
+                value: "${JENKINS_URL}computer/${NODE_NAME}/slave-agent.jnlp"
+              - name: "AGENT_HOME"
+                value: "${remoteFS}"
+              - name: "AGENT_PARAMETERS"
+                value: "-secret ${JNLP_SECRET}"
+            labelString: "windows docker vsphere"
+            launchDelay: 60
+            launcher:
+              jnlp:
+                workDirSettings:
+                  disabled: false
+                  failIfWorkDirIsMissing: false
+                  internalDir: "remoting"
+            limitedRunCount: 0
+            linkedClone: true
+            masterImageName: "windows-server-2019-docker"
+            mode: EXCLUSIVE
+            numberOfExecutors: 1
+            remoteFS: "C:/jenkins"
+            resourcePool: "Resources"
+            retentionStrategy:
+              vSphereCloud:
+                idleMinutes: 5
+            saveFailure: false
+            templateDescription: "Windows Jenkins agent"
+            templateInstanceCap: 5
+            useSnapshot: true
+            waitForVMTools: true
+        vsConnectionConfig:
+          credentialsId: "vsphere"
+          vsHost: "https://somevcenter.test.local"
+        vsDescription: "SomeName"


### PR DESCRIPTION
## Please provide a link to issue you're working on if there's a relevant one
Just testing out vSphere cloud plugin and experienced vsphere retention was not configurable. I can't see why it it is not.

@ndeloof perhaps you could give a hint why it fails?

https://github.com/jenkinsci/vsphere-cloud-plugin/blob/master/src/main/java/org/jenkinsci/plugins/vsphere/VSphereCloudRetentionStrategy.java

## Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
