### PR TITLE
Add known JCasC extensions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,16 @@ You have the following option to trigger a configuration reload:
   query parameter named `casc-reload-token`, i.e. `JENKINS_URL/reload-configuration-as-code/?casc-reload-token=32424324rdsadsa`.
 
   `curl  -X POST "JENKINS_URL:8080/reload-configuration-as-code/?casc-reload-token=32424324rdsadsa"`
+  
+## Configuration-as-Code extension plugins
+
+- [configuration-as-code-groovy-plugin](https://github.com/jenkinsci/configuration-as-code-groovy-plugin)
+  Allows to specify groovy code that should run on during configuration.
+- [configuration-as-code-secret-ssm-plugin](https://github.com/jenkinsci/configuration-as-code-secret-ssm-plugin)
+  Allows to resolve secrets from AWS' SSM secrets
+- [hashicorp-vault-plugin](https://github.com/jenkinsci/hashicorp-vault-plugin)
+  Allows to resolve secrets from Hashicorp vault
+  
 
 ## Jenkins Enhancement Proposal
 


### PR DESCRIPTION
See https://github.com/jenkinsci/configuration-as-code-plugin/tree/casz-patch-1#configuration-as-code-extension-plugins

I plan to move forward with migrating JCasC vault functionality today.
Agent support is still waiting on a release of vault-java-driver.

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
