### PR TITLE
Added escape for secrets to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ with your favourite yaml tools.
 
 Currently, you can provide initial secrets to Configuration-as-Code that all rely on <key,value>
 substitution of strings in configuration. For example, ``Jenkins: `${some_var}` ``. Default variable substitution
-using the `:-` operator from `bash` is also available. For example, `key: ${VALUE:-defaultvalue}` will evaluate to `defaultvalue` if `$VALUE` is unset.
+using the `:-` operator from `bash` is also available. For example, `key: ${VALUE:-defaultvalue}` will evaluate to `defaultvalue` if `$VALUE` is unset. To escape a string from secret interpolation, put `^` in front of the value. For example, `Jenkins: ^${some_var}` will produce the literal `Jenkins: ${some_var}`.
 
 We can provide these initial secrets in the following ways:
 


### PR DESCRIPTION
Per #697 proper interpolation was added. However, some plugins such as the kubernetes plugin require ${computer.jnlpmac} and ${computer.name} literals in the config.xml. The PR didn't add this extra bit of info for escaping the secrets and would require someone to review the PR to see the escape character of `^`.

Here is our checklist for contributors. No hard requirement here, just a reminder

- [X] Please describe what you did

- [X] Link to issue you're working on if there's a relevant one

- [] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [X] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
