### PR TITLE
Make system env vars available in the context used for running the jobdsl/groovy code defining the seed job.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6 (not released yet)
 
+- Make system environment variables available to the context used for running the jobdsl/groovy code used to define the seed job.
 - Add support for secrets while defining `jobs` declarations.
 - #688: fixed an IndexOutOfBounds exception
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.6 (not released yet)
 
-- Make system environment variables available to the context used for running the jobdsl/groovy code used to define the seed job.
+- Make system environment variables available in the context used for running the jobdsl/groovy code defining the seed job.
 - Add support for secrets while defining `jobs` declarations.
 - #688: fixed an IndexOutOfBounds exception
 

--- a/demos/jobs/README.md
+++ b/demos/jobs/README.md
@@ -9,7 +9,7 @@ configuration-as-code file.
 
 ## sample configurations
 
-[bitbucket.yaml](bitbucket.yaml) file is an example of configuration file with Jenkins and an Organization Folder Job Type with automatic branch discovering in Bitbucket.
+[bitbucket.yaml](bitbucket.yaml) file is an example of configuration file with Jenkins and an Organization Folder Job Type with automatic branch discovering in Bitbucket. It requires [Branch API plugin](https://github.com/jenkinsci/branch-api-plugin) and [Bitbucket Branch Source plugin](https://github.com/jenkinsci/bitbucket-branch-source-plugin) to be able to run this demo. `$BITBUCKET_URL` is a system environment variable that needs to be defined before Jenkins is started.
 
 [pipeline.yaml](pipeline.yaml) file is an example of configuring a folder and a descrative pipeline job within that folder.
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
@@ -17,13 +17,14 @@ public class SeedJobTest {
 
     @Rule
     public RuleChain rc = RuleChain.outerRule(new EnvVarsRule()
-            .env("SEED_JOB_PATH", "./src/test/resources/io/jenkins/plugins/casc/testJob2.groovy"))
+            .env("SEED_JOB_PATH", "./src/test/resources/io/jenkins/plugins/casc/testJob2.groovy")
+            .env("REPO_URL", "git://github.com/jenkinsci/configuration-as-code-plugin.git"))
             .around(new JenkinsConfiguredWithCodeRule());
 
     @Test
     @ConfiguredWithCode("SeedJobTest.yml")
     public void configure_seed_job() throws Exception {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         assertNotNull(jenkins.getItem("testJob1"));
         assertNotNull(jenkins.getItem("testJob2"));
     }
@@ -31,7 +32,14 @@ public class SeedJobTest {
     @Test
     @ConfiguredWithCode("SeedJobTest_withSecrets.yml")
     public void configure_seed_job_with_secrets() throws Exception {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         assertNotNull(jenkins.getItem("testJob2"));
+    }
+
+    @Test
+    @ConfiguredWithCode("SeedJobTest_withEnvVars.yml")
+    public void configure_seed_job_with_env_vars() throws Exception {
+        final Jenkins jenkins = Jenkins.get();
+        assertNotNull(jenkins.getItem("seedJobWithEnvVars"));
     }
 }

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/SeedJobTest_withEnvVars.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/SeedJobTest_withEnvVars.yml
@@ -1,0 +1,13 @@
+jobs:
+    - script: >
+          job('seedJobWithEnvVars') {
+              scm {
+                  git("$REPO_URL")
+              }
+              triggers {
+                  scm('H/15 * * * *')
+              }
+              steps {
+                  maven('-e clean test')
+              }
+          }

--- a/support/src/main/java/io/jenkins/plugins/casc/support/jobdsl/SeedJobConfigurator.java
+++ b/support/src/main/java/io/jenkins/plugins/casc/support/jobdsl/SeedJobConfigurator.java
@@ -64,7 +64,7 @@ public class SeedJobConfigurator implements RootElementConfigurator<GeneratedIte
     @Override
     @SuppressWarnings("unchecked")
     public GeneratedItems[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        JenkinsJobManagement management = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
+        JenkinsJobManagement management = new JenkinsJobManagement(System.out, System.getenv(), null, null, LookupStrategy.JENKINS_ROOT);
         Configurator<ScriptSource> configurator = context.lookupOrFail(ScriptSource.class);
         return config.asSequence().stream()
                 .map(source -> getActualValue(source, context))


### PR DESCRIPTION
- [x] **Please describe what you did.**
Made this change to be able to use environment variables in the jobdsl/groovy code defining the seed job. This is useful when using [custom-war-packager](https://github.com/jenkinsci/custom-war-packager) to construct a custom war (and Docker image) that has also configuration to define the seed job. The resulting Docker image can be used to run multiple Jenkins instances and configure particular properties (like Bitbucket URL and project code, for example) using environment variables attached to the container.
- [x] **Link to issue you're working on if there's a relevant one.**
No issue
- [x] **Did you provide a test-case to demonstrate feature actually works / issue is fixed?**
Yes. Added extra test case in SeedJobTest.java
- [x] **Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)**