### PR TITLE
update active directory plugin demo - fixes #740

### DIFF
--- a/demos/active-directory/README.md
+++ b/demos/active-directory/README.md
@@ -4,13 +4,15 @@ Basic configuration of the [Active Directory plugin](https://wiki.jenkins.io/dis
 
 ## sample configuration
 
+For Active Directory Plugin version 2.12 and up:
 ```yaml
 jenkins:
   SecurityRealm:
     activeDirectory:
       groupLookupStrategy: AUTO
       startTls: true
-      tlsConfiguration: TRUST_ALL_CERTIFICATES
       domains:
         - name: "domain.local"
+          servers: "server.acme.com:3128"
+          tlsConfiguration: TRUST_ALL_CERTIFICATES
 ```


### PR DESCRIPTION
Thank you all! I love what this project has made possible!

I updated the YAML example for the Active Directory plugin, which recently moved the tlsConfiguration down to the domain level, as noted in issue #740.

I tested a similar config with a dockerfile like this one:
```dockerfile
FROM jenkinsci/blueocean:1.11.1
RUN install-plugins.sh configuration-as-code:1.6 \
    active-directory:2.12
COPY jenkins.yaml /var/jenkins_home
```