### PR TITLE
Update `@since` in Javadoc for newly introduced APIs

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalMatrixAuthorizationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalMatrixAuthorizationTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * @author Mads Nielsen
- * @since TODO
+ * @since 1.0
  */
 public class GlobalMatrixAuthorizationTest {
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/RoleStrategyTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/RoleStrategyTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertThat;
 
 /**
  * @author Oleg Nenashev
- * @since TODO
+ * @since 1.0
  */
 public class RoleStrategyTest {
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -147,7 +147,7 @@ public class Attribute<Owner, Type> {
      * Sets whether the attribute is secret.
      * If so, various outputs will be suppressed (exports, logging).
      * @param secret {@code true} to make an attribute secret
-     * @since TODO
+     * @since 1.25
      */
     public Attribute<Owner, Type> secret(boolean secret) {
         this.secret = secret;
@@ -195,7 +195,7 @@ public class Attribute<Owner, Type> {
      * @return {@code true} if the attribute is secret
      * @param target Target object.
      *               If {@code null}, only the attribute metadata is checked
-     * @since TODO
+     * @since 1.25
      */
     public boolean isSecret(@CheckForNull Owner target) {
         // This.secret should be always true for the first condition, but getType() is overridable

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfiguratorException.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfiguratorException.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * Exception type for {@link Configurator} issues.
  * @author Oleg Nenashev
- * @since TODO
+ * @since 1.0
  * @see Configurator#configure(CNode, ConfigurationContext)
  * @see Configurator
  */

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -27,7 +27,7 @@ public class SecretSourceResolver {
      * Encodes String so that it can be safely represented in the YAML after export.
      * @param toEncode String to encode
      * @return Encoded string
-     * @since TODO
+     * @since 1.25
      */
     public static String encode(@CheckForNull String toEncode) {
         if (toEncode == null) {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -85,7 +85,7 @@ public final class Scalar implements CNode, CharSequence {
     /**
      * Check whether the scalar value should be masked in the output.
      * @return {@code true} if the value is masked
-     * @since TODO
+     * @since 1.25
      */
     public boolean isMasked() {
         return sensitive && !encrypted;
@@ -96,7 +96,7 @@ public final class Scalar implements CNode, CharSequence {
      * It indicates that the scalar represents a sensitive argument (secret or other restricted data).
      * @param sensitive value to set
      * @return Object instance
-     * @since TODO
+     * @since 1.25
      */
     public Scalar sensitive(boolean sensitive) {
         this.sensitive = sensitive;
@@ -107,7 +107,7 @@ public final class Scalar implements CNode, CharSequence {
      * Indicates that the data is encrypted and hence safe to be exported.
      * @param encrypted Value to set
      * @return Object instance
-     * @since TODO
+     * @since 1.25
      */
     public Scalar encrypted(boolean encrypted) {
         this.encrypted = encrypted;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
@@ -86,7 +86,7 @@ public class JenkinsConfiguredWithCodeRule extends JenkinsRule {
      * @param strict Fail if any export operation returns error
      * @throws Exception Export error
      * @throws AssertionError Failed to export the configuration
-     * @since TODO
+     * @since 1.25
      */
     public String exportToString(boolean strict) throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  * 3. A string that should be present in the logs (casc logger) that guarantees the config is loaded. Usually a weird
  *    text configured.
  *
- * @since TODO
+ * @since 1.20
  */
 public abstract class RoundTripAbstractTest {
     @Rule

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/Util.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/Util.java
@@ -166,7 +166,7 @@ public class Util {
      * Checks whether {@link LoggerRule} has not recorded the message.
      * @param logging Logger rule
      * @param unexpectedText Text to check
-     * @since TODO
+     * @since 1.25
      */
     public static void assertNotInLog(LoggerRule logging, String unexpectedText) {
         assertFalse("The log should not contain '" + unexpectedText + "'",
@@ -177,7 +177,7 @@ public class Util {
      * Checks whether {@link LoggerRule} has recorded the message.
      * @param logging Logger rule
      * @param expectedText Text to check
-     * @since TODO
+     * @since 1.25
      */
     public static void assertLogContains(LoggerRule logging, String expectedText) {
         assertTrue("The log should contain '" + expectedText + "'",


### PR DESCRIPTION
Just a follow-up to 1.25 and few other releases which do not have API documentation. I have updated `@since TODO` entries in the entire codebase

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
