### PR TITLE
[JENKINS-57928] Allow configuring JMH benchmarks using CASC

### DIFF
--- a/docs/benchmarks/jmh-benchmarks.md
+++ b/docs/benchmarks/jmh-benchmarks.md
@@ -1,23 +1,38 @@
 # JMH benchmarks with Configuration-as-Code
 
 You can configure the instance that is started for benchmarks using Configuration as Code by extending
-`CascJmhBenchmarkState` in your benchmarks instead of `JmhBenchmarkState` and overriding the `getResourcePath()` method and returning the path to where your YAML configuration is located.
+`CascJmhBenchmarkState` in your benchmarks instead of `JmhBenchmarkState` and overriding the `getResourcePath()` and
+`getEnclosingClass()` methods.
+
+`getResourcePath()` should returning the path to where your YAML configuration is located.
+`getEnclosingClass()` should return the class containing the state for the benchmark (`MyBenchmark` in the example below).
 
 ## Example
 
 Just like regular JMH benchmarks using `JmhBenchmarkState`, you need to have a `public static` inner class:
 
 ```java
-public static class MyState extends CascJmhBenchmarkState {
-    @Nonnull
-    @Override
-    protected String getResourcePath() {
-        return "path/to/config.yaml";
+@JmhBenchmark
+public class MyBenchmark {
+    public static class MyState extends CascJmhBenchmarkState {
+        @Nonnull
+        @Override
+        protected String getResourcePath() {
+            return "config.yaml";
+        }
+    
+        @Nonnull
+        @Override
+        protected Class<?> getEnclosingClass() {
+            return MyBenchmark.class;
+        }
     }
+    
+    // ...
 }
 ```
 
 If you override the `setup()` method of `CascJmhBenchmarkState`, make sure to call `super.setup()` so 
 that configuration as code works as intended.
 
