### PR TITLE
Update VaultSecretSource.java

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -65,7 +65,7 @@ public class VaultSecretSource extends SecretSource {
                 }
                 if (vaultEngineVersion != null) {
                     // optionally set vault engine version
-                    config = config.setEngineVersion( Integer.parseInt(vaultEngineVersion) );
+                    config = config.engineVersion( Integer.parseInt(vaultEngineVersion) );
                     LOGGER.log(Level.FINE, "Using engine version: {0}", vaultEngineVersion);
                 }
                 config = config.build();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -65,7 +65,8 @@ public class VaultSecretSource extends SecretSource {
                 }
                 if (vaultEngineVersion != null ) {
                     // optionally set vault engine version
-                    config.setEngineVersion(vaultEngineVersion)
+                    config = config.setEngineVersion(vaultEngineVersion)
+                    LOGGER.log(Level.FINE, "Using engine version: {0}", vaultEngineVersion);
                 }
                 config = config.build();
                 Vault vault = new Vault(config);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -63,9 +63,9 @@ public class VaultSecretSource extends SecretSource {
                     config = config.nameSpace(vaultNamespace);
                     LOGGER.log(Level.FINE, "Using namespace with Vault: {0}", vaultNamespace);
                 }
-                if (vaultEngineVersion != null ) {
+                if (vaultEngineVersion != null) {
                     // optionally set vault engine version
-                    config = config.setEngineVersion(vaultEngineVersion)
+                    config = config.setEngineVersion(vaultEngineVersion);
                     LOGGER.log(Level.FINE, "Using engine version: {0}", vaultEngineVersion);
                 }
                 config = config.build();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -50,6 +50,7 @@ public class VaultSecretSource extends SecretSource {
         String vaultAppRole = getVariable("CASC_VAULT_APPROLE", prop);
         String vaultAppRoleSecret = getVariable("CASC_VAULT_APPROLE_SECRET", prop);
         String vaultNamespace = getVariable("CASC_VAULT_NAMESPACE", prop);
+        String vaultEngineVersion = getVariable("CASC_VAULT_ENGINE_VERSION", prop);
 
         if(((vaultPw != null && vaultUsr != null) || 
             vaultToken != null || 
@@ -61,6 +62,10 @@ public class VaultSecretSource extends SecretSource {
                     // optionally set namespace
                     config = config.nameSpace(vaultNamespace);
                     LOGGER.log(Level.FINE, "Using namespace with Vault: {0}", vaultNamespace);
+                }
+                if (vaultEngineVersion != null ) {
+                    // optionally set vault engine version
+                    config.setEngineVersion(vaultEngineVersion)
                 }
                 config = config.build();
                 Vault vault = new Vault(config);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/VaultSecretSource.java
@@ -65,7 +65,7 @@ public class VaultSecretSource extends SecretSource {
                 }
                 if (vaultEngineVersion != null) {
                     // optionally set vault engine version
-                    config = config.setEngineVersion(vaultEngineVersion);
+                    config = config.setEngineVersion( Integer.parseInt(vaultEngineVersion) );
                     LOGGER.log(Level.FINE, "Using engine version: {0}", vaultEngineVersion);
                 }
                 config = config.build();


### PR DESCRIPTION
Here is our checklist for contributors. No hard requirement here, just a reminder

- [ ] Please describe what you did
Allow user to specify which vault engine version to use. The update "vault-java-driver to 4.0.0" broke all vault reads for users on engine version 1. The new vault-java-driver defaults to version 2, but supports specifying the engine version. https://github.com/jenkinsci/configuration-as-code-plugin/pull/741

- [ ] Link to issue you're working on if there's a relevant one
https://github.com/jenkinsci/configuration-as-code-plugin/issues/746
