### PR TITLE
Support encrypted passwords for local security realm

### DIFF
--- a/demos/role-strategy-auth/role-strategy-auth.yaml
+++ b/demos/role-strategy-auth/role-strategy-auth.yaml
@@ -53,6 +53,9 @@ jenkins:
           password: "1234"
         - id: "user1"
           password: ""
+        - id: "user_hashed"
+          # password is password
+          password: "#jbcrypt:$2a$10$3bnAsorIxhl9kTYvNHa2hOJQwPzwT4bv9Vs.9KdXkh9ySANjJKm5u"
 
   nodes:
     - dumb:

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
@@ -3,14 +3,20 @@ package io.jenkins.plugins.casc.core;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.util.VersionNumber;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
+import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -18,7 +24,11 @@ import java.util.stream.Collectors;
  */
 @Extension
 @Restricted(NoExternalUse.class)
-public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurator {
+public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurator<HudsonPrivateSecurityRealm> {
+    private static final Logger logger = Logger.getLogger(HudsonPrivateSecurityRealmConfigurator.class.getName());
+    private static final VersionNumber MIN_VERSION_FOR_HASHED_PASSWORDS = new VersionNumber("2.161");
+    /// matches HudsonPrivateSecurityRealm.JBCRYPT_HEADER
+    private static final String HASHED_PASSWORD_PREFIX = "#jbcrypt:";
 
     public HudsonPrivateSecurityRealmConfigurator() {
         super(HudsonPrivateSecurityRealm.class);
@@ -26,20 +36,45 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
 
     @NonNull
     @Override
-    public Set<Attribute> describe() {
-        final Set<Attribute> describe = super.describe();
+    public Set<Attribute<HudsonPrivateSecurityRealm, ?>> describe() {
+        final Set<Attribute<HudsonPrivateSecurityRealm, ?>> describe = super.describe();
         describe.add(new MultivaluedAttribute<HudsonPrivateSecurityRealm, UserWithPassword>("users", UserWithPassword.class)
-            .getter(target ->
-                target.getAllUsers().stream()
-                    .map(u -> new UserWithPassword(u.getId(), null))    // password isn't actually stored, only hashed
-                    .collect(Collectors.toList()))
-            .setter((target, value) -> {
-                for (UserWithPassword user : value) {
+            .getter(HudsonPrivateSecurityRealmConfigurator::getter)
+            .setter(HudsonPrivateSecurityRealmConfigurator::setter)
+        );
+        return describe;
+    }
+
+    private static Collection<UserWithPassword> getter(HudsonPrivateSecurityRealm target) {
+        return target.getAllUsers().stream()
+                .map(u -> new UserWithPassword(u.getId(), null)) // password isn't actually stored, only hashed
+                .collect(Collectors.toList());
+    }
+
+    private static void setter(HudsonPrivateSecurityRealm target, Collection<UserWithPassword> value) throws IOException {
+        for (UserWithPassword user : value) {
+            if (user.password.startsWith(HASHED_PASSWORD_PREFIX) && jenkinsSupportsHashedPasswords()) {
+                try {
+                    target.createAccountWithHashedPassword(user.id, user.password);
+                } catch (IllegalArgumentException e) {
+                    logger.log(Level.WARNING, "Failed to create user with presumed hashed password", e);
+                    // fallback, just create the account as is
                     target.createAccount(user.id, user.password);
                 }
+            } else {
+                target.createAccount(user.id, user.password);
             }
-        ));
-        return describe;
+        }
+    }
+
+    static boolean jenkinsSupportsHashedPasswords() {
+        VersionNumber currentVersion = Jenkins.getVersion();
+        if (currentVersion == null) {
+            logger.log(Level.WARNING,
+                    "Could not retrieve current version for Jenkins server. Is everything configured correctly?");
+            return false;
+        }
+        return !currentVersion.isOlderThan(MIN_VERSION_FOR_HASHED_PASSWORDS);
     }
 
     public static class UserWithPassword {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
@@ -58,7 +58,6 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
             if (user.password.startsWith(HASHED_PASSWORD_PREFIX) && jenkinsSupportsHashedPasswords()) {
                 try {
                     createAccount(target, user);
-                    target.createAccountWithHashedPassword(user.id, user.password);
                 } catch (IllegalArgumentException e) {
                     logger.log(Level.WARNING, "Failed to create user with presumed hashed password", e);
                     // fallback, just create the account as is
@@ -79,7 +78,9 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
      *        The user to construct
      */
     private static void createAccount(HudsonPrivateSecurityRealm target, UserWithPassword user) {
+        // TODO remove reflection once we target 2.161+
         try {
+            @SuppressWarnings("JavaReflectionMemberAccess") // available from 2.161+
             Method createAccountWithHashedPassword = HudsonPrivateSecurityRealm.class.getDeclaredMethod(
                     "createAccountWithHashedPassword", String.class, String.class);
             createAccountWithHashedPassword.invoke(target, user.id, user.password);

--- a/plugin/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.java
@@ -45,4 +45,16 @@ public class HudsonPrivateSecurityRealmConfiguratorTest {
         final Mapping user = node.asMapping().get("users").asSequence().get(0).asMapping();
         assertEquals("admin", user.getScalarValue("id"));
     }
+
+    @Test
+    @ConfiguredWithCode("HudsonPrivateSecurityRealmConfiguratorTest.yml")
+    public void config_local_security_and_hashed_admin_user() {
+        Assume.assumeTrue(HudsonPrivateSecurityRealmConfigurator.jenkinsSupportsHashedPasswords());
+
+        final User admin = User.getById("hashedadmin", false);
+        assertNotNull(admin);
+        final HudsonPrivateSecurityRealm.Details details = admin.getProperty(HudsonPrivateSecurityRealm.Details.class);
+        assertTrue(details.isPasswordCorrect("password"));
+    }
+
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import jenkins.model.Jenkins;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest.yml
@@ -5,4 +5,7 @@ jenkins:
       users:
         - id: "admin"
           password: "1234"
+        - id: "hashedadmin"
+          # password is 'password'
+          password: "#jbcrypt:$2a$10$LP4bMhwyCPnsDm.XRcTZSuBqWYKGAiDAsQXrSrJGYcEd9padaPgsC"
   authorizationStrategy: loggedInUsersCanDoAnything


### PR DESCRIPTION
This commit bumps the Jenkins supported version to 2.164
which is the first version that includes the necessary API
hooks for using bcrypted passwords.

Fixes #713:

This is the upstream Jenkins PR where this was made part of the core product: jenkinsci/jenkins#3817

- [X] Please describe what you did

- [X] Link to issue you're working on if there's a relevant one

- [X] Did you provide a test-case to demonstrate feature actually works / issue is fixed ?

- [X] Please also consider adding a line to [CHANGELOG.md](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/CHANGELOG.md)
