### PR TITLE
Move mercurial ITs to the demos

### DIFF
--- a/demos/mercurial/README.md
+++ b/demos/mercurial/README.md
@@ -1,0 +1,29 @@
+# Configure mercurial
+
+Basic configuration of the [Mercurial](https://plugins.jenkins.io/mercurial)
+
+## sample configuration
+
+```yaml
+tool:
+  mercurialinstallation:
+    installations:
+      - name: "Mercurial 3"
+        home: "/mercurial"
+        config: |
+          [defaults]
+          clone = --uncompressed
+          bundle = --type none
+        executable: "INSTALLATION/bin/hg"
+        useCaches: true
+        debug: false
+        masterCacheRoot: "/cache/root"
+        useSharing: false
+        properties:
+          - installSource:
+              installers:
+                - command:
+                    toolHome: "mercurial"
+                    label: "SomeLabel"
+                    command: "[ -d mercurial ] || wget -q -O - http://www.archlinux.org/packages/extra/x86_64/mercurial/download/ | xzcat | tar xvf -"
+```

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MercurialTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MercurialTest.java
@@ -3,8 +3,8 @@ package io.jenkins.plugins.casc;
 import hudson.plugins.mercurial.MercurialInstallation;
 import hudson.tools.CommandInstaller;
 import hudson.tools.InstallSourceProperty;
-import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
-import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,10 +15,10 @@ import org.junit.Test;
 public class MercurialTest {
 
     @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+    public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();
 
     @Test
-    @ConfiguredWithCode("MercurialTest.yaml")
+    @ConfiguredWithReadme("mercurial/README.md")
     public void should_configure_maven_tools_and_global_config() {
         final Object descriptor = j.jenkins.getDescriptorOrDie(MercurialInstallation.class);
         Assert.assertNotNull(descriptor);


### PR DESCRIPTION
As a consequence of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1055 let's move each demos in independent PRs to track all the required dependencies.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
