### PR TITLE
Validate simple-theme demo with the integrations framework

### DIFF
--- a/demos/simple-theme-plugin/README.md
+++ b/demos/simple-theme-plugin/README.md
@@ -1,4 +1,6 @@
-# configure simple-theme-plugin plugin
+# Configure simple-theme-plugin plugin
+
+Basic configuration of the [Simple Theme plugin](https://plugins.jenkins.io/simple-theme-plugin)
 
 ## sample configuration
 

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -203,6 +203,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>simple-theme-plugin</artifactId>
+      <version>0.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
       <scope>test</scope>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SimpleThemeTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SimpleThemeTest.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.casc;
+
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import org.codefirst.SimpleThemeDecorator;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author v1v (Victor Martinez)
+ */
+public class SimpleThemeTest {
+
+    @Rule
+    public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();
+
+    @Test
+    @ConfiguredWithReadme("simple-theme-plugin/README.md")
+    public void configure_simple_theme() throws Exception {
+        // Already tested within the plugin itself, let's run some basic tests.
+        // https://github.com/jenkinsci/simple-theme-plugin/blob/master/src/test/java/org/jenkinsci/plugins/simpletheme/ConfigurationAsCodeTest.java
+        SimpleThemeDecorator decorator = ExtensionList.lookupSingleton(SimpleThemeDecorator.class);
+        assertNotNull(decorator);
+    }
+}


### PR DESCRIPTION
As a consequence of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1055 let's move each demos in independent PRs to track all the required dependencies.

This is already validated within the plugin see https://github.com/jenkinsci/simple-theme-plugin/blob/master/src/test/java/org/jenkinsci/plugins/simpletheme/ConfigurationAsCodeTest.java . Therefore, it does only validate the JCasC doesn't fail when using the demo rather than validating whether the fields are the expected one, that' already managed within the plugin itself.


<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->