### PR TITLE
add Release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+name-template: v$NEXT_MINOR_VERSION 🌈
+tag-template: configuration-as-code-$NEXT_MINOR_VERSION
+categories:
+  - title: 🚀 Features
+    label: feature
+  - title: 🐛 Bug Fixes
+    label: fix
+  - title: 👻 Maintenance
+    label: chore
+  - title: 📝 Documentation updates
+    label: documentation
+  - title: 🚦 Tests
+    label: test
+
+change-template: '- $TITLE (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
Here is our checklist for contributors. No hard requirement here, just a reminder

- [x] Please describe what you did

Since we already use PR squashing in most cases we can easily introduce [release-drafter](https://github.com/toolmantim/release-drafter) to manage our changelog.

~Do not merge before everything is moved over to releases tabs~ :smile: 

~I will create a separate PR with all the changelog moved to GitHub releases.~
