### PR TITLE
FEAT: allow secrets to be used by job definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## 1.5 (not released yet)
 
 - Improve explanation of CASC_VAULT in README.md
+- Add proper string interpolation for secrets.
+- Add support for secrets while defining `jobs` declarations.
 
 ## 1.4
 
 - Add support for Vault appRole authentication method
-- Add proper string interpolation for secrets.
 
 ## 1.3
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
@@ -1,12 +1,14 @@
 package io.jenkins.plugins.casc;
 
+import static org.junit.Assert.assertNotNull;
+
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.EnvVarsRule;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNotNull;
+import org.junit.rules.RuleChain;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -14,13 +16,22 @@ import static org.junit.Assert.assertNotNull;
 public class SeedJobTest {
 
     @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+    public RuleChain rc = RuleChain.outerRule(new EnvVarsRule()
+            .env("SEED_JOB_PATH", "./src/test/resources/io/jenkins/plugins/casc/testJob2.groovy"))
+            .around(new JenkinsConfiguredWithCodeRule());
 
     @Test
     @ConfiguredWithCode("SeedJobTest.yml")
     public void configure_seed_job() throws Exception {
         final Jenkins jenkins = Jenkins.getInstance();
         assertNotNull(jenkins.getItem("testJob1"));
+        assertNotNull(jenkins.getItem("testJob2"));
+    }
+
+    @Test
+    @ConfiguredWithCode("SeedJobTest_withSecrets.yml")
+    public void configure_seed_job_with_secrets() throws Exception {
+        final Jenkins jenkins = Jenkins.getInstance();
         assertNotNull(jenkins.getItem("testJob2"));
     }
 }

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/SeedJobTest_withSecrets.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/SeedJobTest_withSecrets.yml
@@ -1,0 +1,2 @@
+jobs:
+  - file: ${SEED_JOB_PATH}

--- a/support/src/main/java/io/jenkins/plugins/casc/support/jobdsl/SeedJobConfigurator.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/jobdsl/SeedJobConfigurator.java
@@ -1,16 +1,19 @@
 package io.jenkins.plugins.casc.support.jobdsl;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import static io.vavr.API.Try;
+import static io.vavr.API.unchecked;
+
 import hudson.EnvVars;
 import hudson.Extension;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.ConfigurationContext;
-import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.SecretSourceResolver;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.CNode;
-import io.jenkins.plugins.casc.model.Sequence;
+import io.jenkins.plugins.casc.model.Mapping;
 import javaposse.jobdsl.dsl.GeneratedItems;
 import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
 import javaposse.jobdsl.plugin.JenkinsJobManagement;
@@ -18,13 +21,12 @@ import javaposse.jobdsl.plugin.LookupStrategy;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 // TODO: Move outside the plugin?
 /**
@@ -34,18 +36,22 @@ import java.util.Set;
 @Restricted(NoExternalUse.class)
 public class SeedJobConfigurator implements RootElementConfigurator<GeneratedItems[]> {
 
+    @Nonnull
     @Override
     public String getName() {
         return "jobs";
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Class getTarget() {
         return GeneratedItems[].class;
     }
 
+    @Nonnull
     @Override
-    public Set<Attribute<GeneratedItems[],?>> describe() {
+    @SuppressWarnings("unchecked")
+    public Set<Attribute<GeneratedItems[], ?>> describe() {
         return Collections.singleton(new MultivaluedAttribute("", ScriptSource.class));
     }
 
@@ -54,26 +60,17 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
         return new GeneratedItems[0]; // Doesn't really make sense
     }
 
+    @Nonnull
     @Override
+    @SuppressWarnings("unchecked")
     public GeneratedItems[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
-        final Sequence sources = config.asSequence();
-        final Configurator<ScriptSource> con = context.lookup(ScriptSource.class);
-        List<GeneratedItems> generated = new ArrayList<>();
-        for (CNode source : sources) {
-            final String script;
-            try {
-                script = con.configure(source, context).getScript();
-            } catch (IOException e) {
-                throw new ConfiguratorException(this, "Failed to retrieve job-dsl script", e);
-            }
-            try {
-                generated.add(new JenkinsDslScriptLoader(mng).runScript(script));
-            } catch (Exception ex) {
-                throw new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), ex);
-            }
-        }
-        return generated.toArray(new GeneratedItems[generated.size()]);
+        JenkinsJobManagement management = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
+        Configurator<ScriptSource> configurator = context.lookupOrFail(ScriptSource.class);
+        return config.asSequence().stream()
+                .map(source -> getActualValue(source, context))
+                .map(source -> getScriptFromSource(source, context, configurator))
+                .map(script -> generateFromScript(script, management))
+                .toArray(GeneratedItems[]::new);
     }
 
     @Override
@@ -92,5 +89,32 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
     @Override
     public CNode describe(GeneratedItems[] instance, ConfigurationContext context) throws Exception {
         return null;
+    }
+
+    private CNode getActualValue(CNode config, ConfigurationContext context) {
+        return unchecked(() -> config.asMapping().entrySet().stream().findFirst()).apply()
+                .map(entry -> {
+                    Mapping mapping = new Mapping();
+                    mapping.put(entry.getKey(), revealSourceOrGetValue(entry, context));
+                    return (CNode) mapping;
+                }).orElse(config);
+    }
+
+    private String revealSourceOrGetValue(Map.Entry<String, CNode> entry, ConfigurationContext context) {
+        String value = unchecked(() -> entry.getValue().asScalar().getValue()).apply();
+        return SecretSourceResolver.resolve(context, value);
+    }
+
+    private GeneratedItems generateFromScript(String script, JenkinsJobManagement management) {
+        return unchecked(() ->
+                Try(() -> new JenkinsDslScriptLoader(management).runScript(script))
+                        .getOrElseThrow(t -> new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), t))).apply();
+    }
+
+    private String getScriptFromSource(CNode source, ConfigurationContext context, Configurator<ScriptSource> configurator) {
+        return unchecked(() ->
+                Try(() -> configurator.configure(source, context))
+                        .getOrElseThrow(t -> new ConfiguratorException(this, "Failed to retrieve job-dsl script", t))
+                        .getScript()).apply();
     }
 }


### PR DESCRIPTION
This PR aims to extend the current functionality of `SeedJobConfigurator` so that secrets can be passed in as values in the YAML file. This is particularly useful because hard-coding paths to a seed job file should be considered bad practice. 

For example: a user X has two Jenkins instances, one for production and one for development. Ideally, user X should be able to define an environment variable, `SEED_JOB_PATH` and let CasC do the replacement when deploying. This would allow user X to have different implementations of a seed job for each of his instances while using the same CasC YAML file.

Here is our checklist for contributors. No hard requirement here, just a reminder

- [X] Please describe what you did

- [X] Link to issue you're working on if there's a relevant one

- [X] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [X] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
