### PR TITLE
Enabled support for Groovy scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4 (not released yet)
 - Add support for Vault appRole authentication method
+- Allow to run Groovy scripts as a part of configuration Yaml (inline or other source)
 
 ## 1.3
 
@@ -24,7 +25,7 @@
 ## 1.1
 
 - [SECURITY-1124] Never export sensitive Secret
-- fix plugin installation 
+- fix plugin installation
 - impersonate as SYSTEM to apply configuration
 - removed Beta API annotations
 - many fixes to documentation and demos

--- a/demos/groovy/README.md
+++ b/demos/groovy/README.md
@@ -1,0 +1,24 @@
+# Run Groovy scripts
+
+Configuration-as-Code can run Groovy scripts.
+
+Groovy scripts cen be:
+ * inline, with entry `script`
+ * from `url`
+ * from local file, using `file`
+
+## Sample configuration
+
+```yaml
+groovy:
+  - script: >
+      println("This is Groovy script!");
+```
+
+
+
+## Implementation notes
+
+ * It is recommended to use semicolons at the end of lines
+ * There is no dry run implemented for Groovy scripts feature
+

--- a/demos/groovy/gerrit-trigger.yml
+++ b/demos/groovy/gerrit-trigger.yml
@@ -1,0 +1,38 @@
+
+groovy:
+  - script: >
+      import jenkins.model.Jenkins;
+      import net.sf.json.JSONObject;
+      import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
+
+      if ( Jenkins.instance.pluginManager.activePlugins.find { it.shortName == "gerrit-trigger" } != null ) {
+          println("Setting gerrit-trigger server plugin");
+
+          def gerritPlugin = Jenkins.instance.getPlugin(com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl.class);
+          gerritPlugin.getPluginConfig().setNumberOfReceivingWorkerThreads(3);
+          gerritPlugin.getPluginConfig().setNumberOfSendingWorkerThreads(1);
+
+          def serverName = "grenoble-gerrit";
+          GerritServer server = new GerritServer(serverName);
+          def config = server.getConfig();
+
+          def triggerConfig = [
+              'gerritHostName':"gerrit.com",
+              'gerritSshPort':29418,
+              'gerritUserName':"szandala_jenkins",
+              'gerritFrontEndUrl':"https://gerrit.com"
+          ];
+
+          config.setValues(JSONObject.fromObject(triggerConfig));
+          server.setConfig(config);
+
+          // avoid duplicate servers on the server list;
+          if ( gerritPlugin.containsServer(serverName) ) {
+              gerritPlugin.removeServer(gerritPlugin.getServer(serverName));
+          }
+
+          gerritPlugin.addServer(server);
+          server.start();
+          server.startConnection();
+          println("Setting ${serverName} completed");
+      }

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GroovyScriptTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GroovyScriptTest.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.casc;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
+ */
+public class GroovyScriptTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("GroovySetProxy.yml")
+    public void shouldSetProxyUsingGroovyScript() throws Exception {
+        final Jenkins jenkins = Jenkins.getInstance();
+        assertEquals("14.3.19.91", jenkins.proxy.name);
+    }
+}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GroovySetProxy.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GroovySetProxy.yml
@@ -1,0 +1,17 @@
+groovy:
+  - script: >
+      import jenkins.model.Jenkins;
+      import hudson.ProxyConfiguration;
+
+
+      def instance = Jenkins.getInstance();
+
+      final String name = "14.3.19.91";
+      final int port = 8080;
+      final String username = "";
+      final String password = "";
+      final String noProxyHost = "";
+
+      final def pc = new ProxyConfiguration(name, port, username, password, noProxyHost);
+      instance.proxy = pc;
+      instance.save();

--- a/support/src/main/java/io/jenkins/plugins/casc/support/groovy/ConfigurableGroovyScriptSource.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/groovy/ConfigurableGroovyScriptSource.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.casc.support.groovy;
+
+import io.jenkins.plugins.casc.Configurable;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.model.CNode;
+
+/**
+ * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
+ */
+public abstract class ConfigurableGroovyScriptSource extends GroovyScriptSource implements Configurable {
+
+    @Override
+    public void configure(CNode node) throws ConfiguratorException {
+        configure(node.asScalar().getValue());
+    }
+
+    protected abstract void configure(String value);
+
+    @Override
+    public void check(CNode node) throws ConfiguratorException {
+        node.asScalar();
+    }
+
+    @Override
+    public CNode describe() throws Exception {
+        return null; // Not relevant here
+    }
+
+}

--- a/support/src/main/java/io/jenkins/plugins/casc/support/groovy/FromFileGroovyScriptSource.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/groovy/FromFileGroovyScriptSource.java
@@ -1,0 +1,34 @@
+package io.jenkins.plugins.casc.support.groovy;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.Symbol;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
+ */
+public class FromFileGroovyScriptSource extends ConfigurableGroovyScriptSource {
+
+    public String path;
+
+    @Override
+    public void configure(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public String getScript() throws IOException {
+        return FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8);
+    }
+
+    @Extension
+    @Symbol("file")
+    public static class DescriptorImpl extends Descriptor<GroovyScriptSource> {
+
+    }
+}

