### PR TITLE
Add a configurable delay to avoid race condition in initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,25 @@ Kubernetes users:\
 
 Most plugins should be supported out-of-the-box, or maybe require some minimal changes. See this [dashboard](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=18341) for known compatibility issues.
 
+## Compatability with Jenkins > 2.199
+
+Jenkins 2.199 introduced a check to prevent saving global configuration before loading the configuration has occurred.  Configurations As Code needs to apply global configuration before Jenkins loads jobs (so they can load and correctly reference any global state) and as such until [JENKINS-51856](https://issues.jenkins-ci.org/browse/JENKINS-51856) is implemented there exists a race condition where by Jenkins may fail to start when used with this plugin.
+
+If you encounter the race condition Jenkins will fail to start with an exception message similar to the following:
+
+```
+SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
+java.lang.IllegalStateException: An attempt to save the global configuration was made before it was loaded
+```
+
+If you encounter this you can tell the plugin to delay configuration for an amount of time to give Jenkins time to load the global configuration before the configuration is applied by the plugin.
+
+To enable this set the `io.jenkins.plugins.casc.ConfigurationAsCode.initialDelay` system property to a number of milliseconds to delay the initialisation by.
+The required value will be dependant on aspects of your system (cpu/disk) and configuration, and can be found is mostly a trial and error.
+A suggestion would be to start with 5000 (5 Seconds) and then increment by 2000 (2 seconds) until you no longer exhibit the issue and finally add 1000 (1 second) for some extra safety.
+For example, to delay the configuration by 9 seconds you would use something like the following command `java -Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=9000 -jar jenkins.war`.
+Exactly how and where you specify this option depends on the installation method used to install Jenkins.
+
 
 ## Configuration-as-Code extension plugins
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Jenkins 2.199 introduced a check to prevent saving global configuration before l
 
 If you encounter the race condition Jenkins will fail to start with an exception message similar to the following:
 
-```
+```text
 SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
 java.lang.IllegalStateException: An attempt to save the global configuration was made before it was loaded
 ```

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ Kubernetes users:\
 
 Most plugins should be supported out-of-the-box, or maybe require some minimal changes. See this [dashboard](https://issues.jenkins.io/secure/Dashboard.jspa?selectPageId=18341) for known compatibility issues.
 
-## Compatability with Jenkins > 2.199
+## Compatibility with Jenkins > 2.199
 
-Jenkins 2.199 introduced a check to prevent saving global configuration before loading the configuration has occurred.  Configurations As Code needs to apply global configuration before Jenkins loads jobs (so they can load and correctly reference any global state) and as such until [JENKINS-51856](https://issues.jenkins-ci.org/browse/JENKINS-51856) is implemented there exists a race condition where by Jenkins may fail to start when used with this plugin.
+Jenkins 2.199 introduced [a check to prevent saving global configuration before loading the configuration has occurred](https://github.com/jenkinsci/jenkins/pull/4171). Configurations As Code needs to apply global configuration before Jenkins loads jobs (so they can load and correctly reference any global state) and as such until [JENKINS-51856](https://issues.jenkins-ci.org/browse/JENKINS-51856) is implemented there exists a race condition where by Jenkins may fail to start when used with this plugin.
 
 If you encounter the race condition Jenkins will fail to start with an exception message similar to the following:
 
@@ -173,7 +173,7 @@ java.lang.IllegalStateException: An attempt to save the global configuration was
 If you encounter this you can tell the plugin to delay configuration for an amount of time to give Jenkins time to load the global configuration before the configuration is applied by the plugin.
 
 To enable this set the `io.jenkins.plugins.casc.ConfigurationAsCode.initialDelay` system property to a number of milliseconds to delay the initialisation by.
-The required value will be dependant on aspects of your system (cpu/disk) and configuration, and can be found is mostly a trial and error.
+The required value will be dependant on aspects of your system (cpu/disk) and configuration, and how it can be found is mostly a trial and error.
 A suggestion would be to start with 5000 (5 Seconds) and then increment by 2000 (2 seconds) until you no longer exhibit the issue and finally add 1000 (1 second) for some extra safety.
 For example, to delay the configuration by 9 seconds you would use something like the following command `java -Dio.jenkins.plugins.casc.ConfigurationAsCode.initialDelay=9000 -jar jenkins.war`.
 Exactly how and where you specify this option depends on the installation method used to install Jenkins.

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -274,7 +274,7 @@ public class ConfigurationAsCode extends ManagementLink {
             try {
                 Thread.sleep(duration);
             } catch (InterruptedException e) {
-                LOGGER.log(Level.WARNING, "interupted whilst delaying startup", e);
+                LOGGER.log(Level.WARNING, "Interrupted whilst delaying CasC startup", e);
             }
         }
         detectVaultPluginMissing();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -269,6 +269,14 @@ public class ConfigurationAsCode extends ManagementLink {
      */
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
     public static void init() throws Exception {
+        Long duration = Long.getLong(ConfigurationAsCode.class.getName() + ".initialDelay");
+        if (duration != null) {
+            try {
+                Thread.sleep(duration);
+            } catch (InterruptedException e) {
+                LOGGER.log(Level.WARNING, "interupted whilst delaying startup", e);
+            }
+        }
         detectVaultPluginMissing();
         get().configure();
     }


### PR DESCRIPTION
The initializer needs to wait until Jenkins has loaded.
Until Jenkins has more milestones add a configurable delay before configuring from code

hacky workaround for #280 until https://issues.jenkins-ci.org/browse/JENKINS-51856 is implemented.

Completely untested drive by PR.  may blow up, std.disclaimers etc etc.

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
