### PR TITLE
add example file for setting up config-file-provider plugin

### DIFF
--- a/demos/config-file-provider/README.md
+++ b/demos/config-file-provider/README.md
@@ -1,0 +1,52 @@
+# configure config-file-provider files 
+
+## sample configuration
+
+```yaml
+jenkins: 
+  [...]
+unclassified:
+  globalConfigFiles:
+    configs:
+    - custom:
+        id: custom-test
+        name: DummyCustom1
+        comment: dummy custom 1
+        content: dummy content 1
+    - json:
+        id: json-test
+        name: DummyJsonConfig
+        comment: dummy json config
+        content: |
+          { "dummydata": {"dummyKey": "dummyValue"} }
+    - xml:
+        id: xml-test
+        name: DummyXmlConfig
+        comment: dummy xml config
+        content: <root><dummy test="abc"></dummy></root>
+    - mavenSettings:
+        id: maven-test
+        name: DummySettings
+        comment: dummy settings
+        isReplaceAll: false
+        serverCredentialMappings:
+        - serverId: server1
+          credentialsId: someCredentials1
+        - serverId: server2
+          credentialsId: someCredentials2
+        content: |
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <!-- activeProfiles
+             | List of profiles that are active for all builds.
+             |
+            -->
+            <activeProfiles>
+              <activeProfile>alwaysActiveProfile</activeProfile>
+              <activeProfile>anotherAlwaysActiveProfile</activeProfile>
+            </activeProfiles>
+          </settings>
+```
+
+


### PR DESCRIPTION
add example file for setting up config-file-provider plugin configuration files using casc.

- [* ] Please describe what you did
* Added examples for creating some configuration files using `config-file-provider` plugin . 
https://wiki.jenkins.io/display/JENKINS/Config+File+Provider+Plugin
- [ ] Link to issue you're working on if there's a relevant one

- [ ] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [ ] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
