### PR TITLE
[ad-hoc] EC2 Plugin v1.42 parameters deprecated 

### DIFF
--- a/demos/ec2/README.md
+++ b/demos/ec2/README.md
@@ -12,6 +12,10 @@ jenkins:
         credentialsId: "jenkins-aws"
         privateKey: "${EC2_PRIVATE_KEY}"
         region: "eu-central-1"
+        instanceCapStr: ""
+        roleArn: ""
+        roleSessionName: ""
+        noDelayProvisioning: true        
         useInstanceProfileForCredentials: false
         templates:
           - ami: "ami-xyz"
@@ -20,12 +24,13 @@ jenkins:
                 sshPort: "22"
             associatePublicIp: false
             connectBySSHProcess: false
-            connectUsingPublicIp: false
+            connectionStrategy: PRIVATE_IP
             deleteRootOnTermination: false
             description: "docker"
             ebsOptimized: false
             idleTerminationMinutes: "10"
             labelString: "docker ubuntu linux"
+            maxTotalUses: -1
             mode: NORMAL
             monitoring: false
             numExecutors: 1
@@ -35,5 +40,4 @@ jenkins:
             type: T2Micro
             useDedicatedTenancy: false
             useEphemeralDevices: false
-            usePrivateDnsName: false
 ```


### PR DESCRIPTION
- *Plugin version:* 1.20
- *Jenkins version:* 2.164.3
- *OS:* Alpine

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

EC2 Plugin 1.43 version deprecated couple of parameters. Previous example will fail on validation.

- Updated example with correct parameters. 
