### PR TITLE
Validate TFS demos with the integrations tests

### DIFF
--- a/demos/tfs/README.md
+++ b/demos/tfs/README.md
@@ -1,4 +1,6 @@
-# TFS/Team Services plugin
+# Configure TFS/Team Services plugin
+
+Basic configuration of the [Team Foundation Server plugin](https://plugins.jenkins.io/tfs)
 
 TFS plugin configuration belongs under `unclassified` root element
 

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -258,6 +258,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>tfs</artifactId>
+      <version>5.157.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
       <scope>test</scope>
@@ -499,6 +506,11 @@
         <version>2.3.3</version>
       </dependency>
       <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.5</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>3.0.0-beta-2</version>
@@ -620,5 +632,48 @@
          <directory>../demos</directory>
        </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>1.4.2</version>
+        <executions>
+          <execution>
+            <id>download.tfs.sdk.jar.locally</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/jenkinsci/tfs-plugin/raw/master/tfs-sdk/src/com.microsoft.tfs.sdk-14.0.3.jar</url>
+              <md5>88d646750fe93030183ca12e61b3dca9</md5>
+              <outputFileName>com.microsoft.tfs.sdk-14.0.3.jar</outputFileName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+        <executions>
+          <execution>
+            <id>install.tfs.sdk.jar.locally</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>install-file</goal>
+            </goals>
+            <configuration>
+              <file>${project.build.directory}/com.microsoft.tfs.sdk-14.0.3.jar</file>
+              <groupId>com.microsoft.tfs.sdk</groupId>
+              <artifactId>com.microsoft.tfs.sdk</artifactId>
+              <version>14.0.3</version>
+              <packaging>jar</packaging>
+              <generatePom>true</generatePom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -640,7 +640,7 @@
         <executions>
           <execution>
             <id>download.tfs.sdk.jar.locally</id>
-            <phase>clean</phase>
+            <phase>validate</phase>
             <goals>
               <goal>wget</goal>
             </goals>
@@ -659,7 +659,7 @@
         <executions>
           <execution>
             <id>install.tfs.sdk.jar.locally</id>
-            <phase>clean</phase>
+            <phase>validate</phase>
             <goals>
               <goal>install-file</goal>
             </goals>
@@ -671,6 +671,15 @@
               <packaging>jar</packaging>
               <generatePom>true</generatePom>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/TfsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/TfsTest.java
@@ -1,0 +1,38 @@
+package io.jenkins.plugins.casc;
+
+import hudson.plugins.tfs.TeamCollectionConfiguration;
+import hudson.plugins.tfs.TeamPluginGlobalConfig;
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import jenkins.model.GlobalConfiguration;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author v1v (Victor Martinez)
+ */
+public class TfsTest {
+
+    @ClassRule
+    @ConfiguredWithReadme("tfs/README.md")
+    public static JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();
+
+    @Test
+    public void configure_tfs() {
+        final TeamPluginGlobalConfig configuration = GlobalConfiguration.all().get(TeamPluginGlobalConfig.class);
+        assertNotNull(configuration);
+        assertThat(configuration.getCollectionConfigurations(), hasSize(1));
+        TeamCollectionConfiguration team = configuration.getCollectionConfigurations().get(0);
+        assertThat(team.getCollectionUrl(), is("http://test.com"));
+        assertThat(team.getCredentialsId(), is("tfsCredentials"));
+        assertTrue(configuration.isEnableTeamPushTriggerForAllJobs());
+        assertTrue(configuration.isEnableTeamStatusForAllJobs());
+        assertTrue(configuration.isConfigFolderPerNode());
+    }
+}


### PR DESCRIPTION
As a consequence of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1055 let's move each demos in independent PRs to track all the required dependencies.

## Highlights.
- `com.microsoft.tfs.sdk-14.0.3.jar` is not hosted, in fact, the plugin itself does some tweaks to install it locally before building it. https://github.com/jenkinsci/tfs-plugin/tree/master/tfs-sdk
- The above workaround works by overring the order of the maven plugins executions, so the enforce  plugin is required to be launched afterwards, that's the reason for being redefined in the integrations/pom.xml

## Questions
- If the above approach is too over engineering, what other suggestions do you have?

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->