### PR TITLE
allowRestart flag added

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -18,6 +18,7 @@ public class ConfigurationContext implements ConfiguratorRegistry {
     private Deprecation deprecation = Deprecation.reject;
     private Restriction restriction = Restriction.reject;
     private Unknown unknown = Unknown.reject;
+    private AllowRestart allowRestart = AllowRestart.restart;
 
     private transient List<Listener> listeners = new ArrayList<>();
 
@@ -43,6 +44,8 @@ public class ConfigurationContext implements ConfiguratorRegistry {
 
     public Unknown getUnknown() { return unknown; }
 
+    public AllowRestart getAllowRestart() { return allowRestart; }
+
     public void setDeprecated(Deprecation deprecation) {
         this.deprecation = deprecation;
     }
@@ -53,6 +56,10 @@ public class ConfigurationContext implements ConfiguratorRegistry {
 
     public void setUnknown(Unknown unknown) {
         this.unknown = unknown;
+    }
+
+    public void setAllowRestart(AllowRestart allowRestart) {
+        this.allowRestart = allowRestart;
     }
 
 
@@ -144,6 +151,11 @@ public class ConfigurationContext implements ConfiguratorRegistry {
      * Policy regarding {@link Deprecated} attributes.
      */
     enum Deprecation { reject, warn }
+
+    /**
+     * Policy regarding automatic restarts .
+     */
+    public enum AllowRestart { restart, safeRestart, noRestart }
 
     @FunctionalInterface
     public interface Listener {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/plugins/PluginManagerConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/plugins/PluginManagerConfigurator.java
@@ -225,7 +225,7 @@ public class PluginManagerConfigurator extends BaseConfigurator<PluginManager> i
             }
             writeShrinkwrapFile(jenkins, shrinkwrap, pluginManager);
 
-            if (requireRestart) {
+            if (requireRestart && context.getAllowRestart() != ConfigurationContext.AllowRestart.noRestart) {
                 try {
                     jenkins.restart();
                 } catch (RestartNotSupportedException e) {


### PR DESCRIPTION
Here is our checklist for contributors. No hard requirement here, just a reminder

- [x] Please describe what you did

added an `allowRestart` flag as an option to set under `configuration-as-code` root element.

flag is being set but accessing it in PluginManagerConfigurator required making AllowRestart enum in ConfigurationContext to public - not sure if that's the right way... @casz @timja care to comment?
The flag might be needed in more places, this is work in progress, just wanted to get some feedback

- [x] Link to issue you're working on if there's a relevant one
#744 

- [ ] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?
not yet

- [ ] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
