### PR TITLE
prefer environment variable over global config for config file path

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -297,7 +297,8 @@ public class ConfigurationAsCode extends ManagementLink {
                 System.getenv(CASC_JENKINS_CONFIG_ENV)
         );
 
-        if (!StringUtils.isBlank(cascPath)) {
+        // We prefer to rely on environment variable over global config
+        if (StringUtils.isNotBlank(cascPath) && StringUtils.isBlank(configParameter)) {
             configParameter = cascPath;
         }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -15,7 +15,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
-import org.hamcrest.core.Is;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -177,10 +176,10 @@ public class ConfigurationAsCodeTest {
         assertNotNull(descriptor);
         descriptor.setConfigurationPath(firstConfig);
         ConfigurationAsCode.get().configure();
-        Assert.assertThat(j.jenkins.getDescription(), Is.is("configuration as code - JenkinsConfigTest"));
+        Assert.assertThat(j.jenkins.getDescription(), is("configuration as code - JenkinsConfigTest"));
         System.setProperty(CASC_JENKINS_CONFIG_PROPERTY, secondConfig);
         ConfigurationAsCode.get().configure();
-        Assert.assertThat(j.jenkins.getDescription(), Is.is("Configured by Configuration as Code plugin"));
+        Assert.assertThat(j.jenkins.getDescription(), is("Configured by Configuration as Code plugin"));
         System.clearProperty(CASC_JENKINS_CONFIG_PROPERTY);
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -181,5 +181,6 @@ public class ConfigurationAsCodeTest {
         System.setProperty(CASC_JENKINS_CONFIG_PROPERTY, secondConfig);
         ConfigurationAsCode.get().configure();
         Assert.assertThat(j.jenkins.getDescription(), Is.is("Configured by Configuration as Code plugin"));
+        System.clearProperty(CASC_JENKINS_CONFIG_PROPERTY);
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -15,12 +15,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import org.hamcrest.core.Is;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import static com.gargoylesoftware.htmlunit.HttpMethod.POST;
+import static io.jenkins.plugins.casc.ConfigurationAsCode.CASC_JENKINS_CONFIG_PROPERTY;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -162,5 +166,20 @@ public class ConfigurationAsCodeTest {
         WebClient loggedInClient = client.login(user, user);
         response = loggedInClient.loadWebResponse(request);
         assertThat(response.getStatusCode(), is(200));
+    }
+
+    @Test
+    @Issue("Issue #739")
+    public void preferEnvOverGlobalConfigForConfigPath() throws Exception {
+        String firstConfig = getClass().getResource("JenkinsConfigTest.yml").toExternalForm();
+        String secondConfig = getClass().getResource("merge3.yml").toExternalForm();
+        CasCGlobalConfig descriptor = (CasCGlobalConfig) j.jenkins.getDescriptor(CasCGlobalConfig.class);
+        assertNotNull(descriptor);
+        descriptor.setConfigurationPath(firstConfig);
+        ConfigurationAsCode.get().configure();
+        Assert.assertThat(j.jenkins.getDescription(), Is.is("configuration as code - JenkinsConfigTest"));
+        System.setProperty(CASC_JENKINS_CONFIG_PROPERTY, secondConfig);
+        ConfigurationAsCode.get().configure();
+        Assert.assertThat(j.jenkins.getDescription(), Is.is("Configured by Configuration as Code plugin"));
     }
 }


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [na] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Fixes #739 we prefer environment variable over global config, for most use cases this is the desired behavior.