### PR TITLE
Dependabot: Ignore Docker, Kubernetes, Declarative Pipeline and Custom Tools plugins which have custom group IDs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -15,5 +15,5 @@ update_configs:
     - match:
         dependency_name: "com.cloudbees.jenkins.plugins*"
      - match:
-        dependency_name: "org.csanchez.jenkins.pluginss*"
+        dependency_name: "org.csanchez.jenkins.plugins*"
   

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,6 +9,8 @@ update_configs:
     - match:
         dependency_name: "org.jenkins-ci.plugins*"
     - match:
+        dependency_name: "org.jenkinsci.plugins*"
+    - match:
         dependency_name: "io.jenkins.plugins*"
     - match:
         dependency_name: "io.jenkins.docker:docker-plugin"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,4 +10,10 @@ update_configs:
         dependency_name: "org.jenkins-ci.plugins*"
     - match:
         dependency_name: "io.jenkins.plugins*"
+    - match:
+        dependency_name: "io.jenkins.docker:docker-plugin"
+    - match:
+        dependency_name: "com.cloudbees.jenkins.plugins*"
+     - match:
+        dependency_name: "org.csanchez.jenkins.pluginss*"
   


### PR DESCRIPTION
Should prevent new PRs from appearing for integration tests

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
