### PR TITLE
update vault-java-driver to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Make system environment variables available in the context used for running the jobdsl/groovy code defining the seed job.
 - Add support for secrets while defining `jobs` declarations.
 - #688: fixed an IndexOutOfBounds exception
+- Add support for Enterprise Vault to store secrets; set CASC_VAULT_NAMESPACE to provide a namespace
 
 ## 1.5
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Prerequisites:
 - The environment variable `CASC_VAULT_PATH` must be present. (Vault key path. For example, `/secrets/jenkins`.)
 - The environment variable `CASC_VAULT_URL` must be present. (Vault url, including port number.)
 - The environment variable `CASC_VAULT_MOUNT` is optional. (Vault auth mount. For example, `ldap` or another username & password authentication type, defaults to `userpass`.)
+- The environment variable `CASC_VAULT_NAMESPACE` is optional. If used, sets the Vault namespace for Enterprise Vaults.
 - The environment variable `CASC_VAULT_FILE` is optional, provides a way for the other variables to be read from a file instead of environment variables.
 
 If the environment variables `CASC_VAULT_URL` and `CASC_VAULT_PATH` are present, Configuration-as-Code will try to gather initial secrets from Vault. However for it to work properly there is a need for authentication by either the combination of `CASC_VAULT_USER` and `CASC_VAULT_PW`, a `CASC_VAULT_TOKEN`, or the combination of `CASC_VAULT_APPROLE` and `CASC_VAULT_APPROLE_SECRET`. The authenticated user must have at least read access.

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.0</version>
     </dependency>
 
     <dependency>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -49,13 +49,20 @@ public class VaultSecretSource extends SecretSource {
         String vaultToken = getVariable("CASC_VAULT_TOKEN", prop);
         String vaultAppRole = getVariable("CASC_VAULT_APPROLE", prop);
         String vaultAppRoleSecret = getVariable("CASC_VAULT_APPROLE_SECRET", prop);
+        String vaultNamespace = getVariable("CASC_VAULT_NAMESPACE", prop);
 
         if(((vaultPw != null && vaultUsr != null) || 
             vaultToken != null || 
             (vaultAppRole != null && vaultAppRoleSecret != null)) && vaultPth != null && vaultUrl != null) {
             LOGGER.log(Level.FINE, "Attempting to connect to Vault: {0}", vaultUrl);
             try {
-                VaultConfig config = new VaultConfig().address(vaultUrl).build();
+                VaultConfig config = new VaultConfig().address(vaultUrl);
+                if (vaultNamespace != null) {
+                    // optionally set namespace
+                    config = config.nameSpace(vaultNamespace);
+                    LOGGER.log(Level.FINE, "Using namespace with Vault: {0}", vaultNamespace);
+                }
+                config = config.build();
                 Vault vault = new Vault(config);
                 //Obtain a login token
                 final String token;


### PR DESCRIPTION
Updated vault-java-driver to 4.0.0 to get support for Enterprise vaults
Adding CASC_VAULT_NAMESPACE to optionally set the namespace.

Related issue #710 

Note: hard to test as requires an Enterprise Vault instance. Will test manually.