### PR TITLE
use `VersionConverter` instead of lambda

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -6,8 +6,7 @@ import io.jenkins.plugins.casc.model.CNode;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.beanutils.Converter;
-import org.kohsuke.stapler.Stapler;
+    import org.kohsuke.stapler.Stapler;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -6,7 +6,7 @@ import io.jenkins.plugins.casc.model.CNode;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
-    import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.Stapler;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -6,6 +6,7 @@ import io.jenkins.plugins.casc.model.CNode;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.beanutils.Converter;
 import org.kohsuke.stapler.Stapler;
 
 /**
@@ -126,7 +127,7 @@ public class ConfigurationContext implements ConfiguratorRegistry {
     }
 
     static {
-        Stapler.CONVERT_UTILS.register((type, value) -> Version.of(value.toString()), Version.class);
+        Stapler.CONVERT_UTILS.register(new VersionConverter(), Version.class);
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/casc/VersionConverter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/VersionConverter.java
@@ -1,0 +1,12 @@
+package io.jenkins.plugins.casc;
+
+import io.jenkins.plugins.casc.ConfigurationContext.Version;
+import org.apache.commons.beanutils.Converter;
+
+public class VersionConverter implements Converter {
+
+    @Override
+    public Version convert(Class type, Object value) {
+        return Version.of(value.toString());
+    }
+}


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [ ] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Java complains that target method is generic and cannot compile.
Seems EnumConverter already exist so let's use that.
```java
Stapler.CONVERT_UTILS.register((type, value) -> Version.of(value.toString()), Version.class);
```
