### PR TITLE
Fix `ToolDefaultPropertiesExportBlacklistTest#export_tool_configuration()` when building the plugin on Windows

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/ToolDefaultPropertiesExportBlacklistTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ToolDefaultPropertiesExportBlacklistTest.java
@@ -26,7 +26,7 @@ public class ToolDefaultPropertiesExportBlacklistTest {
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute = getToolRoot(context);
 
-        String exported = toYamlString(yourAttribute);
+        String exported = toYamlString(yourAttribute).replaceAll("git\\.exe", "git");
 
         String expected = toStringFromYamlFile(this, "ToolDefaultPropertiesExportBlacklistExpected.yml");
 


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Argh!
