### PR TITLE
Fix space in logs

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -209,7 +209,7 @@ public class Attribute<Owner, Type> {
     }
 
     public void setValue(Owner target, Type value) throws Exception {
-        LOGGER.log(Level.FINE, "Setting {0}. {1} = {2}",
+        LOGGER.log(Level.FINE, "Setting {0}.{1} = {2}",
                 new Object[] {target, name, (isSecret(target) ? "****" : value)});
         setter.setValue(target, value);
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -161,7 +161,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                         args[i] = configurator.configure(value, context);
                     }
                     if (LOGGER.isLoggable(Level.FINE)) {
-                        LOGGER.log(Level.FINE, "Setting {0}. {1} = {2}",
+                        LOGGER.log(Level.FINE, "Setting {0}.{1} = {2}",
                                 new Object[]{target, names[i], t == Secret.class || Attribute.calculateIfSecret(target, names[i]) ? "****" : value});
                     }
                 } else if (t.isPrimitive()) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
before:
```
Sep 08, 2019 9:14:47 PM io.jenkins.plugins.casc.Attribute setValue
INFO: Setting hudson.model.Hudson@2ddc1480. systemMessage = Hi
```

now:
```
Sep 08, 2019 9:15:22 PM io.jenkins.plugins.casc.Attribute setValue
INFO: Setting hudson.model.Hudson@2ddc1480.systemMessage = Hi
```

note this will likely break some plugin tests when they upgrade but it's a trivial fix, doing this change now to help get https://github.com/jenkinsci/bom/pull/78 over the line

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
Fixes https://github.com/jenkinsci/configuration-as-code-plugin/issues/1048
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue. - provided down stream test cases 😆

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
