### PR TITLE
Prevent NumberFormatException in system log when exporting the JSON schema

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/Attribute/schema.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/Attribute/schema.jelly
@@ -3,7 +3,7 @@
 <j:choose>
   <j:when test="${it.type.enum}">
     <j:choose>
-      <j:when test="${it.type.values().length == 0}">
+      <j:when test="${it.type.getEnumConstants().size() == 0}">
         "type": "string"
       </j:when>
       <j:otherwise>


### PR DESCRIPTION
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [X] Please describe what you did

- [] Link to relevant GitHub issues or pull requests

- [] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [] Did you provide a test-case? That demonstrates feature works or fixes the issue.

### Description

Previously a warning was displayed when evaluating the jelly file. As such, an empty array would be added to the generated JSON and a warning displayed in the logs.

![Screen Shot 2019-07-11 at 09 31 17](https://user-images.githubusercontent.com/6572596/61036771-0854b080-a3ca-11e9-8ce5-a9f0d7caaed3.png)

I did not raise a ticket because it's more a cosmetic non-important change.
