### PR TITLE
Fix config file list always contain one item

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -284,10 +284,11 @@ public class ConfigurationAsCode extends ManagementLink {
     private List<YamlSource> getStandardConfigSources() throws ConfiguratorException {
         List<YamlSource> configs = new ArrayList<>();
 
-        for (String p : getStandardConfig()) {
+        List<String> standardConfig = getStandardConfig();
+        for (String p : standardConfig) {
             appendSources(configs, p);
-            sources = Collections.singletonList(p);
         }
+        sources = Collections.unmodifiableList(standardConfig);
         return configs;
     }
 
@@ -557,8 +558,8 @@ public class ConfigurationAsCode extends ManagementLink {
 
         for (String p : configParameters) {
             appendSources(configs, p);
-            sources = Collections.singletonList(p);
         }
+        sources = Collections.unmodifiableList(configParameters.stream().collect(toList()));
         configureWith(configs);
         lastTimeLoaded = System.currentTimeMillis();
     }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -122,6 +122,16 @@ public class ConfigurationAsCodeTest {
         assertThat(j.jenkins.getSystemMessage(), equalTo("configuration as code - JenkinsConfigTest"));
     }
 
+    @Test
+    @ConfiguredWithCode(value = {"merge1.yml", "merge3.yml"}, expected = ConfiguratorException.class)
+    public void test_loads_multi_files() throws Exception {
+        ConfigurationAsCode casc = ConfigurationAsCode.get();
+
+        List<String> sources = casc.getSources();
+        assertNotNull(sources);
+        assertEquals(sources.size(), 2);
+    }
+
     @Test(expected = ConfiguratorException.class)
     public void shouldReportMissingFileOnNotFoundConfig() throws ConfiguratorException {
         ConfigurationAsCode casc = new ConfigurationAsCode();


### PR DESCRIPTION
CASC allows providing config files located in multiple places. But no matter how many files were loaded. We can only see the last of them on the page.
This PR will expose all the config files which were loaded.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.