### PR TITLE
Make the `io.jenkins.plugins.casc.ConfigurationAsCode` API available to plugins

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -269,6 +269,7 @@ public class ConfigurationAsCode extends ManagementLink {
      *
      * @throws Exception when the file provided cannot be found or parsed
      */
+    @Restricted(NoExternalUse.class)
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void init() throws Exception {
         detectVaultPluginMissing();
@@ -327,6 +328,7 @@ public class ConfigurationAsCode extends ManagementLink {
         return configParameters;
     }
 
+    @Restricted(NoExternalUse.class)
     public List<String> getBundledCasCURIs() {
         final String cascFile = "/WEB-INF/" + DEFAULT_JENKINS_YAML_PATH;
         final String cascDirectory = "/WEB-INF/" + DEFAULT_JENKINS_YAML_PATH + ".d/";
@@ -448,6 +450,7 @@ public class ConfigurationAsCode extends ManagementLink {
         req.getView(this, "reference.jelly").forward(req, res);
     }
 
+    @Restricted(NoExternalUse.class)
     public void export(OutputStream out) throws Exception {
 
         final List<NodeTuple> tuples = new ArrayList<>();
@@ -629,6 +632,7 @@ public class ConfigurationAsCode extends ManagementLink {
      * @param path base path to start (can be file or directory)
      * @return list of all paths matching pattern. Only base file itself if it is a file matching pattern
      */
+    @Restricted(NoExternalUse.class)
     public List<Path> configs(String path) throws ConfiguratorException {
         final Path root = Paths.get(path);
 
@@ -790,6 +794,7 @@ public class ConfigurationAsCode extends ManagementLink {
      * @return String that shows help. May be empty
      * @throws IOException if the resource cannot be read
      */
+    @Restricted(NoExternalUse.class)
     @NonNull
     public String getHtmlHelp(Class type, String attribute) throws IOException {
         final URL resource = Klass.java(type).getResource("help-" + attribute + ".html");
@@ -804,6 +809,7 @@ public class ConfigurationAsCode extends ManagementLink {
      *
      * @return String representation of the extension source, usually artifactId.
      */
+    @Restricted(NoExternalUse.class)
     @CheckForNull
     public String getExtensionSource(Configurator c) throws IOException {
         final Class e = c.getImplementedAPI();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -147,6 +147,7 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doReload(StaplerRequest request, StaplerResponse response) throws Exception {
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
@@ -157,6 +158,7 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doReplace(StaplerRequest request, StaplerResponse response) throws Exception {
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
@@ -200,6 +202,7 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     @POST
+    @Restricted(NoExternalUse.class)
     public FormValidation doCheckNewSource(@QueryParameter String newSource) {
         Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
         String normalizedSource = Util.fixEmptyAndTrim(newSource);
@@ -359,6 +362,7 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doCheck(StaplerRequest req, StaplerResponse res) throws Exception {
 
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
@@ -375,6 +379,7 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doApply(StaplerRequest req, StaplerResponse res) throws Exception {
 
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
@@ -389,6 +394,7 @@ public class ConfigurationAsCode extends ManagementLink {
      * @throws Exception
      */
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doExport(StaplerRequest req, StaplerResponse res) throws Exception {
 
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
@@ -405,6 +411,7 @@ public class ConfigurationAsCode extends ManagementLink {
      * Export JSONSchema to URL
      * @throws Exception
      */
+    @Restricted(NoExternalUse.class)
     public void doSchema(StaplerRequest req, StaplerResponse res) throws Exception {
 
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
@@ -417,6 +424,7 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     @RequirePOST
+    @Restricted(NoExternalUse.class)
     public void doViewExport(StaplerRequest req, StaplerResponse res) throws Exception {
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
             res.sendError(HttpServletResponse.SC_FORBIDDEN);
@@ -430,6 +438,7 @@ public class ConfigurationAsCode extends ManagementLink {
         req.getView(this, "viewExport.jelly").forward(req, res);
     }
 
+    @Restricted(NoExternalUse.class)
     public void doReference(StaplerRequest req, StaplerResponse res) throws Exception {
         if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
             res.sendError(HttpServletResponse.SC_FORBIDDEN);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -99,7 +99,6 @@ import static java.util.stream.Collectors.toList;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Extension
-@Restricted(NoExternalUse.class)
 public class ConfigurationAsCode extends ManagementLink {
 
     public static final String CASC_JENKINS_CONFIG_PROPERTY = "casc.jenkins.config";
@@ -440,7 +439,6 @@ public class ConfigurationAsCode extends ManagementLink {
         req.getView(this, "reference.jelly").forward(req, res);
     }
 
-    @Restricted(NoExternalUse.class)
     public void export(OutputStream out) throws Exception {
 
         final List<NodeTuple> tuples = new ArrayList<>();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Removed Restricted from ConfigurationAsCode in order to use it (reload and dump configuration) from another plugin

fixes #1202

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
