### PR TITLE
support multi-line string export using literal style

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -183,7 +183,7 @@ public class Attribute<Owner, Type> {
     public CNode describe(Owner instance, ConfigurationContext context) throws ConfiguratorException {
         final Configurator c = context.lookup(type);
         if (c == null) {
-            return new Scalar("FAILED TO EXPORT " + instance.getClass().getName()+"#"+name +
+            return new Scalar("FAILED TO EXPORT\n" + instance.getClass().getName()+"#"+name +
                     ": No configurator found for type " + type);
         }
         try {
@@ -203,7 +203,7 @@ public class Attribute<Owner, Type> {
         } catch (Exception | /* Jenkins.getDescriptorOrDie */AssertionError e) {
             // Don't fail the whole export, prefer logging this error
             LOGGER.log(Level.WARNING, "Failed to export", e);
-            return new Scalar("FAILED TO EXPORT " + instance.getClass().getName() + "#" + name + ": "
+            return new Scalar("FAILED TO EXPORT\n" + instance.getClass().getName() + "#" + name + ": "
                 + printThrowable(e));
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -17,6 +17,7 @@ import io.jenkins.plugins.casc.impl.DefaultConfiguratorRegistry;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.jenkins.plugins.casc.model.Scalar;
+import io.jenkins.plugins.casc.model.Scalar.Format;
 import io.jenkins.plugins.casc.model.Sequence;
 import io.jenkins.plugins.casc.model.Source;
 import io.jenkins.plugins.casc.snakeyaml.DumperOptions;
@@ -87,6 +88,7 @@ import org.kohsuke.stapler.verb.POST;
 
 import static io.jenkins.plugins.casc.snakeyaml.DumperOptions.FlowStyle.BLOCK;
 import static io.jenkins.plugins.casc.snakeyaml.DumperOptions.ScalarStyle.DOUBLE_QUOTED;
+import static io.jenkins.plugins.casc.snakeyaml.DumperOptions.ScalarStyle.LITERAL;
 import static io.jenkins.plugins.casc.snakeyaml.DumperOptions.ScalarStyle.PLAIN;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
@@ -492,7 +494,14 @@ public class ConfigurationAsCode extends ManagementLink {
                 final String value = scalar.getValue();
                 if (value == null || value.length() == 0) return null;
 
-                final DumperOptions.ScalarStyle style = scalar.isRaw() ? PLAIN : DOUBLE_QUOTED;
+                final DumperOptions.ScalarStyle style;
+                if (scalar.getFormat().equals(Format.MULTILINESTRING) && !scalar.isRaw()) {
+                    style = LITERAL;
+                } else if (scalar.isRaw()) {
+                    style = PLAIN;
+                } else {
+                    style = DOUBLE_QUOTED;
+                }
 
                 return new ScalarNode(getTag(scalar.getFormat()), value, null, null, style);
         }
@@ -507,6 +516,7 @@ public class ConfigurationAsCode extends ManagementLink {
             case BOOLEAN:
                 return Tag.BOOL;
             case STRING:
+            case MULTILINESTRING:
             default:
                 return Tag.STR;
         }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -768,7 +768,7 @@ public class ConfigurationAsCode extends ManagementLink {
     public static String printThrowable(@NonNull Throwable t) {
         String s = Functions.printThrowable(t)
             .split("at io.jenkins.plugins.casc.ConfigurationAsCode.export")[0]
-            .replaceAll("\n\t", "  ");
+            .replaceAll("\t", "  ");
         return s.substring(0, s.lastIndexOf(")") + 1);
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
@@ -107,7 +107,7 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
             if (node != null) mapping.put(c.getName(), node);
         } catch (Exception e) {
             final Scalar scalar = new Scalar(
-                "FAILED TO EXPORT " + d.getClass().getName() + " : " + printThrowable(e));
+                "FAILED TO EXPORT\n" + d.getClass().getName() + " : " + printThrowable(e));
             mapping.put(c.getName(), scalar);
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -14,7 +14,7 @@ public final class Scalar implements CNode, CharSequence {
     private boolean raw;
     private Source source;
 
-    public enum Format { STRING, BOOLEAN, NUMBER, FLOATING }
+    public enum Format { STRING, MULTILINESTRING, BOOLEAN, NUMBER, FLOATING }
 
     public Scalar(String value, Source source) {
         this(value);
@@ -23,7 +23,7 @@ public final class Scalar implements CNode, CharSequence {
 
     public Scalar(String value) {
         this.value = value;
-        this.format = Format.STRING;
+        this.format = value.contains("\n") ? Format.MULTILINESTRING : Format.STRING;
         this.raw = false;
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -29,8 +29,6 @@ import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import static com.gargoylesoftware.htmlunit.HttpMethod.POST;
 import static io.jenkins.plugins.casc.ConfigurationAsCode.CASC_JENKINS_CONFIG_PROPERTY;
 import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
-import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
-import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -9,6 +9,7 @@ import hudson.Functions;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +28,10 @@ import org.jvnet.hudson.test.JenkinsRule.WebClient;
 
 import static com.gargoylesoftware.htmlunit.HttpMethod.POST;
 import static io.jenkins.plugins.casc.ConfigurationAsCode.CASC_JENKINS_CONFIG_PROPERTY;
+import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
+import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -204,5 +209,41 @@ public class ConfigurationAsCodeTest {
     public void isSupportedURI_should_not_throw_on_invalid_uri() {
         //for example, a Windows path is not a valid URI
         assertThat(ConfigurationAsCode.isSupportedURI("C:\\jenkins\\casc"), is(false));
+    }
+
+
+
+    @Test
+    @ConfiguredWithCode("multi-line1.yml")
+    public void multiline_literal_stays_literal_in_export() throws Exception {
+        assertEquals("Welcome to our build server.\n\n"
+                + "This Jenkins is 100% configured and managed 'as code'.\n",
+            j.jenkins.getSystemMessage());
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode systemMessage = getJenkinsRoot(context).get("systemMessage");
+        String exported = toYamlString(systemMessage);
+        String expected = "|\n"
+            + "  Welcome to our build server.\n\n"
+            + "  This Jenkins is 100% configured and managed 'as code'.\n";
+        assertThat(exported, is(expected));
+    }
+
+    @Test
+    @ConfiguredWithCode("multi-line2.yml")
+    public void string_to_literal_in_export() throws Exception {
+        assertEquals("Welcome to our build server.\n\n"
+                + "This Jenkins is 100% configured and managed 'as code'.\n",
+            j.jenkins.getSystemMessage());
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode systemMessage = getJenkinsRoot(context).get("systemMessage");
+        String exported = toYamlString(systemMessage);
+        String expected = "|\n"
+            + "  Welcome to our build server.\n\n"
+            + "  This Jenkins is 100% configured and managed 'as code'.\n";
+        assertThat(exported, is(expected));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -209,8 +209,6 @@ public class ConfigurationAsCodeTest {
         assertThat(ConfigurationAsCode.isSupportedURI("C:\\jenkins\\casc"), is(false));
     }
 
-
-
     @Test
     @ConfiguredWithCode("multi-line1.yml")
     public void multiline_literal_stays_literal_in_export() throws Exception {

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/multi-line1.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/multi-line1.yml
@@ -1,0 +1,5 @@
+jenkins:
+  systemMessage: |
+    Welcome to our build server.
+
+    This Jenkins is 100% configured and managed 'as code'.

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/multi-line2.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/multi-line2.yml
@@ -1,0 +1,2 @@
+jenkins:
+  systemMessage: "Welcome to our build server.\n\nThis Jenkins is 100% configured and managed 'as code'.\n"


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Support multi-line string export
fixes #883 

so something with newlines get exported as [literal style](https://yaml.org/spec/1.2/spec.html#id2795688):
```yml
jenkins:
  systemMessage: |
    Welcome to our build server.

    This Jenkins is 100% configured and managed 'as code'.
    Config is now mostly handled by the 'Jenkins Configuration as Code' (JCasC) plugin.
    JCasC config can be found in the jenkins.yaml file in the $JENKINS_HOME/casc/ folder.

    Some settings are still injected from init.groovy.d scripts,
    but these settings will be ported over to JCasC as support becomes available.
```