### PR TITLE
Secret sources get initialized too late

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -685,6 +685,9 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     private void configureWith(Mapping entries) throws ConfiguratorException {
+        // Initialize secret sources
+        SecretSource.all().forEach(SecretSource::init);
+
         // Check input before actually applying changes,
         // so we don't let master in a weird state after some ConfiguratorException has been thrown
         final Mapping clone = entries.clone();
@@ -694,7 +697,6 @@ public class ConfigurationAsCode extends ManagementLink {
         monitor.reset();
         ConfigurationContext context = new ConfigurationContext(registry);
         context.addListener(monitor::record);
-        context.getSecretSources().forEach(SecretSource::init);
         try (ACLContext acl = ACL.as(ACL.SYSTEM)) {
             invokeWith(entries, (configurator, config) -> configurator.configure(config, context));
         }


### PR DESCRIPTION
I use CasC with Hashicorp Vault for secret handling. After an update from CasC 1.24 to the latest, I got a lot of following warnings:

```
2019-08-18 15:56:03.740+0000 [id=25]    WARNING i.j.p.casc.SecretSourceResolver#handleUndefinedVariable: Configuration import:
Found unresolved variable ldap_password. Will default to empty string
```

although I didn't change my configuration or contents of my Vault. After looking at the stacktraces for [reveal](http://dpaste.com/10GPAGX.txt) and [init](http://dpaste.com/305GZ8R.txt) I have found out that ```VaultSecretSource#reveal``` is called before ```VaultSecretSource#init```, hence ```secrets.size() ``` is ```0```.

With support of @casz I suggest this fix.