### PR TITLE
Security Hardening: Guess sensitive attributes by name in addition to API checks

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ProxyConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ProxyConfigurator.java
@@ -58,7 +58,7 @@ public class ProxyConfigurator extends BaseConfigurator<ProxyConfiguration> {
                         .getter(ProxyConfiguration::getUserName)
                         .setter(noop()),
                 new Attribute<ProxyConfiguration, String>("password", String.class)
-                        .getter(ProxyConfiguration::getEncryptedPassword)
+                        .getter(ProxyPasswordGetter.INSTANCE)
                         .setter(noop()),
                 new Attribute<ProxyConfiguration, String>("noProxyHost", String.class)
                         .getter(config -> config.noProxyHost)
@@ -126,6 +126,21 @@ public class ProxyConfigurator extends BaseConfigurator<ProxyConfiguration> {
         @DataBoundSetter
         public void setTestUrl(String testUrl) {
             this.testUrl = testUrl;
+        }
+    }
+
+    static class ProxyPasswordGetter implements Attribute.Getter<ProxyConfiguration, String> {
+
+        private static final ProxyPasswordGetter INSTANCE = new ProxyPasswordGetter();
+
+        @Override
+        public String getValue(ProxyConfiguration target) throws Exception {
+            return target.getEncryptedPassword();
+        }
+
+        @Override
+        public boolean encrypted() {
+            return true;
         }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -94,23 +94,25 @@ public final class Scalar implements CNode, CharSequence {
     /**
      * Sets the sensitive flag.
      * It indicates that the scalar represents a sensitive argument (secret or other restricted data).
+     * Sensitive flag cannot be reset to {@code false}.
      * @param sensitive value to set
      * @return Object instance
      * @since 1.25
      */
     public Scalar sensitive(boolean sensitive) {
-        this.sensitive = sensitive;
+        this.sensitive = this.sensitive || sensitive;
         return this;
     }
 
     /**
      * Indicates that the data is encrypted and hence safe to be exported.
+     * Encrypted flag cannot be reset to {@code false}.
      * @param encrypted Value to set
      * @return Object instance
      * @since 1.25
      */
     public Scalar encrypted(boolean encrypted) {
-        this.encrypted = encrypted;
+        this.encrypted = this.encrypted || encrypted;
         return this;
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
@@ -41,6 +41,7 @@ public class AttributeTest {
         assertFieldIsSecret(SecretFromPublicField.class, "secretField");
         assertFieldIsSecret(SecretFromPrivateField.class, "secretField");
 
+        assertFieldIsSecret(SecretFromImpliedAttributeName.class, "password");
         assertFieldIsSecret(SecretRenamedFieldFithSecretConstructor.class, "mySecretValueField");
     }
 
@@ -61,12 +62,33 @@ public class AttributeTest {
         assertFieldIsSecret(SecretFromPublicField2.class, "secretField");
         assertFieldIsSecret(SecretFromPrivateField2.class, "secretField");
         assertFieldIsSecret(SecretFromPrivateField3.class, "secretField");
+
+        assertFieldIsSecret(SecretFromImpliedAttributeName2.class, "password");
     }
 
     @Test
     @Issue("SECURITY-1279")
     public void checkNonSecretPatterns() {
         assertFieldIsNotSecret(NonSecretField.class, "passwordPath");
+    }
+
+    @Test
+    public void shouldConsiderSuffixes() {
+        assertFieldIsSecret(null, "secretKey");
+        assertFieldIsSecret(null, "mySecretKey");
+        assertFieldIsSecret(null, "myPwd");
+        assertFieldIsSecret(null, "superSecretPassword");
+
+        // Examples of false positives
+        assertFieldIsSecret(null, "pathToSecretKey");
+        assertFieldIsSecret(null, "foretoken"); // https://en.wiktionary.org/wiki/foretoken
+    }
+
+    @Test
+    public void shouldNotConsiderSuffixesInTheMiddle() {
+        assertFieldIsNotSecret(null, "passwordPath");
+        assertFieldIsNotSecret(null, "passwordFile");
+        assertFieldIsNotSecret(null, "tokenSource");
     }
 
     public static void assertFieldIsSecret(Class<?> clazz, String fieldName) {
@@ -156,6 +178,24 @@ public class AttributeTest {
     public static class SecretFromPrivateField3 extends SecretFromPrivateField2 {
         public SecretFromPrivateField3(String secret) {
             super(secret);
+        }
+    }
+
+    public static class SecretFromImpliedAttributeName {
+
+        public String password;
+
+        @DataBoundConstructor
+        public SecretFromImpliedAttributeName(String password) {
+            this.password = password;
+        }
+    }
+
+    public static class SecretFromImpliedAttributeName2 extends SecretFromImpliedAttributeName {
+
+        @DataBoundConstructor
+        public SecretFromImpliedAttributeName2(String password) {
+            super(password);
         }
     }
 


### PR DESCRIPTION
This is a follow-up to the SECURITY-1279, SECURITY-1458, SECURITY-1497 fixes in JCasC 1.25 and 1.27. Although these fixes provide a decent level of security for attributes where `Secret` is somehow referenced in plugin APIs, there is still a gap for plugins which do not use `Secret` API at all. If passwords are stored in plain text (like in plugins references in [this advisory](https://jenkins.io/security/advisory/2019-04-03/)) and retrieved as Strings in API, there is nothing JCasC can do about it at the moment. It makes JCasC use-cases impacted by vulnerabilities in other plugins.

This change...

- [x] Introduces an additional security hardening layer where sensitive AND not encrypted attributes are masked by default in system logs and configuration exports. `Secret` exports are encrypted, and nothing changes there
- [x] Adds new API which allow `Attribute`s to indicate that a field is encrypted
- [x] Fixes a regression in `ProxyConfigurator` which is caused by the changes. It demonstrates the use of new APIs

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
