### PR TITLE
Allow loading of a single file in a hidden folder

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -551,7 +551,6 @@ public class ConfigurationAsCode extends ManagementLink {
      * @return list of all paths matching pattern. Only base file itself if it is a file matching pattern
      */
     public List<Path> configs(String path) throws ConfiguratorException {
-        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(YAML_FILES_PATTERN);
         final Path root = Paths.get(path);
 
         if (!Files.exists(root)) {
@@ -562,6 +561,7 @@ public class ConfigurationAsCode extends ManagementLink {
             return Collections.singletonList(root);
         }
 
+        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(YAML_FILES_PATTERN);
         try (Stream<Path> stream = Files.find(Paths.get(path), Integer.MAX_VALUE,
                 (next, attrs) -> !attrs.isDirectory() && !isHidden(next) && matcher.matches(next))) {
             return stream.collect(toList());

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -557,7 +557,7 @@ public class ConfigurationAsCode extends ManagementLink {
             throw new ConfiguratorException("Invalid configuration: '"+path+"' isn't a valid path.");
         }
 
-        if (Files.isRegularFile(root)) {
+        if (Files.isRegularFile(root) && Files.isReadable(root)) {
             return Collections.singletonList(root);
         }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -558,6 +558,10 @@ public class ConfigurationAsCode extends ManagementLink {
             throw new ConfiguratorException("Invalid configuration: '"+path+"' isn't a valid path.");
         }
 
+        if (Files.isRegularFile(root)) {
+            return Collections.singletonList(root);
+        }
+
         try (Stream<Path> stream = Files.find(Paths.get(path), Integer.MAX_VALUE,
                 (next, attrs) -> !attrs.isDirectory() && !isHidden(next) && matcher.matches(next))) {
             return stream.collect(toList());

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.casc;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.google.common.io.Resources;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -17,7 +17,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -3,19 +3,22 @@ package io.jenkins.plugins.casc;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.google.common.io.Resources;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -61,6 +64,21 @@ public class ConfigurationAsCodeTest {
         assertThat(casc.configs(exactFile.getAbsolutePath()), hasSize(1));
         final List<Path> foo = casc.configs(tempFolder.getRoot().getAbsolutePath());
         assertThat(foo, hasSize(6));
+    }
+
+    @Test
+    public void test_loads_single_file_from_hidden_folder() throws Exception {
+        ConfigurationAsCode casc = ConfigurationAsCode.get();
+
+        File hiddenFolder = tempFolder.newFolder(".nested");
+        File singleFile = new File(hiddenFolder, "jenkins.yml");
+        try (InputStream configStream = getClass().getResourceAsStream("JenkinsConfigTest.yml")) {
+            Files.copy(configStream, singleFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        casc.configure(singleFile.getAbsolutePath());
+        assertThat(casc.getSources(), contains(singleFile.getAbsolutePath()));
+        assertThat(j.jenkins.getSystemMessage(), equalTo("configuration as code - JenkinsConfigTest"));
     }
 
     @Test(expected = ConfiguratorException.class)


### PR DESCRIPTION
If you specify a single regular file as the configuration source,
you can skip the recursive searching and just return the file
as is.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [X] Please describe what you did

- [X] Link to relevant GitHub issues or pull requests

- [X] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Fix #833. Ensure that you can specify a single file for configuration if it happens to exist in a hidden folder.

If you specify a single regular file as the configuration source,
you can skip the recursive searching and just return the file
as is.
