### PR TITLE
exclude original snakeyaml from plugin

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -22,6 +22,12 @@
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!--TODO: This should be in a separate plugin at some point -->


### PR DESCRIPTION
### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

fixes #413 
https://github.com/jenkins-infra/update-center2/pull/263

The org.yaml.snakeyaml jar does not get adequately excluded by maven-shade-plugin

![image](https://user-images.githubusercontent.com/1661688/55422696-865c1c80-557c-11e9-8329-9d73a00d1bc7.png)
