### PR TITLE
Include only needed classes in test jar

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -70,9 +70,9 @@
               <goal>test-jar</goal>
             </goals>
             <configuration>
-              <excludes>
-                <exclude>test-dependencies/index</exclude>
-              </excludes>
+              <includes>
+                <include>io/jenkins/plugins/casc/misc/**</include>
+              </includes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- Include only needed classes in `tests` artifact.
I have tried to move it to `src` but all this classes have references to `junit` internal classes so its not that easy.
If keeping it working will be hard in future than maybe extra subjects could be added just for those classes.

- Fixes #798 

Tested it externally on Google compute plugin.
Any idea how to test it locally?
