### PR TITLE
Validate jenkins demos with the integrations tests

### DIFF
--- a/demos/jenkins/jenkins.yaml
+++ b/demos/jenkins/jenkins.yaml
@@ -42,16 +42,19 @@ tool:
       - name: git
         home: /usr/local/bin/git
 
-security:
-  remotingCLI:
-    enabled: false
+##  If Jenkins <2.165 then you can comment out the below section:
+##
+##  https://github.com/jenkinsci/configuration-as-code-plugin/issues/754
+##
+##security:
+##  remotingCLI:
+##    enabled: false
 
 unclassified:
   artifactorybuilder:
     useCredentialsPlugin: true
     artifactoryServers:
-      - name: foo
-        serverId: artifactory
+      - serverId: artifactory
         artifactoryUrl: http://acme.com/artifactory
         resolverCredentialsConfig:
           username: artifactory_user
@@ -69,14 +72,6 @@ unclassified:
   location:
     adminAddress: you@example.com
     url: https://ci.example.com/
-
-  teampluginglobalconfig:
-    collectionConfigurations:
-      - collectionUrl: http://test.com
-        credentialsId: tfsCredentials
-    enableTeamPushTriggerForAllJobs: true
-    enableTeamStatusForAllJobs: true
-    configFolderPerNode: true
 
   mailer:
     replyToAddress: do-not-reply@acme.org

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsDemoTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsDemoTest.java
@@ -1,0 +1,82 @@
+package io.jenkins.plugins.casc;
+
+import com.nirima.jenkins.plugins.docker.DockerCloud;
+import hudson.model.Node.Mode;
+import hudson.plugins.git.GitTool;
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
+import hudson.tasks.Mailer;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+import org.jfrog.hudson.ArtifactoryBuilder;
+import org.jfrog.hudson.ArtifactoryServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.RuleChain;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author v1v (Victor Martinez)
+ */
+public class JenkinsDemoTest {
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
+        .set("ARTIFACTORY_PASSWORD", "password123"))
+        .around(new JenkinsConfiguredWithCodeRule());
+
+    @Test
+    @ConfiguredWithCode("jenkins/jenkins.yaml")
+    public void configure_demo_yaml() throws Exception {
+        final Jenkins jenkins = Jenkins.get();
+        assertEquals("Jenkins configured automatically by Jenkins Configuration as Code plugin\n\n", jenkins.getSystemMessage());
+        assertEquals(5, jenkins.getNumExecutors());
+        assertEquals(2, jenkins.getScmCheckoutRetryCount());
+        assertEquals(Mode.NORMAL, jenkins.getMode());
+        assertEquals("https://ci.example.com/", jenkins.getRootUrl());
+
+        final FullControlOnceLoggedInAuthorizationStrategy strategy = (FullControlOnceLoggedInAuthorizationStrategy) jenkins.getAuthorizationStrategy();
+        assertFalse(strategy.isAllowAnonymousRead());
+
+        final DockerCloud docker = DockerCloud.getCloudByName("docker");
+        assertNotNull(docker);
+        assertNotNull(docker.getDockerApi());
+        assertNotNull(docker.getDockerApi().getDockerHost());
+        assertEquals("unix:///var/run/docker.sock", docker.getDockerApi().getDockerHost().getUri());
+
+        final GitTool.DescriptorImpl gitTool = (GitTool.DescriptorImpl) jenkins.getDescriptor(GitTool.class);
+        assertEquals(1, gitTool.getInstallations().length);
+
+        assertEquals(1, GlobalLibraries.get().getLibraries().size());
+        final LibraryConfiguration library = GlobalLibraries.get().getLibraries().get(0);
+        assertEquals("awesome-lib", library.getName());
+
+        final Mailer.DescriptorImpl descriptor = (Mailer.DescriptorImpl) jenkins.getDescriptor(Mailer.class);
+        assertEquals("4441", descriptor.getSmtpPort());
+        assertEquals("do-not-reply@acme.org", descriptor.getReplyToAddress());
+        assertEquals("smtp.acme.org", descriptor.getSmtpHost() );
+
+        final ArtifactoryBuilder.DescriptorImpl artifactory = (ArtifactoryBuilder.DescriptorImpl) jenkins.getDescriptor(ArtifactoryBuilder.class);
+        assertTrue(artifactory.getUseCredentialsPlugin());
+
+        final List<ArtifactoryServer> actifactoryServers = artifactory.getArtifactoryServers();
+        assertThat(actifactoryServers, hasSize(1));
+        assertThat(actifactoryServers.get(0).getName(), is(equalTo("artifactory")));
+        assertThat(actifactoryServers.get(0).getUrl(), is(equalTo("http://acme.com/artifactory")));
+        assertThat(actifactoryServers.get(0).getResolverCredentialsConfig().getUsername(), is(equalTo("artifactory_user")));
+        assertThat(actifactoryServers.get(0).getResolverCredentialsConfig().getPassword(), is(equalTo("password123")));
+    }
+
+}

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsReadmeDemoTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsReadmeDemoTest.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.casc;
+
+import hudson.model.Node.Mode;
+import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author v1v (Victor Martinez)
+ */
+public class JenkinsReadmeDemoTest {
+
+    @Rule
+    public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();
+
+    @Test
+    @ConfiguredWithReadme("jenkins/README.md#0")
+    public void configure_demo_first_code_block() throws Exception {
+        final Jenkins jenkins = Jenkins.get();
+        assertEquals("Jenkins configured automatically by Jenkins Configuration as Code plugin\n\n", jenkins.getSystemMessage());
+        assertEquals(5, jenkins.getNumExecutors());
+        assertEquals(2, jenkins.getScmCheckoutRetryCount());
+        assertEquals(Mode.NORMAL, jenkins.getMode());
+    }
+
+    @Test
+    @ConfiguredWithReadme("jenkins/README.md#1")
+    public void configure_demo_second_code_block() throws Exception {
+        final Jenkins jenkins = Jenkins.get();
+        assertThat(jenkins.getSystemMessage(), containsString("Welcome to our build server."));
+        assertEquals(1, jenkins.getNumExecutors());
+    }
+}

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithCodeRule.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc.misc;
 
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import java.lang.reflect.Field;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -27,7 +28,19 @@ public class JenkinsConfiguredWithCodeRule extends JenkinsConfiguredRule {
             final String[] resource = configuredWithCode.value();
 
             final List<String> configs = Arrays.stream(resource)
-                .map(s -> clazz.getResource(s).toExternalForm())
+                .map(s -> {
+                    // Let's get the resources from the given class.
+                    URL config = clazz.getResource(s);
+                    // Otherwise let's try with the more generic classloader
+                    if (config == null) {
+                        config = clazz.getClassLoader().getResource(s);
+                    }
+                    if (config != null) {
+                        return config.toExternalForm();
+                    } else {
+                        throw new AssertionError("Exception when accessing the resources: " + s);
+                    }
+                })
                 .collect(Collectors.toList());
 
             try {

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithReadmeRule.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredWithReadmeRule.java
@@ -122,7 +122,7 @@ public class JenkinsConfiguredWithReadmeRule extends JenkinsConfiguredRule {
         Node document = PARSER.parseReader(targetReader);
         TextCollectingVisitor textCollectingVisitor = new TextCollectingVisitor();
         Node fencedCodeBlock = document.getChildOfType(FencedCodeBlock.class);
-        while(fencedCodeBlock!=null) {
+        while (fencedCodeBlock != null) {
             results.add(textCollectingVisitor.collectAndGetText(fencedCodeBlock));
             fencedCodeBlock = fencedCodeBlock.getNextAny(FencedCodeBlock.class);
         }


### PR DESCRIPTION
As a consequence of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1055 let's move each demos in independent PRs to track all the required dependencies.

### Tasks
- [x] Support `ConfiguredWithCode` with either reference to the `integrations` maven submodule or the `demos` one.
- [x] Support `ConfiguredWithReadme` with different code block sections within the same markdown. The default one is the very first code block section. Supported formats:
  - `@ConfiguredWithReadme("jenkins/README.md")`
  - `@ConfiguredWithReadme("jenkins/README.md#0")`, that's equivalent to the above one.
- [x] Commented sections in the yaml example as https://github.com/jenkinsci/configuration-as-code-plugin/issues/754
- [x] Remove the TFS support since https://github.com/jenkinsci/configuration-as-code-plugin/pull/1158 still open.  

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
