### PR TITLE
Validate graphite demo with the integrations framework

### DIFF
--- a/demos/graphite/README.md
+++ b/demos/graphite/README.md
@@ -1,12 +1,14 @@
-# configure Metrics Graphite plugin
+# Configure Metrics Graphite plugin
 
-## sample configuration
+Basic configuration of the [Metrics Graphite plugin](https://plugins.jenkins.io/metrics-graphite)
+
+## Sample configuration
 
 ```yaml
 unclassified:
-  graphiteserver:
+  graphiteServer:
     servers:
-      - hostname: "1.2.3.4"
-        port: 2003
-        prefix: jenkins.master.
+    - hostname: "1.2.3.4"
+      port: 2003
+      prefix: "jenkins.master."
 ```

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -219,6 +219,13 @@
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>metrics-graphite</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mesos</artifactId>
       <version>1.0.0</version>
       <scope>test</scope>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GraphiteTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GraphiteTest.java
@@ -1,0 +1,31 @@
+package io.jenkins.plugins.casc;
+
+import hudson.ExtensionList;
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import jenkins.metrics.impl.graphite.GraphiteServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author v1v (Victor Martinez)
+ */
+public class GraphiteTest {
+
+    @Rule
+    public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();
+
+    @Test
+    @ConfiguredWithReadme("graphite/README.md")
+    public void configure_graphite() {
+        final GraphiteServer.DescriptorImpl descriptor = ExtensionList.lookupSingleton(GraphiteServer.DescriptorImpl.class);
+        assertNotNull(descriptor);
+        assertEquals(1, descriptor.getServers().size());
+        assertEquals("1.2.3.4", descriptor.getServers().get(0).getHostname());
+        assertEquals(2003, descriptor.getServers().get(0).getPort());
+        assertEquals("jenkins.master.", descriptor.getServers().get(0).getPrefix());
+    }
+}


### PR DESCRIPTION
As a consequence of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1055 let's move each demos in independent PRs to track all the required dependencies.

It does work in my local jenkins instance, but it fails with the ITs:

```
Caused by: io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator configurator
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:702)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:738)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:611)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:581)
	at io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule.before(JenkinsConfiguredWithReadmeRule.java:69)
	... 5 more
Caused by: io.jenkins.plugins.casc.ConfiguratorException: Failed to save jenkins.metrics.impl.graphite.GraphiteServer$DescriptorImpl@58c21c4b
Caused by: io.jenkins.plugins.casc.ConfiguratorException: : Failed to set attribute servers(class: class jenkins.metrics.impl.graphite.GraphiteServer, multiple: true)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:360)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:270)
	... 13 more
```

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.