### PR TITLE
Allow `@CheckForNull` annotations to override `@ParametersAreNonnullByDefault` in DataBoundContructor

### DIFF
--- a/integrations/src/test/resources/io/jenkins/plugins/casc/SonarQubeTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/SonarQubeTest.yml
@@ -6,6 +6,7 @@ unclassified:
         serverUrl: "http://url:9000"
         serverAuthenticationToken: "token"
         mojoVersion: "mojoVersion"
+        additionalProperties: "blah=blah"
         additionalAnalysisProperties: "additionalAnalysisProperties"
         triggers:
           skipScmCause: true

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.casc.impl.configurators;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Descriptor;
 import hudson.util.Secret;
@@ -26,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.annotation.PostConstruct;
@@ -118,7 +118,8 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                 if (value == null && (parameters[i].isAnnotationPresent(Nonnull.class)   ||
                     constructor.isAnnotationPresent(ParametersAreNonnullByDefault.class) ||
                     clazz.isAnnotationPresent(ParametersAreNonnullByDefault.class)       ||
-                    clazz.getPackage().isAnnotationPresent(ParametersAreNonnullByDefault.class))) {
+                    clazz.getPackage().isAnnotationPresent(ParametersAreNonnullByDefault.class) &&
+                        !parameters[i].isAnnotationPresent(CheckForNull.class))) {
 
                     if (Set.class.isAssignableFrom(t)) {
                         LOGGER.log(Level.FINER, "The parameter to be set is @Nonnull but is not present; " +

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -129,8 +129,6 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
                         LOGGER.log(Level.FINER, "The parameter to be set is @Nonnull but is not present; " +
                                                            "setting equal to empty list.");
                         args[i] = Collections.emptyList();
-                    } else if (String.class.isAssignableFrom(t)) {
-                        args[i] = "";
                     } else {
                         throw new ConfiguratorException(names[i] + " is required to configure " + target);
                     }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -9,6 +9,7 @@ import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.impl.configurators.nonnull.ClassParametersAreNonnullByDefault;
 import io.jenkins.plugins.casc.impl.configurators.nonnull.NonnullParameterConstructor;
 import io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage.PackageParametersAreNonnullByDefault;
+import io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage.PackageParametersNonNullCheckForNull;
 import io.jenkins.plugins.casc.misc.Util;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
@@ -36,6 +37,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -149,6 +151,17 @@ public class DataBoundConfiguratorTest {
                                                         .lookupOrFail(PackageParametersAreNonnullByDefault.class)
                                                         .configure(config, new ConfigurationContext(registry));
         assertTrue(configured.getString().isEmpty());
+    }
+
+    @Test
+    @Issue("#1025")
+    public void packageParametersAreNonnullByDefaultButCanBeNullable() throws Exception {
+        Mapping config = new Mapping();
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        final PackageParametersNonNullCheckForNull configured = (PackageParametersNonNullCheckForNull) registry
+            .lookupOrFail(PackageParametersNonNullCheckForNull.class)
+            .configure(config, new ConfigurationContext(registry));
+        assertNull(configured.getSecret());
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -24,6 +24,7 @@ import javax.annotation.PostConstruct;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
@@ -52,6 +53,9 @@ public class DataBoundConfiguratorTest {
 
     @Rule
     public LoggerRule logging = new LoggerRule();
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void tearUp() {
@@ -140,17 +144,20 @@ public class DataBoundConfiguratorTest {
         final ClassParametersAreNonnullByDefault configured = (ClassParametersAreNonnullByDefault) registry
                                                         .lookupOrFail(ClassParametersAreNonnullByDefault.class)
                                                         .configure(config, new ConfigurationContext(registry));
-        assertEquals(0, configured.getStrings().size());
+        assertTrue(configured.getStrings().isEmpty());
     }
 
     @Test
     public void packageParametersAreNonnullByDefault() throws Exception {
         Mapping config = new Mapping();
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        final PackageParametersAreNonnullByDefault configured = (PackageParametersAreNonnullByDefault) registry
-                                                        .lookupOrFail(PackageParametersAreNonnullByDefault.class)
-                                                        .configure(config, new ConfigurationContext(registry));
-        assertTrue(configured.getString().isEmpty());
+
+        exceptionRule.expect(ConfiguratorException.class);
+        exceptionRule.expectMessage("string is required to configure class io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage.PackageParametersAreNonnullByDefault");
+
+        registry
+            .lookupOrFail(PackageParametersAreNonnullByDefault.class)
+            .configure(config, new ConfigurationContext(registry));
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersNonNullCheckForNull.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersNonNullCheckForNull.java
@@ -6,7 +6,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Checks the behaviour of {@link io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator} with non null
- * {@link String} when using package-level {@link javax.annotation.ParametersAreNonnullByDefault} annotations.
+ * {@link Secret} when using package-level {@link javax.annotation.ParametersAreNonnullByDefault} annotations.
  */
 public class PackageParametersNonNullCheckForNull {
     private Secret secret;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersNonNullCheckForNull.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersNonNullCheckForNull.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage;
+
+import hudson.util.Secret;
+import javax.annotation.CheckForNull;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Checks the behaviour of {@link io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator} with non null
+ * {@link String} when using package-level {@link javax.annotation.ParametersAreNonnullByDefault} annotations.
+ */
+public class PackageParametersNonNullCheckForNull {
+    private Secret secret;
+
+    @DataBoundConstructor
+    public PackageParametersNonNullCheckForNull(@CheckForNull Secret secret) {
+        this.secret = secret;
+    }
+
+    public Secret getSecret() {
+        return secret;
+    }
+}


### PR DESCRIPTION
Previously if someone had put ParametersAreNonnullByDefault on a class /
method / package-info there was no way to override and say this field
should be nullable.

Fixes #1025

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
