### PR TITLE
Validate slack demo with the integrations framework

### DIFF
--- a/demos/slack/README.md
+++ b/demos/slack/README.md
@@ -1,6 +1,6 @@
 # Configure Slack
 
-Basic configuration of the [Slack plugin](https://wiki.jenkins.io/display/JENKINS/Slack+Plugin)
+Basic configuration of the [Slack plugin](https://plugins.jenkins.io/slack)
 
 ## Sample configuration
 

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -266,7 +266,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.9.9.1</version>
+      <version>2.9.10</version>
     </dependency>
 
     <dependency>
@@ -398,12 +398,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.9</version>
+        <version>2.9.10</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.1</version>
+        <version>2.9.10</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -568,7 +568,7 @@
       <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20180813</version>
+        <version>20190722</version>
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -266,13 +266,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.8.11.2</version>
+      <version>2.9.9.1</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ec2</artifactId>
       <version>1.44</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>slack</artifactId>
+      <version>2.34</version>
       <scope>test</scope>
     </dependency>
 
@@ -314,7 +321,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>1.1.1</version>
+      <version>2.3.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -396,7 +403,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9</version>
+        <version>2.9.9.1</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -411,7 +418,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.9</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SlackTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SlackTest.java
@@ -1,11 +1,15 @@
 package io.jenkins.plugins.casc;
 
+import hudson.ExtensionList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import jenkins.plugins.slack.SlackNotifier;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.RuleChain;
+
+import static junit.framework.TestCase.assertNotNull;
 
 /**
  * @author v1v (Victor Martinez)
@@ -20,7 +24,9 @@ public class SlackTest {
     @Test
     @ConfiguredWithReadme("slack/README.md")
     public void configure_slack() throws Exception {
-        // Already validated within the plugin itself
+        // Already validated within the plugin itself, so let's run some simple validations
         // https://github.com/jenkinsci/slack-plugin/pull/582
+        SlackNotifier.DescriptorImpl slackNotifier = ExtensionList.lookupSingleton(SlackNotifier.DescriptorImpl.class);
+        assertNotNull(slackNotifier);
     }
 }

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SlackTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SlackTest.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.casc;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.RuleChain;
+
+/**
+ * @author v1v (Victor Martinez)
+ */
+public class SlackTest {
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
+        .set("SLACK_TOKEN", "ADMIN123"))
+        .around(new JenkinsConfiguredWithReadmeRule());
+
+    @Test
+    @ConfiguredWithReadme("slack/README.md")
+    public void configure_slack() throws Exception {
+        // Already validated within the plugin itself
+        // https://github.com/jenkinsci/slack-plugin/pull/582
+    }
+}


### PR DESCRIPTION
As a consequence of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1055 let's move each demos in independent PRs to track all the required dependencies.

This is already validated within the plugin see https://github.com/jenkinsci/slack-plugin/pull/582 . Therefore, it does only validate the JCasC doesn't fail when using the demo rather than validating whether the fields are the expected one, that' already managed within the plugin itself.

Let's bump jackson dependencies too.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->