### PR TITLE
Allow partial selection in export viewer.

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/assets/viewExport.css
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/assets/viewExport.css
@@ -10,8 +10,8 @@ Support easy copy with select all keyboard shortcut
 }
 
 code.language-yaml, code.language-yaml > .token {
-  -webkit-user-select: auto;
-  -moz-user-select: auto;
-  -ms-user-select: auto;
-  user-select: auto;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
 }


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

#853 makes it easy to select all of the export to copy it elsewhere. However, sometimes one wants to only copy little bits from the export, instead of all of it. As it stands, the CSS does not allow selecting parts of the text using the mouse.

This changes the CSS to allow mouse selection in addition to select-all.
