### PR TITLE
Do not fail Windows-style path validation.

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -41,6 +41,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
@@ -530,8 +531,13 @@ public class ConfigurationAsCode extends ManagementLink {
             return false;
         }
         final List<String> supportedProtocols = Arrays.asList("https","http","file");
-        URI uri = URI.create(configurationParameter);
-        if(uri == null || uri.getScheme() == null) {
+        URI uri;
+        try {
+            uri = new URI(configurationParameter);
+        } catch (URISyntaxException ex) {
+            return false;
+        }
+        if(uri.getScheme() == null) {
             return false;
         }
         return supportedProtocols.contains(uri.getScheme());

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -187,6 +187,6 @@ public class ConfigurationAsCodeTest {
     @Issue("Issue #914")
     public void isSupportedURI_should_not_throw_on_invalid_uri() {
         //for example, a Windows path is not a valid URI
-        ConfigurationAsCode.isSupportedURI("C:\\jenkins\\casc");
+        assertThat(ConfigurationAsCode.isSupportedURI("C:\\jenkins\\casc"), is(false));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -182,4 +182,11 @@ public class ConfigurationAsCodeTest {
         Assert.assertThat(j.jenkins.getDescription(), is("Configured by Configuration as Code plugin"));
         System.clearProperty(CASC_JENKINS_CONFIG_PROPERTY);
     }
+
+    @Test
+    @Issue("Issue #914")
+    public void isSupportedURI_should_not_throw_on_invalid_uri() {
+        //for example, a Windows path is not a valid URI
+        ConfigurationAsCode.isSupportedURI("C:\\jenkins\\casc");
+    }
 }


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [n/a] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Apparently, #914 happens because the plugin always tries to parse any given configuration path as a URI. This works fine for unix paths, because those also happen to be syntactically correct URIs. For Windows paths however, an exception is thrown.

This PR makes the URI validation fail more gracefully, resolving #914.
