### PR TITLE
fix revealing secret with default where env is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.7 (not released yet)
 
+- fix revealing secret with default defined, where environment variable is defined, it would always default.
+
 ## 1.6 
 
 - Make system environment variables available in the context used for running the jobdsl/groovy code defining the seed job.

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc;
 
 import static io.vavr.API.unchecked;
 
+import io.vavr.control.Try;
 import org.bigtesting.interpolatd.Interpolator;
 
 import java.util.Optional;
@@ -25,13 +26,11 @@ public class SecretSourceResolver {
     }
 
     private static String handle(ConfigurationContext context, String captured) {
-        int limit = 2;
-        String[] split = captured.split(defaultDelimiter, limit);
+        String[] split = captured.split(defaultDelimiter, 2);
         String reveal = split[0];
-        Optional<String> defaultValue = Optional.empty();
-        if (split.length == limit) {
-            defaultValue = Optional.ofNullable(split[1]);
-        }
+        Optional<String> defaultValue = Try.of(() -> Optional.ofNullable(split[1]))
+                .getOrElse(Optional.empty());
+
         return reveal(context, reveal)
                 .map(Optional::of)
                 .orElse(defaultValue)

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -25,9 +25,16 @@ public class SecretSourceResolver {
     }
 
     private static String handle(ConfigurationContext context, String captured) {
-        return reveal(context, captured)
+        int limit = 2;
+        String[] split = captured.split(defaultDelimiter, limit);
+        String reveal = split[0];
+        Optional<String> defaultValue = Optional.empty();
+        if (split.length == limit) {
+            defaultValue = Optional.ofNullable(split[1]);
+        }
+        return reveal(context, reveal)
                 .map(Optional::of)
-                .orElse(defaultValue(captured))
+                .orElse(defaultValue)
                 .orElse("");
     }
 
@@ -36,14 +43,5 @@ public class SecretSourceResolver {
                 .map(source -> unchecked(() -> source.reveal(captured)).apply())
                 .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
                 .findFirst();
-    }
-
-    private static Optional<String> defaultValue(String captured) {
-        int limit = 2;
-        String[] split = captured.split(defaultDelimiter, limit);
-        if (split.length == limit) {
-            return Optional.ofNullable(split[1]);
-        }
-        return Optional.empty();
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc;
 
 import static io.vavr.API.unchecked;
 
+import io.vavr.Tuple;
 import io.vavr.control.Try;
 import org.bigtesting.interpolatd.Interpolator;
 
@@ -27,14 +28,11 @@ public class SecretSourceResolver {
 
     private static String handle(ConfigurationContext context, String captured) {
         String[] split = captured.split(defaultDelimiter, 2);
-        String reveal = split[0];
-        Optional<String> defaultValue = Try.of(() -> Optional.ofNullable(split[1]))
-                .getOrElse(Optional.empty());
-
-        return reveal(context, reveal)
+        return Tuple.of(split[0], Try.of(() -> split[1]).toJavaOptional()).apply(
+            (toReveal, defaultValue) -> reveal(context, toReveal)
                 .map(Optional::of)
                 .orElse(defaultValue)
-                .orElse("");
+                .orElse(""));
     }
 
     private static Optional<String> reveal(ConfigurationContext context, String captured) {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
@@ -4,8 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import io.jenkins.plugins.casc.SecretSource;
 import org.apache.commons.io.FileUtils;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.Beta;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +30,7 @@ public class DockerSecretSource extends SecretSource {
 
     @Override
     public Optional<String> reveal(String secret) throws IOException {
+        if (StringUtils.isBlank(secret)) return Optional.empty();
         final File file = new File(secrets, secret);
         if (file.exists()) {
             return Optional.of(FileUtils.readFileToString(file).trim());

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/EnvSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/EnvSecretSource.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc.impl.secrets;
 
 import hudson.Extension;
 import io.jenkins.plugins.casc.SecretSource;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -12,10 +13,8 @@ import java.util.Optional;
 public class EnvSecretSource extends SecretSource {
 
     @Override
-    public Optional<String> reveal(String envKey) {
-        Optional<String> returnValue = Optional.empty();
-        String config = System.getProperty(envKey, System.getenv(envKey));
-        if (config != null) returnValue = Optional.of(config);
-        return returnValue;
+    public Optional<String> reveal(String secret) {
+        if (StringUtils.isBlank(secret)) return Optional.empty();
+        return Optional.ofNullable(System.getProperty(secret, System.getenv(secret)));
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -5,8 +5,7 @@ import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
 import hudson.Extension;
 import io.jenkins.plugins.casc.SecretSource;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.Beta;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -91,12 +90,9 @@ public class VaultSecretSource extends SecretSource {
     }
 
     @Override
-    public Optional<String> reveal(String vaultKey) {
-        Optional<String> returnValue = Optional.empty();
-        if(secrets.containsKey(vaultKey))  {
-            returnValue = Optional.of(secrets.get(vaultKey));
-        }
-        return returnValue;
+    public Optional<String> reveal(String secret) {
+        if (StringUtils.isBlank(secret)) return Optional.empty();
+        return Optional.ofNullable(secrets.get(secret));
     }
 
     public Map<String, String> getSecrets() {

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -39,6 +39,14 @@ public class SecretSourceResolverTest {
     }
 
     @Test
+    public void resolve_singleEntryWithDefaultValueAndWithEnvDefined() {
+        environment.set("FOO", "hello");
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        assertThat(SecretSourceResolver.resolve(context, "${FOO:-default}"), equalTo("hello"));
+    }
+
+    @Test
     public void resolve_singleEntryEscaped() {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -143,6 +143,13 @@ public class SecretSourceResolverTest {
     }
 
     @Test
+    public void resolve_mixedMultipleEntriesWithDefault() {
+        environment.set("FOO", "www.foo.io");
+        environment.set("protocol", "http");
+        assertThat(SecretSourceResolver.resolve(context, "${protocol:-https}://${FOO:-www.bar.io}"), equalTo("http://www.foo.io"));
+    }
+
+    @Test
     public void resolve_mixedMultipleEntriesEscaped() {
         assertThat(SecretSourceResolver.resolve(context, "http://^${FOO}:^${BAR}"), equalTo("http://${FOO}:${BAR}"));
     }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -88,6 +88,32 @@ public class SecretSourceResolverTest {
     }
 
     @Test
+    public void resolve_nothingSpace() {
+        assertThat(SecretSourceResolver.resolve(context, "${ }"), equalTo("${ }"));
+    }
+
+    @Test
+    public void resolve_nothingBrackets() {
+        assertThat(SecretSourceResolver.resolve(context, "${}"), equalTo("${}"));
+    }
+
+    @Test
+    public void resolve_nothingDefault() {
+        assertThat(SecretSourceResolver.resolve(context, "${:-default}"), equalTo("default"));
+    }
+
+    @Test
+    public void resolve_emptyDefault() {
+        assertThat(SecretSourceResolver.resolve(context, "${FOO:-}"), equalTo(""));
+    }
+
+    @Test
+    public void resolve_emptyDefaultEnvDefined() {
+        environment.set("FOO", "foo");
+        assertThat(SecretSourceResolver.resolve(context, "${FOO:-}"), equalTo("foo"));
+    }
+
+    @Test
     public void resolve_defaultValueLimit() {
         assertThat(SecretSourceResolver.resolve(context, "${FOO:-default:-other}"), equalTo("default:-other"));
     }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -10,46 +12,44 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class SecretSourceResolverTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
 
     @Rule
     public final EnvironmentVariables environment = new EnvironmentVariables();
 
+    private static ConfigurationContext context;
+
+    @BeforeClass
+    public static void setup() {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        context = new ConfigurationContext(registry);
+    }
+
     @Test
     public void resolve_singleEntry() {
         environment.set("FOO", "hello");
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO}"), equalTo("hello"));
     }
 
     @Test
     public void resolve_singleEntryWithoutDefaultValue() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO}"), equalTo(""));
     }
 
     @Test
     public void resolve_singleEntryWithDefaultValue() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO:-default}"), equalTo("default"));
     }
 
     @Test
     public void resolve_singleEntryWithDefaultValueAndWithEnvDefined() {
         environment.set("FOO", "hello");
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO:-default}"), equalTo("hello"));
     }
 
     @Test
     public void resolve_singleEntryEscaped() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "^${FOO}"), equalTo("${FOO}"));
     }
 
@@ -57,58 +57,55 @@ public class SecretSourceResolverTest {
     public void resolve_multipleEntries() {
         environment.set("FOO", "hello");
         environment.set("BAR", "world");
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO}:${BAR}"), equalTo("hello:world"));
     }
 
     @Test
     public void resolve_multipleEntriesWithoutDefaultValue() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO}:${BAR}"), equalTo(":"));
     }
 
     @Test
     public void resolve_multipleEntriesWithDefaultValue() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO:-hello}:${BAR:-world}"), equalTo("hello:world"));
     }
 
     @Test
