### PR TITLE
Change log level to WARN when configuration sources could not be applied

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -179,7 +179,7 @@ public class ConfigurationAsCode extends ManagementLink {
                 }
                 LOGGER.log(Level.FINE, "Replace configuration with: " + normalizedSource);
             } else {
-                LOGGER.log(Level.INFO, "Provided sources could not be applied");
+                LOGGER.log(Level.WARNING, "Provided sources could not be applied");
                 // todo: show message in UI
             }
         } else {


### PR DESCRIPTION
Fixes #961 as suggested by https://github.com/jenkinsci/configuration-as-code-plugin/issues/961#issuecomment-514055087