### PR TITLE
Deprecate misspelled Mapping.putIfNotEmpry in favor of Mapping.putIfNotEmpty

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
@@ -47,7 +47,15 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
         if (node != null) super.put(key, node);
     }
 
+    /**
+     * @deprecated Misspelled name, use {@link #putIfNotEmpty(String, Sequence)} instead.
+     */
+    @Deprecated
     public void putIfNotEmpry(String key, Sequence seq) {
+        this.putIfNotEmpty(key, seq);
+    }
+
+    public void putIfNotEmpty(String key, Sequence seq) {
         if (!seq.isEmpty()) super.put(key, seq);
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Mapping.java
@@ -47,14 +47,6 @@ public final class Mapping extends HashMap<String, CNode> implements CNode {
         if (node != null) super.put(key, node);
     }
 
-    /**
-     * @deprecated Misspelled name, use {@link #putIfNotEmpty(String, Sequence)} instead.
-     */
-    @Deprecated
-    public void putIfNotEmpry(String key, Sequence seq) {
-        this.putIfNotEmpty(key, seq);
-    }
-
     public void putIfNotEmpty(String key, Sequence seq) {
         if (!seq.isEmpty()) super.put(key, seq);
     }


### PR DESCRIPTION
fixes #1162

Annotated the old, misspelled method with @Deprecated and made the old method call the new one.
Link to the issue: https://github.com/jenkinsci/configuration-as-code-plugin/issues/1162


### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
