### PR TITLE
Update error message in RoundTripAbstractTest

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
@@ -160,7 +160,7 @@ public abstract class RoundTripAbstractTest {
         NameValuePair param = new NameValuePair("newSource", f.toURI().toURL().toExternalForm());
         request.setRequestParameters(Collections.singletonList(param));
         WebResponse response = client.loadWebResponse(request);
-        assertEquals("Failed to POST to " + request.getURL().toString(), 200, response.getStatusCode());
+        assertEquals("Failed to POST to " + request.getUrl().toString(), 200, response.getStatusCode());
         String res = response.getContentAsString();
         assertThat(res, containsString("The configuration can be applied"));
     }
@@ -177,7 +177,7 @@ public abstract class RoundTripAbstractTest {
         request.setRequestParameters(Collections.singletonList(param));
         request.setRequestParameters(Collections.singletonList(param));
         WebResponse response = client.loadWebResponse(request);
-        assertEquals("Failed to POST to " + request.getURL().toString(), 200, response.getStatusCode());
+        assertEquals("Failed to POST to " + request.getUrl().toString(), 200, response.getStatusCode());
         String res = response.getContentAsString();
         /* The result page has:
         Configuration loaded from :

--- a/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
@@ -160,7 +160,7 @@ public abstract class RoundTripAbstractTest {
         NameValuePair param = new NameValuePair("newSource", f.toURI().toURL().toExternalForm());
         request.setRequestParameters(Collections.singletonList(param));
         WebResponse response = client.loadWebResponse(request);
-        assertEquals(200, response.getStatusCode());
+        assertEquals("Failed to POST to " + request.getURL().toString(), 200, response.getStatusCode());
         String res = response.getContentAsString();
         assertThat(res, containsString("The configuration can be applied"));
     }
@@ -177,7 +177,7 @@ public abstract class RoundTripAbstractTest {
         request.setRequestParameters(Collections.singletonList(param));
         request.setRequestParameters(Collections.singletonList(param));
         WebResponse response = client.loadWebResponse(request);
-        assertEquals(200, response.getStatusCode());
+        assertEquals("Failed to POST to " + request.getURL().toString(), 200, response.getStatusCode());
         String res = response.getContentAsString();
         /* The result page has:
         Configuration loaded from :


### PR DESCRIPTION
In case if assertConfigViaWebUI or applyConfigViaWebUI fails to POST to Jenkins fails, there is a reasonable error message now.