### PR TITLE
Allow DataBoundConfigurator to convert and export `Set`s

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -118,11 +119,18 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                         final Type pt = parameters[i].getParameterizedType();
                         final Configurator lookup = context.lookupOrFail(pt);
 
-                        final ArrayList<Object> list = new ArrayList<>();
-                        for (CNode o : value.asSequence()) {
-                            list.add(lookup.configure(o, context));
+                        final Collection<Object> collection;
+
+                        if (Set.class.isAssignableFrom(parameters[i].getType())) {
+                            collection = new HashSet<>();
+                        } else {
+                            collection = new ArrayList<>();
                         }
-                        args[i] = list;
+
+                        for (CNode o : value.asSequence()) {
+                            collection.add(lookup.configure(o, context));
+                        }
+                        args[i] = collection;
 
                     } else {
                         final Type pt = parameters[i].getParameterizedType();
@@ -250,10 +258,14 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
             Object value = a.getValue(instance);
             if (value != null) {
                 Object converted = Stapler.CONVERT_UTILS.convert(value, a.getType());
-                if (converted instanceof List || !a.isMultiple()) {
+                if (converted instanceof Collection || !a.isMultiple()) {
                     args[i] = converted;
                 } else {
-                    args[i] = Collections.singletonList(converted);
+                    if (Set.class.isAssignableFrom(p.getType())) {
+                        args[i] = Collections.singleton(converted);
+                    } else {
+                        args[i] = Collections.singletonList(converted);
+                    }
                 }
             }
             if (args[i] == null && p.getType().isPrimitive()) {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -260,12 +260,10 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                 Object converted = Stapler.CONVERT_UTILS.convert(value, a.getType());
                 if (converted instanceof Collection || !a.isMultiple()) {
                     args[i] = converted;
+                } else if (Set.class.isAssignableFrom(p.getType())) {
+                    args[i] = Collections.singleton(converted);
                 } else {
-                    if (Set.class.isAssignableFrom(p.getType())) {
-                        args[i] = Collections.singleton(converted);
-                    } else {
-                        args[i] = Collections.singletonList(converted);
-                    }
+                    args[i] = Collections.singletonList(converted);
                 }
             }
             if (args[i] == null && p.getType().isPrimitive()) {


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [X] Please describe what you did

- [X] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [X] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

I had a `@DataBoundConstructor` which was accepting two sets. The `DataBoundConfigurator` was not unable to convert to a `Set` nor export it with the following stack trace:
```
WARNING: Failed to export
java.lang.IllegalArgumentException: argument type mismatch
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.describe(DataBoundConfigurator.java:265)
```

This pull request makes the configurator return a set when the expected parameter type is also a set (instead of always returning an `ArrayList`).

@jenkinsci/gsoc2019-role-strategy This pull request us to configure the new `AuthorizationStrategy` in https://github.com/jenkinsci/role-strategy-plugin/pull/89

Closes #944 