### PR TITLE
[JENKINS-52906] - Update JIRA Plugin test dependency to verify the JCasC compatibility and support writing roundtrip tests

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -348,7 +348,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jira</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.8</version>
     </dependency>
 
     <dependency>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
@@ -7,6 +7,7 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import static org.junit.Assert.assertEquals;
 
@@ -20,19 +21,15 @@ public class JiraTest {
 
     @Test
     @ConfiguredWithCode("JiraTest.yml")
+    @Issue("JENKINS-52906")
     public void configure_jira_project_globalconfig() throws Exception {
 
         final DescriptorImpl descriptor = (DescriptorImpl) j.jenkins.getDescriptor(JiraProjectProperty.class);
 
-        /*  JENKINS-52906
-         *  assertEquals(2, descriptor.getSites().length);
-         *  assertEquals("http://jira.codehaus.org/", sites[0].getUrl().toString());
-         *  assertEquals("http://issues.jenkins.io/", sites[1].getUrl().toString());
-         */
-
-        assertEquals(1, descriptor.getSites().length);
-        final JiraSite site = descriptor.getSites()[0];
-        assertEquals("http://jira.codehaus.org/", site.getUrl().toString());
+        // Was failing due to JENKINS-52906
+        assertEquals(2, descriptor.getSites().length);
+        assertEquals("http://jira.codehaus.org/", descriptor.getSites()[0].getUrl().toString());
+        assertEquals("http://issues.jenkins.io/", descriptor.getSites()[1].getUrl().toString());
     }
 
 }

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.casc;
 
 import hudson.plugins.jira.JiraProjectProperty;
 import hudson.plugins.jira.JiraProjectProperty.DescriptorImpl;
-import hudson.plugins.jira.JiraSite;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import org.junit.Rule;

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/JiraTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/JiraTest.yml
@@ -2,5 +2,4 @@ unclassified:
   jiraGlobalConfiguration:
     sites:
       - url: "http://jira.codehaus.org/"
-      # see https://issues.jenkins.io/browse/JENKINS-52906
       - url: "http://issues.jenkins.io/"

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/JiraTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/JiraTest.yml
@@ -1,7 +1,6 @@
 unclassified:
-  jiraProjectProperty:
+  jiraGlobalConfiguration:
     sites:
-      url: "http://jira.codehaus.org/"
-# see https://issues.jenkins.io/browse/JENKINS-52906
-#      - url: "http://jira.codehaus.org/"
-#      - url: "http://issues.jenkins.io/"
+      - url: "http://jira.codehaus.org/"
+      # see https://issues.jenkins.io/browse/JENKINS-52906
+      - url: "http://issues.jenkins.io/"


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Without this fix any attempt to run a roundtrip tests in JCasC fails due to the import issues. Note that JIRA plugin fix is incompatiblem as designed by @olamy 

See https://issues.jenkins.io/browse/JENKINS-52906