### PR TITLE
Remove dependency on the interpolatd library which is not used since 1.25

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -49,13 +49,6 @@
       <version>4.0.0</version>
     </dependency>
 
-    <!--TODO: Not longer used, remove it? -->
-    <dependency>
-      <groupId>org.bigtesting</groupId>
-      <artifactId>interpolatd</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-
     <dependency>
       <groupId>io.vavr</groupId>
       <artifactId>vavr</artifactId>


### PR DESCRIPTION
This is a follow-up to the 1.25 release where https://github.com/lantunes/interpolatd was replaced by a standard Apache Commons Text component. The dependency is no longer used, and I would like to remove it from the code.

I cannot find any transitive usages of the library in Jenkins plugins.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.