### PR TITLE
Reduce logging level for JCasC YAML loading messages

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/MailExtTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MailExtTest.java
@@ -29,7 +29,7 @@ public class MailExtTest {
 
     @Rule
     public RuleChain chain= RuleChain
-            .outerRule(logging.record(Logger.getLogger(Attribute.class.getName()), Level.INFO).capture(2048))
+            .outerRule(logging.record(Logger.getLogger(Attribute.class.getName()), Level.FINER).capture(2048))
             .around(j);
 
     private static final String SMTP_PASSWORD = "myPassword";

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -204,7 +204,8 @@ public class Attribute<Owner, Type> {
     }
 
     public void setValue(Owner target, Type value) throws Exception {
-        LOGGER.info("Setting " + target + '.' + name + " = " + (isSecret(target) ? "****" : value));
+        LOGGER.log(Level.FINE, "Setting {0}. {1} = {2}",
+                new Object[] {target, name, (isSecret(target) ? "****" : value)});
         setter.setValue(target, value);
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -121,11 +121,11 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                     clazz.getPackage().isAnnotationPresent(ParametersAreNonnullByDefault.class))) {
 
                     if (Set.class.isAssignableFrom(t)) {
-                        LOGGER.log(Level.INFO, "The parameter to be set is @Nonnull but is not present; " +
+                        LOGGER.log(Level.FINER, "The parameter to be set is @Nonnull but is not present; " +
                                                            "setting equal to empty set.");
                         args[i] = Collections.emptySet();
                     } else if (List.class.isAssignableFrom(t)) {
-                        LOGGER.log(Level.INFO, "The parameter to be set is @Nonnull but is not present; " +
+                        LOGGER.log(Level.FINER, "The parameter to be set is @Nonnull but is not present; " +
                                                            "setting equal to empty list.");
                         args[i] = Collections.emptyList();
                     } else if (String.class.isAssignableFrom(t)) {
@@ -160,7 +160,8 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                         final Configurator configurator = context.lookupOrFail(k);
                         args[i] = configurator.configure(value, context);
                     }
-                    LOGGER.info("Setting " + target + "." + names[i] + " = " + (t == Secret.class ? "****" : value));
+                    LOGGER.log(Level.FINE, "Setting {0}. {1} = {2}",
+                        new Object[] {target, names[i], t == Secret.class ? "****" : value});
                 } else if (t.isPrimitive()) {
                     args[i] = defaultValue(t);
                 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/core/ProxyConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/core/ProxyConfiguratorTest.java
@@ -33,7 +33,7 @@ public class ProxyConfiguratorTest {
 
     @Rule
     public RuleChain chain = RuleChain
-            .outerRule(logging.record(Logger.getLogger(Attribute.class.getName()), Level.INFO).capture(2048))
+            .outerRule(logging.record(Logger.getLogger(Attribute.class.getName()), Level.FINER).capture(2048))
             .around(new EnvVarsRule())
             .around(j);
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
@@ -114,7 +114,7 @@ public abstract class RoundTripAbstractTest {
 
             // Start recording the logs just before restarting, to avoid capture the previous startup. We're look there
             // if the "magic token" is there
-            logging.record("io.jenkins.plugins.casc", Level.INFO).capture(5);
+            logging.record("io.jenkins.plugins.casc", Level.FINER).capture(2048);
         });
 
         r.then(step -> {


### PR DESCRIPTION
When I run Jenkins with a default `INFO` logging level, JCasC plugins prints A LOT of diagnostics information for initialization of settings by YAML. I believe that diagnostics information should be printed on lower levels so that the startup log is not flooded.

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
