### PR TITLE
Prevent failure of  `ConfigurationAsCodeTest.java#init_test_from_accepted_sources()` when building on Windows

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -61,6 +61,7 @@ public class ConfigurationAsCodeTest {
         try {
             Files.createSymbolicLink(newLink, target);
         } catch (IOException e) {
+            // often fails on windows due to non admin users not having symlink permission by default, see: https://stackoverflow.com/questions/23217460/how-to-create-soft-symbolic-link-using-java-nio-files/24353758#24353758
             Assume.assumeFalse(Functions.isWindows());
         }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -63,6 +63,7 @@ public class ConfigurationAsCodeTest {
         } catch (IOException e) {
             // often fails on windows due to non admin users not having symlink permission by default, see: https://stackoverflow.com/questions/23217460/how-to-create-soft-symbolic-link-using-java-nio-files/24353758#24353758
             Assume.assumeFalse(Functions.isWindows());
+            throw e;
         }
 
         // should *NOT* be picked up

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -10,6 +10,7 @@ import hudson.util.FormValidation;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,10 +60,10 @@ public class ConfigurationAsCodeTest {
 
         try {
             Files.createSymbolicLink(newLink, target);
-        } catch (Exception e) {
+        } catch (IOException e) {
             Assume.assumeFalse(Functions.isWindows());
         }
-        
+
         // should *NOT* be picked up
         tempFolder.newFolder("folder.yaml");
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -5,6 +5,7 @@ import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.Functions;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -16,6 +17,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -54,8 +56,13 @@ public class ConfigurationAsCodeTest {
         // should be picked up
         Path target = Paths.get("jenkins.tmp");
         Path newLink = Paths.get(tempFolder.getRoot().getAbsolutePath(), "jenkins_5.yaml");
-        Files.createSymbolicLink(newLink, target);
 
+        try {
+            Files.createSymbolicLink(newLink, target);
+        } catch (Exception e) {
+            Assume.assumeFalse(Functions.isWindows());
+        }
+        
         // should *NOT* be picked up
         tempFolder.newFolder("folder.yaml");
 


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x ] Please describe what you did

- [x ] Link to relevant GitHub issues or pull requests

- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Please describe your pull request here.
Added a try catch block to the symlink test because it requires admin priveleges to create a symlink.
Assumed false `isWindows` propery.
Fixes https://github.com/jenkinsci/configuration-as-code-plugin/issues/926
