### PR TITLE
Sort the configuration files for ordered loading of config

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -581,7 +581,7 @@ public class ConfigurationAsCode extends ManagementLink {
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(YAML_FILES_PATTERN);
         try (Stream<Path> stream = Files.find(Paths.get(path), Integer.MAX_VALUE,
                 (next, attrs) -> !attrs.isDirectory() && !isHidden(next) && matcher.matches(next))) {
-            return stream.collect(toList());
+            return stream.sorted().collect(toList());
         } catch (IOException e) {
             throw new IllegalStateException("failed config scan for " + path, e);
         }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class ConfigurationAsCodeTest {
 
@@ -70,6 +71,23 @@ public class ConfigurationAsCodeTest {
         assertThat(casc.configs(exactFile.getAbsolutePath()), hasSize(1));
         final List<Path> foo = casc.configs(tempFolder.getRoot().getAbsolutePath());
         assertThat(foo, hasSize(6));
+    }
+
+    @Test
+    public void test_ordered_config_loading() throws Exception {
+        ConfigurationAsCode casc = new ConfigurationAsCode();
+
+        tempFolder.newFile("0.yaml");
+        tempFolder.newFile("1.yaml");
+        tempFolder.newFile("a.yaml");
+        tempFolder.newFile("z.yaml");
+
+        final List<Path> foo = casc.configs(tempFolder.getRoot().getAbsolutePath());
+        assertThat(foo, hasSize(4));
+        assertTrue(foo.get(0).endsWith("0.yaml"));
+        assertTrue(foo.get(1).endsWith("1.yaml"));
+        assertTrue(foo.get(2).endsWith("a.yaml"));
+        assertTrue(foo.get(3).endsWith("z.yaml"));
     }
 
     @Test


### PR DESCRIPTION
Fixes: #824

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

fixes #824

Currently config is loaded unordered, which means depending on filesystem you'd get unpredictable behaviour. Just sorting the config before returning it as a list seems sufficient. 

I've tested manually through installing the plugin on a jenkins backed by EXT4 and observing the config loads in a predictable order.