+    public void resolve_multipleEntriesWithDefaultValueAndEnvDefined() {
+        environment.set("FOO", "hello");
+        environment.set("BAR", "world");
+        assertThat(SecretSourceResolver.resolve(context, "${FOO:-default}:${BAR:-default}"), equalTo("hello:world"));
+    }
+
+    @Test
     public void resolve_multipleEntriesEscaped() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "^${FOO}:^${BAR}"), equalTo("${FOO}:${BAR}"));
     }
 
     @Test
     public void resolve_nothing() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "FOO"), equalTo("FOO"));
     }
 
     @Test
     public void resolve_defaultValueLimit() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "${FOO:-default:-other}"), equalTo("default:-other"));
     }
 
     @Test
     public void resolve_mixedSingleEntry() {
         environment.set("FOO", "www.foo.io");
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "http://${FOO}"), equalTo("http://www.foo.io"));
     }
 
     @Test
+    public void resolve_mixedSingleEntryWithDefault() {
+        environment.set("FOO", "www.foo.io");
+        assertThat(SecretSourceResolver.resolve(context, "${protocol:-https}://${FOO:-www.bar.io}"), equalTo("https://www.foo.io"));
+    }
+
+    @Test
     public void resolve_mixedSingleEntryEscaped() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "http://^${FOO}"), equalTo("http://${FOO}"));
     }
 
@@ -116,15 +113,11 @@ public class SecretSourceResolverTest {
     public void resolve_mixedMultipleEntries() {
         environment.set("FOO", "www.foo.io");
         environment.set("BAR", "8080");
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "http://${FOO}:${BAR}"), equalTo("http://www.foo.io:8080"));
     }
 
     @Test
     public void resolve_mixedMultipleEntriesEscaped() {
-        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        ConfigurationContext context = new ConfigurationContext(registry);
         assertThat(SecretSourceResolver.resolve(context, "http://^${FOO}:^${BAR}"), equalTo("http://${FOO}:${BAR}"));
     }
 }


### PR DESCRIPTION
Here is our checklist for contributors. No hard requirement here, just a reminder

- [x] Please describe what you did

- [ ] Link to issue you're working on if there's a relevant one

- [x] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [x] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)

reveal was passed the full `FOO:-default` which is impossible to reveal from environment variables. So we need to split on the handle before passing the captured value to reveal and determining the default value.

Test case provided (which was missed in the initial PR #699) to demonstrate that it was an issue which is now fixed 😄