### PR TITLE
Missing "$" added to reference keyword in schema.

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/Attribute/schema.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/Attribute/schema.jelly
@@ -38,7 +38,7 @@
       </j:case>
       <j:default>
         "type":  "object",
-        "ref": "#/definitions/${it.type.name}"
+        "$ref": "#/definitions/${it.type.name}"
       </j:default>
     </j:switch>
   </j:otherwise>


### PR DESCRIPTION
#760 According to https://json-schema.org/latest/json-schema-core.html#rfc.section.8.3 the reference keyword starts with an "$".
