### PR TITLE
Prevent null pointer when non-first yml file is empty.

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
@@ -36,7 +36,9 @@ public final class YamlUtils {
                 if (root == null) {
                     root = node;
                 } else {
-                    merge(root, node, source.toString());
+                    if (node != null) {
+                        merge(root, node, source.toString());
+                    }
                 }
             } catch (IOException io) {
                 throw new ConfiguratorException("Failed to read " + source, io);

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -186,6 +186,7 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode(value = {"aNonEmpty.yml", "empty.yml"}) //file names matter for order!
     public void test_non_first_yaml_file_empty() {
+        assertEquals("Configured by Configuration as Code plugin", j.jenkins.getSystemMessage());
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -182,4 +182,9 @@ public class ConfigurationAsCodeTest {
         Assert.assertThat(j.jenkins.getDescription(), is("Configured by Configuration as Code plugin"));
         System.clearProperty(CASC_JENKINS_CONFIG_PROPERTY);
     }
+
+    @Test
+    @ConfiguredWithCode(value = {"aNonEmpty.yml", "empty.yml"}) //file names matter for order!
+    public void test_non_first_yaml_file_empty() {
+    }
 }

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/aNonEmpty.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/aNonEmpty.yml
@@ -1,0 +1,2 @@
+jenkins:
+  systemMessage: "Configured by Configuration as Code plugin"


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [n/a] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Prevent NPE when loading the configuration from a folder where an empty file follows a non-empty one.
(This is a completion for #548, since it looks like 977b0b213f4f58b4facd50b6b1dfda1dab77f5fa was not quite enough.)
