### PR TITLE
Updated demo for the new Structure in Warnings Next Gen

### DIFF
--- a/demos/warnings/README.md
+++ b/demos/warnings/README.md
@@ -1,28 +1,30 @@
 # warnings-plugin
 
-Supported in plugin **version >= 4.66**
+Supported in plugin **version >= 5.00**
+
+Now present in the new `Groovy Based Warnings Parsers` section.
 
 ## sample-configuration (Example parser from help)
 
 ```yaml
-jenkins: 
-  [...]
 unclassified:
-  warnings:
+  warningsParsers:
     parsers:
       - name: "Example parser"
-        linkName: "Example parser link"
-        trendName: "Example parser trend name"
+        id: example-id
         regexp: "^\\s*(.*):(\\d+):(.*):\\s*(.*)$"
         script: |
-          import hudson.plugins.warnings.parser.Warning
-          String fileName = matcher.group(1)
-          String lineNumber = matcher.group(2)
-          String category = matcher.group(3)
-          String message = matcher.group(4)
-          return new Warning(fileName, Integer.parseInt(lineNumber), "Dynamic Parser", category, message);
+          import edu.hm.hafner.analysis.Severity
+          builder.setFileName(matcher.group(1))
+                  .setLineStart(Integer.parseInt(matcher.group(2)))
+                  .setSeverity(Severity.WARNING_NORMAL)
+                  .setCategory(matcher.group(3))
+                  .setMessage(matcher.group(4))
+          return builder.buildOptional();
         example: "somefile.txt:2:SeriousWarnings:SomethingWentWrong"
 ```
+
+
 
 
 


### PR DESCRIPTION
Updated the demo section for the warnings parser. The current example is outdated and logic has since been moved the the Next Generation Warnings Plugin. I've updated the demo to work with the latest version.

No code changes aside from that.