--- a/support/src/main/java/io/jenkins/plugins/casc/support/groovy/FromUrlGroovyScriptSource.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/groovy/FromUrlGroovyScriptSource.java
@@ -1,0 +1,34 @@
+package io.jenkins.plugins.casc.support.groovy;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.casc.Configurable;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.Symbol;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
+ */
+public class FromUrlGroovyScriptSource extends ConfigurableGroovyScriptSource implements Configurable {
+
+    public String url;
+
+    @Override
+    public void configure(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String getScript() throws IOException {
+        return IOUtils.toString(URI.create(url));
+    }
+
+    @Extension
+    @Symbol("url")
+    public static class DescriptorImpl extends Descriptor<GroovyScriptSource> {
+
+    }
+}

--- a/support/src/main/java/io/jenkins/plugins/casc/support/groovy/GroovyScriptCaller.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/groovy/GroovyScriptCaller.java
@@ -1,0 +1,98 @@
+package io.jenkins.plugins.casc.support.groovy;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.EnvVars;
+import hudson.Extension;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Sequence;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import groovy.lang.GroovyShell;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+
+/**
+ * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
+ */
+@Extension(optional = true)
+@Restricted(NoExternalUse.class)
+public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
+
+    @Override
+    public String getName() {
+        return "groovy";
+    }
+
+    @Override
+    public Class getTarget() {
+        return Boolean[].class;
+    }
+
+    @Override
+    public Set<Attribute<Boolean[],?>> describe() {
+        return Collections.singleton(new MultivaluedAttribute("", GroovyScriptSource.class));
+    }
+
+    @Override
+    public Boolean[] getTargetComponent(ConfigurationContext context) {
+        return new Boolean[0]; // Doesn't really make sense
+    }
+
+    @Override
+    public Boolean[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
+        //JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
+        final Sequence sources = config.asSequence();
+        final Configurator<GroovyScriptSource> con = context.lookup(GroovyScriptSource.class);
+        List<Boolean> generated = new ArrayList<>();
+        for (CNode source : sources) {
+            final String script;
+            try {
+                script = con.configure(source, context).getScript();
+            } catch (IOException e) {
+                throw new ConfiguratorException(this, "Failed to retrieve Groovy script", e);
+            }
+            try {
+                //Binding binding = new Binding();
+                //binding.setVariable("foo", new Integer(2));
+                GroovyShell shell = new GroovyShell();
+                shell.evaluate(script);
+                generated.add(true);
+
+            } catch (Exception ex) {
+                throw new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), ex);
+            }
+        }
+        return generated.toArray(new Boolean[generated.size()]);
+    }
+
+    @Override
+    public Boolean[] check(CNode config, ConfigurationContext context) throws ConfiguratorException {
+        // Any way to dry-run a Groovy script ?
+        return new Boolean[0];
+    }
+
+    @Nonnull
+    @Override
+    public List<Configurator> getConfigurators(ConfigurationContext context) {
+        return Collections.singletonList(context.lookup(GroovyScriptSource.class));
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(Boolean[] instance, ConfigurationContext context) throws Exception {
+        return null;
+    }
+}

--- a/support/src/main/java/io/jenkins/plugins/casc/support/groovy/GroovyScriptSource.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/groovy/GroovyScriptSource.java
@@ -1,0 +1,14 @@
+package io.jenkins.plugins.casc.support.groovy;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
+ */
+public abstract class GroovyScriptSource extends AbstractDescribableImpl<GroovyScriptSource> implements ExtensionPoint {
+
+    public abstract String getScript() throws IOException;
+}

--- a/support/src/main/java/io/jenkins/plugins/casc/support/groovy/InlinePureGroovyScriptSource.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/groovy/InlinePureGroovyScriptSource.java
@@ -1,0 +1,32 @@
+package io.jenkins.plugins.casc.support.groovy;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.casc.Configurable;
+import org.jenkinsci.Symbol;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
+ */
+public class InlinePureGroovyScriptSource extends ConfigurableGroovyScriptSource implements Configurable {
+
+    public String script;
+
+    @Override
+    public void configure(String script) {
+        this.script = script;
+    }
+
+    @Override
+    public String getScript() throws IOException {
+        return script;
+    }
+
+    @Extension
+    @Symbol("script")
+    public static class DescriptorImpl extends Descriptor<GroovyScriptSource> {
+
+    }
+}

--- a/support/src/main/resources/io/jenkins/plugins/casc/support/groovy/FromFileGroovyScriptSource/schema.jelly
+++ b/support/src/main/resources/io/jenkins/plugins/casc/support/groovy/FromFileGroovyScriptSource/schema.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    "io.jenkins.plugins.casc.support.groovy.FromFileGroovyScriptSource": { "type": "string" }
+</j:jelly>

--- a/support/src/main/resources/io/jenkins/plugins/casc/support/groovy/FromUrlGroovyScriptSource/schema.jelly
+++ b/support/src/main/resources/io/jenkins/plugins/casc/support/groovy/FromUrlGroovyScriptSource/schema.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    "io.jenkins.plugins.casc.support.groovy.FromUrlGroovyScriptSource": { "type": "string" }
+</j:jelly>

--- a/support/src/main/resources/io/jenkins/plugins/casc/support/groovy/InlinePureGroovyScriptSource/schema.jelly
+++ b/support/src/main/resources/io/jenkins/plugins/casc/support/groovy/InlinePureGroovyScriptSource/schema.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    "io.jenkins.plugins.casc.support.groovy.InlinePureGroovyScriptSource": { "type": "string" }
+</j:jelly>


### PR DESCRIPTION
New module in support allows user to run Groovy scripts inline,
but with semicolons ';' at the end of each line.
Or as separate script e.g. url or file
This satisfies:
https://issues.jenkins-ci.org/browse/JENKINS-55344
https://github.com/jenkinsci/configuration-as-code-plugin/issues/686

- [x] Please describe what you did

- [x] Link to issue you're working on if there's a relevant one

- [x] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [x] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
