### PR TITLE
Print warning when a secret variable cannot be resolved during import

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -1,14 +1,19 @@
 package io.jenkins.plugins.casc;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class SecretSourceResolverTest {
 
@@ -17,6 +22,14 @@ public class SecretSourceResolverTest {
 
     @Rule
     public final EnvironmentVariables environment = new EnvironmentVariables();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule();
+
+    @Before
+    public void initLogging() {
+        logging.record(Logger.getLogger(SecretSourceResolver.class.getName()), Level.INFO).capture(2048);
+    }
 
     private static ConfigurationContext context;
 
@@ -35,6 +48,11 @@ public class SecretSourceResolverTest {
     @Test
     public void resolve_singleEntryWithoutDefaultValue() {
         assertThat(SecretSourceResolver.resolve(context, "${FOO}"), equalTo(""));
+
+        // TODO: Create a new utility method?
+        final String expectedText ="Configuration import: Found unresolved variable FOO";
+        assertTrue("The log should contain '" + expectedText + "'",
+                logging.getMessages().stream().anyMatch(m -> m.contains(expectedText)));
     }
 
     @Test


### PR DESCRIPTION
<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Please describe what you did
- [x] Link to relevant GitHub issues or pull requests
- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Just a diagnosability improvement for Jenkins admins. When a configuration YAML references an undefined variable, a warning will be printed to System logs
