### PR TITLE
DataBoundConfigurator: do not throw NullPointerException with empty collection

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -5,6 +5,9 @@ import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.Configurator;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.impl.configurators.nonnull.ClassParametersAreNonnullByDefault;
+import io.jenkins.plugins.casc.impl.configurators.nonnull.NonnullParameterConstructor;
+import io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage.PackageParametersAreNonnullByDefault;
 import io.jenkins.plugins.casc.misc.Util;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
@@ -101,6 +104,36 @@ public class DataBoundConfiguratorTest {
         final Bar configured = (Bar) registry.lookupOrFail(Bar.class).configure(config, new ConfigurationContext(registry));
         Set<String> strings = configured.getStrings();
         assertEquals(0, strings.size());
+    }
+
+    @Test
+    public void nonnullConstructorParameter() throws Exception {
+        Mapping config = new Mapping();
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final NonnullParameterConstructor configured = (NonnullParameterConstructor) registry
+                                                        .lookupOrFail(NonnullParameterConstructor.class)
+                                                        .configure(config, new ConfigurationContext(registry));
+        assertEquals(0, configured.getStrings().size());
+    }
+
+    @Test
+    public void classParametersAreNonnullByDefault() throws Exception {
+        Mapping config = new Mapping();
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final ClassParametersAreNonnullByDefault configured = (ClassParametersAreNonnullByDefault) registry
+                                                        .lookupOrFail(ClassParametersAreNonnullByDefault.class)
+                                                        .configure(config, new ConfigurationContext(registry));
+        assertEquals(0, configured.getStrings().size());
+    }
+
+    @Test
+    public void packageParametersAreNonnullByDefault() throws Exception {
+        Mapping config = new Mapping();
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final PackageParametersAreNonnullByDefault configured = (PackageParametersAreNonnullByDefault) registry
+                                                        .lookupOrFail(PackageParametersAreNonnullByDefault.class)
+                                                        .configure(config, new ConfigurationContext(registry));
+        assertTrue(configured.getString().isEmpty());
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -12,6 +12,7 @@ import io.jenkins.plugins.casc.model.Scalar;
 import io.jenkins.plugins.casc.model.Sequence;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.annotation.PostConstruct;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,6 +92,15 @@ public class DataBoundConfiguratorTest {
         assertTrue(strings.contains("foo"));
         assertTrue(strings.contains("bar"));
         assertFalse(strings.contains("baz"));
+    }
+
+    @Test
+    public void configureWithEmptySet() throws Exception {
+        Mapping config = new Mapping();
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final Bar configured = (Bar) registry.lookupOrFail(Bar.class).configure(config, new ConfigurationContext(registry));
+        Set<String> strings = configured.getStrings();
+        assertEquals(0, strings.size());
     }
 
     @Test
@@ -234,6 +244,7 @@ public class DataBoundConfiguratorTest {
         final Set<String> strings;
 
         @DataBoundConstructor
+        @ParametersAreNonnullByDefault
         public Bar(Set<String> strings) {
             this.strings = strings;
         }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/ClassParametersAreNonnullByDefault.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/ClassParametersAreNonnullByDefault.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.casc.impl.configurators.nonnull;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * This class checks the behaviour of {@link io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator}
+ * with {@link Nonnull} {@link List} parameters.
+ */
+@ParametersAreNonnullByDefault
+public class ClassParametersAreNonnullByDefault {
+    private List<String> strings;
+
+    @DataBoundConstructor
+    public ClassParametersAreNonnullByDefault(@Nonnull List<String> strings) {
+        this.strings = strings;
+    }
+
+    public List<String> getStrings() {
+        return strings;
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/NonnullParameterConstructor.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/NonnullParameterConstructor.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.casc.impl.configurators.nonnull;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * This class checks the behaviour of {@link io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator}
+ * with {@link Nonnull} {@link Set} parameters
+ */
+public class NonnullParameterConstructor {
+    private Set<String> strings;
+
+    @DataBoundConstructor
+    public NonnullParameterConstructor(@Nonnull Set<String> strings) {
+        this.strings = strings;
+    }
+
+    public Set<String> getStrings() {
+        return strings;
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersAreNonnullByDefault.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersAreNonnullByDefault.java
@@ -1,0 +1,20 @@
+package io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Checks the behaviour of {@link io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator} with non null
+ * {@link String} when using package-level {@link javax.annotation.ParametersAreNonnullByDefault} annotations.
+ */
+public class PackageParametersAreNonnullByDefault {
+    private String string;
+
+    @DataBoundConstructor
+    public PackageParametersAreNonnullByDefault(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/package-info.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/package-info.java
@@ -1,5 +1,6 @@
 /**
- * This package tests {@link org.kohsuke.stapler.DataBoundConstructor}
+ * This package tests {@link io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator}'s behaviour with
+ * package-level {@link javax.annotation.ParametersAreNonnullByDefault} annotation.
  */
 @ParametersAreNonnullByDefault
 package io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/package-info.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This package tests {@link org.kohsuke.stapler.DataBoundConstructor}
+ */
+@ParametersAreNonnullByDefault
+package io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/package-info.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains classes used by {@link io.jenkins.plugins.casc.impl.configurators.DataBoundConfiguratorTest}
+ * for checking behaviour of {@code Nonnull} parameters.
+ */
+package io.jenkins.plugins.casc.impl.configurators.nonnull;


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [X] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [X] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

When `DataBoundConfigurator` finds a collection that is not present in the `CNode`, it passes a `null` to the constructor leading to the following exception:
```
Caused by: io.jenkins.plugins.casc.ConfiguratorException: folderBased: Failed to construct instance of class io.jenkins.plugins.folderauth.FolderBasedAuthorizationStrategy.
 Constructor: public io.jenkins.plugins.folderauth.FolderBasedAuthorizationStrategy(java.util.Set,java.util.Set).
 Arguments: [java.util.HashSet, null].
 Expected Parameters: globalRoles java.util.Set<io.jenkins.plugins.folderauth.roles.GlobalRole>, folderRoles java.util.Set<io.jenkins.plugins.folderauth.roles.FolderRole>
    at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.tryConstructor(DataBoundConfigurator.java:168)
```

This pull request changes the old behavior and makes the configurator pass `Collections.emptySet()` and `Collections.emptyList()` when the parameters are known to be `Nonnull`.

@jenkinsci/gsoc2019-role-strategy 

Closes #951 