### PR TITLE
Validate global libraries demo with the integrations framework

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
@@ -1,10 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
-import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
-import jenkins.plugins.git.GitSCMSource;
 import org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait;
 import org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait;
 import org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait.TrustPermission;
@@ -28,17 +25,6 @@ public class GlobalLibrariesTest {
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
-
-    @Test
-    @ConfiguredWithReadme("workflow-cps-global-lib/README.md")
-    public void configure_global_library() throws Exception {
-        assertEquals(1, GlobalLibraries.get().getLibraries().size());
-        final LibraryConfiguration library = GlobalLibraries.get().getLibraries().get(0);
-        assertEquals("awesome-lib", library.getName());
-        final SCMSourceRetriever retriever = (SCMSourceRetriever) library.getRetriever();
-        final GitSCMSource scm = (GitSCMSource) retriever.getScm();
-        assertEquals("https://github.com/jenkins-infra/pipeline-library.git", scm.getRemote());
-    }
 
     @Issue("JENKINS-57557")
     @Test

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
@@ -1,7 +1,9 @@
 package io.jenkins.plugins.casc;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.plugins.git.GitSCMSource;
 import org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait;
 import org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait;
@@ -28,7 +30,7 @@ public class GlobalLibrariesTest {
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
 
     @Test
-    @ConfiguredWithCode("GlobalLibrariesTest.yml")
+    @ConfiguredWithReadme("workflow-cps-global-lib/README.md")
     public void configure_global_library() throws Exception {
         assertEquals(1, GlobalLibraries.get().getLibraries().size());
         final LibraryConfiguration library = GlobalLibraries.get().getLibraries().get(0);
@@ -36,7 +38,6 @@ public class GlobalLibrariesTest {
         final SCMSourceRetriever retriever = (SCMSourceRetriever) library.getRetriever();
         final GitSCMSource scm = (GitSCMSource) retriever.getScm();
         assertEquals("https://github.com/jenkins-infra/pipeline-library.git", scm.getRemote());
-
     }
 
     @Issue("JENKINS-57557")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/WorkflowCpsGlobalLibTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/WorkflowCpsGlobalLibTest.java
@@ -1,0 +1,32 @@
+package io.jenkins.plugins.casc;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import jenkins.plugins.git.GitSCMSource;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:VictorMartinezRubio@gmail.com">Victor Martinez</a>
+ */
+public class WorkflowCpsGlobalLibTest {
+
+    @Rule
+    public JenkinsConfiguredWithReadmeRule j2 = new JenkinsConfiguredWithReadmeRule();
+
+    @Test
+    @ConfiguredWithReadme("workflow-cps-global-lib/README.md")
+    public void configure_global_library() throws Exception {
+        assertEquals(1, GlobalLibraries.get().getLibraries().size());
+        final LibraryConfiguration library = GlobalLibraries.get().getLibraries().get(0);
+        assertEquals("awesome-lib", library.getName());
+        final SCMSourceRetriever retriever = (SCMSourceRetriever) library.getRetriever();
+        final GitSCMSource scm = (GitSCMSource) retriever.getScm();
+        assertEquals("https://github.com/jenkins-infra/pipeline-library.git", scm.getRemote());
+    }
+}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalLibrariesTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalLibrariesTest.yml
@@ -1,9 +1,0 @@
-unclassified:
-  globalLibraries:
-    libraries:
-      - name: "awesome-lib"
-        retriever:
-          modernSCM:
-            scm:
-              git:
-                remote: "https://github.com/jenkins-infra/pipeline-library.git"


### PR DESCRIPTION
As a consequence of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1055 let's move each demos in independent PRs to track all the required dependencies.

`integrations/src/test/resources/io/jenkins/plugins/casc/GlobalLibrariesTest.yml` has been deleted since it's already tested with the demos.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->