### PR TITLE
Ignore setters which rely on Maps

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -102,6 +102,12 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
 
             LOGGER.log(Level.FINER, "Processing {0} property", name);
 
+            if (Map.class.isAssignableFrom(type.rawType)) {
+                // yaml has support for Maps, but as nobody seem to like them we agreed not to support them
+                LOGGER.log(Level.FINER, "{0} is a Map<?,?>. We decided not to support Maps.", name);
+                continue;
+            }
+
             Attribute attribute = createAttribute(name, type);
             if (attribute == null) continue;
 


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

### Description


This is a potential fix for https://github.com/jenkinsci/configuration-as-code-plugin/issues/536
As we do not support yaml Maps (by decision, initial prototype did, but nobody seems to like them) we should just exclude fields/setter which rely on Maps, and at most log a debug message for it