### PR TITLE
fix tag name format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
+    <tagNameFormat>configuration-as-code-${project.version}</tagNameFormat>
   </properties>
 
   <name>Configuration as Code Parent</name>


### PR DESCRIPTION
instead of `prepare release parent-1.5` it should say `prepare release configuration-as-code-1.5` and tags in git should be of said format

Here is our checklist for contributors. No hard requirement here, just a reminder

- [x] Please describe what you did

- [ ] Link to issue you're working on if there's a relevant one

- [ ] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [ ] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
