### PR TITLE
[JENKINS-45740] - Inject plugin changelog and logo URLs into the plugin manifest

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -20,6 +20,10 @@
   <properties>
     <!-- SECURITY-1446 and SECURITY-1290 are considered as breaking changes. Others also contain a risk of regressions -->
     <hpi.compatibleSinceVersion>1.25</hpi.compatibleSinceVersion>
+    <!--TODO: PoC for https://github.com/jenkinsci/maven-hpi-plugin/pull/68 -->
+    <hpi-plugin.version>3.7-20190820.090442-1.</hpi-plugin.version>
+    <hpi.pluginChagelogUrl>https://github.com/jenkinsci/configuration-as-code-plugin/releases</hpi.pluginChagelogUrl>
+    <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/configuration-as-code-plugin/master/plugin/src/main/webapp/img/logo-head.svg</hpi.pluginLogoUrl>
   </properties>
 
   <developers>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -21,7 +21,7 @@
     <!-- SECURITY-1446 and SECURITY-1290 are considered as breaking changes. Others also contain a risk of regressions -->
     <hpi.compatibleSinceVersion>1.25</hpi.compatibleSinceVersion>
     <!--TODO: PoC for https://github.com/jenkinsci/maven-hpi-plugin/pull/68 -->
-    <hpi-plugin.version>3.7-20190820.090442-1.</hpi-plugin.version>
+    <hpi-plugin.version>3.7-20190820.090442-1</hpi-plugin.version>
     <hpi.pluginChagelogUrl>https://github.com/jenkinsci/configuration-as-code-plugin/releases</hpi.pluginChagelogUrl>
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/configuration-as-code-plugin/master/plugin/src/main/webapp/img/logo-head.svg</hpi.pluginLogoUrl>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -20,8 +20,6 @@
   <properties>
     <!-- SECURITY-1446 and SECURITY-1290 are considered as breaking changes. Others also contain a risk of regressions -->
     <hpi.compatibleSinceVersion>1.25</hpi.compatibleSinceVersion>
-    <!--TODO: PoC for https://github.com/jenkinsci/maven-hpi-plugin/pull/68 -->
-    <hpi-plugin.version>3.7-20190820.090442-1</hpi-plugin.version>
     <hpi.pluginChagelogUrl>https://github.com/jenkinsci/configuration-as-code-plugin/releases</hpi.pluginChagelogUrl>
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/configuration-as-code-plugin/master/plugin/src/main/webapp/img/logo-head.svg</hpi.pluginLogoUrl>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.46</version>
+    <version>3.49</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.configuration-as-code</groupId>


### PR DESCRIPTION
This is a reference implementation for https://github.com/jenkinsci/maven-hpi-plugin/pull/68/files . My end goal: support linking changelogs and displaying plugin logos in the Jenkins update center and inside plugin sites.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