-You can find more examples in the [Role Strategy Plugin](https://github.com/jenkinsci/role-strategy-plugin/tree/master/src/test/java/jmh/casc).
+You can find more examples in the [Role Strategy Plugin](https://github.com/jenkinsci/role-strategy-plugin/tree/master/src/test/java/jmh).

--- a/docs/benchmarks/jmh-benchmarks.md
+++ b/docs/benchmarks/jmh-benchmarks.md
@@ -1,0 +1,23 @@
+# JMH benchmarks with Configuration-as-Code
+
+You can configure the instance that is started for benchmarks using Configuration as Code by extending
+`CascJmhBenchmarkState` in your benchmarks instead of `JmhBenchmarkState` and overriding the `getResourcePath()` method and returning the path to where your YAML configuration is located.
+
+## Example
+
+Just like regular JMH benchmarks using `JmhBenchmarkState`, you need to have a `public static` inner class:
+
+```java
+public static class MyState extends CascJmhBenchmarkState {
+    @Nonnull
+    @Override
+    protected String getResourcePath() {
+        return "path/to/config.yaml";
+    }
+}
+```
+
+If you override the `setup()` method of `CascJmhBenchmarkState`, make sure to call `super.setup()` so 
+that configuration as code works as intended.
+
+You can find more examples in the [Role Strategy Plugin](https://github.com/jenkinsci/role-strategy-plugin/tree/master/src/test/java/jmh/casc).

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -69,12 +69,6 @@
       <version>1.10.6</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
-      <version>2.50-rc1168.d591189fccf7</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -70,6 +70,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness</artifactId>
+      <version>2.50-rc1168.d591189fccf7</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -40,9 +40,8 @@ public class CascJmhBenchmarkStateTest {
                         .shouldFailOnError(true)
                         .result(reportPath)
                         .timeUnit(TimeUnit.MICROSECONDS)
-                        .resultFormat(ResultFormatType.JSON);
-        BenchmarkFinder finder = new BenchmarkFinder(this.getClass().getPackage().getName());
-        finder.findBenchmarks(optionsBuilder);
+                        .resultFormat(ResultFormatType.JSON);;
+        BenchmarkFinder.findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();
 
         assertTrue(Files.exists(Paths.get(reportPath)));

--- a/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import jenkins.benchmark.jmh.BenchmarkFinder;
 import org.junit.Test;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -41,7 +41,7 @@ public class CascJmhBenchmarkStateTest {
                         .result(reportPath)
                         .timeUnit(TimeUnit.MICROSECONDS)
                         .resultFormat(ResultFormatType.JSON);
-        BenchmarkFinder.findBenchmarks(optionsBuilder);
+        new BenchmarkFinder(getClass()).findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();
 
         assertTrue(Files.exists(Paths.get(reportPath)));

--- a/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -1,41 +1,50 @@
 package io.jenkins.plugins.casc;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import jenkins.benchmark.jmh.BenchmarkFinder;
+import org.junit.Before;
 import org.junit.Test;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import static junit.framework.TestCase.assertTrue;
+
 /**
  * Runs sample benchmarks from JUnit tests.
  */
 public class CascJmhBenchmarkStateTest {
+    private static final String reportPath = "target/jmh-reports/jmh-benchmark-report.json";
+
+    @Before
+    public void createDirectoryForBenchmarkReport() throws IOException {
+        Path directory = Paths.get("target/jmh-reports/");
+        Files.createDirectories(directory);
+    }
+
     @Test
     public void testJmhBenchmarks() throws Exception {
-        // create directory for JMH reports
-        Path path = Paths.get("target/jmh-reports/");
-        Files.createDirectories(path);
-
         // number of iterations is kept to a minimum just to verify that the benchmarks work without spending extra
         // time during builds.
         ChainedOptionsBuilder optionsBuilder =
                 new OptionsBuilder()
                         .forks(1)
-                        .warmupIterations(1)
-                        .warmupBatchSize(1)
-                        .measurementIterations(1)
+                        .warmupIterations(0)
                         .measurementBatchSize(1)
+                        .measurementIterations(1)
                         .shouldFailOnError(true)
-                        .result("target/jmh-reports/jmh-benchmark-report.json")
+                        .result(reportPath)
                         .timeUnit(TimeUnit.MICROSECONDS)
                         .resultFormat(ResultFormatType.JSON);
         BenchmarkFinder finder = new BenchmarkFinder(this.getClass().getPackage().getName());
         finder.findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();
+
+        assertTrue(Files.exists(Paths.get(reportPath)));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -40,7 +40,7 @@ public class CascJmhBenchmarkStateTest {
                         .shouldFailOnError(true)
                         .result(reportPath)
                         .timeUnit(TimeUnit.MICROSECONDS)
-                        .resultFormat(ResultFormatType.JSON);;
+                        .resultFormat(ResultFormatType.JSON);
         BenchmarkFinder.findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -1,4 +1,4 @@
-package jenkins.benchmark.jmh;
+package io.jenkins.plugins.casc;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -1,0 +1,40 @@
+package jenkins.benchmark.jmh;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Runs sample benchmarks from JUnit tests.
+ */
+public class CascJmhBenchmarkStateTest {
+    @Test
+    public void testJmhBenchmarks() throws Exception {
+        // create directory for JMH reports
+        Path path = Paths.get("target/jmh-reports/");
+        Files.createDirectories(path);
+
+        // number of iterations is kept to a minimum just to verify that the benchmarks work without spending extra
+        // time during builds.
+        ChainedOptionsBuilder optionsBuilder =
+                new OptionsBuilder()
+                        .forks(1)
+                        .warmupIterations(1)
+                        .warmupBatchSize(1)
+                        .measurementIterations(1)
+                        .measurementBatchSize(1)
+                        .shouldFailOnError(true)
+                        .result("target/jmh-reports/jmh-benchmark-report.json")
+                        .timeUnit(TimeUnit.MICROSECONDS)
+                        .resultFormat(ResultFormatType.JSON);
+        BenchmarkFinder finder = new BenchmarkFinder(this.getClass().getPackage().getName());
+        finder.findBenchmarks(optionsBuilder);
+        new Runner(optionsBuilder.build()).run();
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.casc;
+
+import io.jenkins.plugins.casc.misc.jmh.CascJmhBenchmarkState;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+import jenkins.benchmark.jmh.JmhBenchmark;
+import jenkins.model.Jenkins;
+import org.openjdk.jmh.annotations.Benchmark;
+
+import static org.junit.Assert.assertEquals;
+
+@JmhBenchmark
+public class SampleBenchmark {
+    public static class MyState extends CascJmhBenchmarkState {
+        @Nonnull
+        @Override
+        protected String getResourcePath() {
+            return "io/jenkins/plugins/casc/benchmarks.yml";
+        }
+    }
+
+    @Benchmark
+    public void benchmark(MyState state) throws IOException {
+        Jenkins jenkins = state.getJenkins();
+        assertEquals("Benchmark started with Configuration as Code", jenkins.getSystemMessage());
+        assertEquals(22, jenkins.getNumExecutors());
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
@@ -15,7 +15,13 @@ public class SampleBenchmark {
         @Nonnull
         @Override
         protected String getResourcePath() {
-            return "io/jenkins/plugins/casc/benchmarks.yml";
+            return "benchmarks.yml";
+        }
+
+        @Nonnull
+        @Override
+        protected Class<?> getEnclosingClass() {
+            return SampleBenchmark.class;
         }
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.casc;
 
 import io.jenkins.plugins.casc.misc.jmh.CascJmhBenchmarkState;
-import java.io.IOException;
 import javax.annotation.Nonnull;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.model.Jenkins;
@@ -26,7 +25,7 @@ public class SampleBenchmark {
     }
 
     @Benchmark
-    public void benchmark(MyState state) throws IOException {
+    public void benchmark(MyState state) {
         Jenkins jenkins = state.getJenkins();
         assertEquals("Benchmark started with Configuration as Code", jenkins.getSystemMessage());
         assertEquals(22, jenkins.getNumExecutors());

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/jmh/CascJmhBenchmarkState.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/jmh/CascJmhBenchmarkState.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.benchmark.jmh.JmhBenchmarkState;
 
 /**
@@ -23,6 +24,14 @@ public abstract class CascJmhBenchmarkState extends JmhBenchmarkState {
     protected abstract String getResourcePath();
 
     /**
+     * The class containing this benchmark state. The config is loaded using this class's {@link Class#getResource(String)}.
+     *
+     * @return the class containing this benchmark state
+     */
+    @Nonnull
+    protected abstract Class<?> getEnclosingClass();
+
+    /**
      * Setups the Jenkins instance using configuration as code
      * available through the {@link CascJmhBenchmarkState#getResourcePath()}.
      *
@@ -30,7 +39,14 @@ public abstract class CascJmhBenchmarkState extends JmhBenchmarkState {
      */
     @Override
     public void setup() throws Exception {
-        String config = Objects.requireNonNull(getClass().getClassLoader().getResource(getResourcePath())).toExternalForm();
+        Class<?> enclosingClass = getEnclosingClass();
+
+        if (!enclosingClass.isAnnotationPresent(JmhBenchmark.class)) {
+            throw new Exception("The enclosing class must be annotated with @JmhBenchmark");
+        }
+
+        String config = Objects.requireNonNull(getEnclosingClass().getResource(getResourcePath()),
+                "Unable to find YAML config file").toExternalForm();
         try {
             ConfigurationAsCode.get().configure(config);
         } catch (ConfiguratorException e) {

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/jmh/CascJmhBenchmarkState.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/jmh/CascJmhBenchmarkState.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.casc.misc.jmh;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import jenkins.benchmark.jmh.JmhBenchmarkState;
+
+/**
+ * Use Configuration as Code to setup the Jenkins instance for JMH benchmark.
+ */
+public abstract class CascJmhBenchmarkState extends JmhBenchmarkState {
+    private static final Logger LOGGER = Logger.getLogger(CascJmhBenchmarkState.class.getName());
+
+    /**
+     * Location of the YAML file to be used for configuration-as-code
+     *
+     * @return String containing the location of YAML file in the classpath
+     */
+    @Nonnull
+    protected abstract String getResourcePath();
+
+    /**
+     * Setups the Jenkins instance using configuration as code
+     * available through the {@link CascJmhBenchmarkState#getResourcePath()}.
+     *
+     * @throws ConfiguratorException when unable to configure
+     */
+    @Override
+    public void setup() throws Exception {
+        String config = Objects.requireNonNull(getClass().getClassLoader().getResource(getResourcePath())).toExternalForm();
+        try {
+            ConfigurationAsCode.get().configure(config);
+        } catch (ConfiguratorException e) {
+            LOGGER.log(Level.SEVERE, "Unable to configure using configuration as code. Aborting.");
+            terminateJenkins();
+            throw e; // causes JMH to abort benchmark
+        }
+    }
+}

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/benchmarks.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/benchmarks.yml
@@ -1,0 +1,3 @@
+jenkins:
+  systemMessage: "Benchmark started with Configuration as Code"
+  numExecutors: 22

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.45</version>
+    <version>3.46</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.configuration-as-code</groupId>
@@ -24,7 +24,6 @@
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
-    <jenkins-test-harness.version>2.51-rc1190.0446fa11a41f</jenkins-test-harness.version>
   </properties>
 
   <name>Configuration as Code Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
+    <jenkins-test-harness.version>2.51-rc1188.061ed497968c</jenkins-test-harness.version>
   </properties>
 
   <name>Configuration as Code Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
-    <jenkins-test-harness.version>2.51-rc1188.061ed497968c</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.51-rc1190.0446fa11a41f</jenkins-test-harness.version>
   </properties>
 
   <name>Configuration as Code Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>3.45</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.configuration-as-code</groupId>


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [X] Please describe what you did

- [X] Link to relevant GitHub issues or pull requests

- [X] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [X] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Adds support for running JMH benchmarks with temporary instances configured using Configuration as Code. This is a direct follow-up to https://github.com/jenkinsci/jenkins-test-harness/pull/135.

JIRA issue: https://issues.jenkins-ci.org/browse/JENKINS-57928

@jenkinsci/gsoc2019-role-strategy 