### PR TITLE
HOTFIX: handle empty extension list in configurator registry.

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/DefaultConfiguratorRegistry.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/DefaultConfiguratorRegistry.java
@@ -134,7 +134,10 @@ public class DefaultConfiguratorRegistry implements ConfiguratorRegistry {
         }
 
         if (Descriptor.class.isAssignableFrom(clazz)) {
-            return new DescriptorConfigurator((Descriptor) jenkins.getExtensionList(clazz).get(0));
+            ExtensionList extensions = jenkins.getExtensionList(clazz);
+            if (!extensions.isEmpty()) {
+                return new DescriptorConfigurator((Descriptor) extensions.get(0));
+            }
         }
 
         if (DataBoundConfigurator.getDataBoundConstructor(clazz) != null) {


### PR DESCRIPTION
This PR aims to fix https://github.com/jenkinsci/configuration-as-code-plugin/issues/688. The stack-trace points to line 137 of `DefaultConfiguratorRegistry` in which we assumed the `ExtensionList` had to be non-empty at all times. This is not the case, and we should guard against it.

I was able to reproduce the exception by installing `perfpublisher:latest` plugin. Not sure why this particular plugin causes the CasC code to break.

Here is our checklist for contributors. No hard requirement here, just a reminder

- [X] Please describe what you did

- [X] Link to issue you're working on if there's a relevant one

- [ ] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [ ] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
