### PR TITLE
chore: Update dashboard links to only show open issues

### DIFF
--- a/COMPATIBILITY.adoc
+++ b/COMPATIBILITY.adoc
@@ -4,7 +4,7 @@ This document captures the ongoing status of plugins known to be compatible or i
 
 Because of how the tool was designed, plugins _should_ be expected to work out of the box if they followed the main patterns in place.
 
-There is a list of already known issues in the Jenkins issue tracker, tracked through using the label `jcasc-incompatible` (link:https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=17346[see dashboard]).
+There is a list of already known issues in the Jenkins issue tracker, tracked through using the label `jcasc-incompatible` (link:https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=18341[see dashboard]).
 
 This document is an *ongoing* community effort.
 Hence a missing plugin here and has no existing issue filed in JIRA (see above) does not _necessarily_ mean it won't work.

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Kubernetes users:
 
 ## Supported Plugins
 
-Most plugins should be supported out-of-the-box, or maybe require some minimal changes. See this [dashboard](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=17346) for known compatibility issues.
+Most plugins should be supported out-of-the-box, or maybe require some minimal changes. See this [dashboard](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=18341) for known compatibility issues.
 
 ## Jenkins Enhancement Proposal
 


### PR DESCRIPTION
Change dashboard link to only be open issues,
The all issues one is useful too but not sure if its worth keeping there?

If I'm looking for issues, its normally just the open ones