### PR TITLE
Remove 2 second sleep in vault test

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/casc/vault/VaultSecretSourceTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/vault/VaultSecretSourceTest.java
@@ -202,9 +202,6 @@ public class VaultSecretSourceTest {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("auth-test"));
 
         try {
-            // Wait for auth token to become stale
-            Thread.sleep(2000);
-
             // Update secret
             runCommand(vaultContainer, "vault", "kv", "put", VAULT_PATH_KV2_AUTH_TEST,
                 "key1=re-auth-test");

--- a/plugin/src/test/java/io/jenkins/plugins/casc/vault/VaultTestUtil.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/vault/VaultTestUtil.java
@@ -80,7 +80,7 @@ class VaultTestUtil {
             // Create AppRole
             runCommand(container, "vault", "auth", "enable", "approle");
             runCommand(container, "vault", "write", "auth/approle/role/admin",
-                "secret_id_ttl=10m", "token_num_uses=0", "token_ttl=4s", "token_max_ttl=4s",
+                "secret_id_ttl=10m", "token_num_uses=0", "token_ttl=50ms", "token_max_ttl=50ms",
                 "secret_id_num_uses=1000", "policies=admin");
 
             // Retrieve AppRole credentials


### PR DESCRIPTION
Removing a hard thread sleep.

Dat branch naming :rofl: `casz:NoSleepWhenVaulting`
![Vaulting](https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/Belgian_Warmblood_Vaulting_Horse.jpg/362px-Belgian_Warmblood_Vaulting_Horse.jpg)