### PR TITLE
Remove Markdown from the Support Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-support.md
+++ b/.github/ISSUE_TEMPLATE/4-support.md
@@ -1,7 +1,7 @@
 ---
 name: "❓ Need help"
 labels: question
-about: Please ask in [our Gitter channel](https://gitter.im/jenkinsci/configuration-as-code-plugin) first
+about: Please ask in our Gitter channel first
 ---
 
 <!--


### PR DESCRIPTION
🤦‍♂ . I do not want to fight with Codacy, so let;s just remove the hyperlink
