### PR TITLE
Added support to export array config

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java
@@ -282,7 +282,7 @@ public class DataBoundConfigurator<T> extends BaseConfigurator<T> {
             Object value = a.getValue(instance);
             if (value != null) {
                 Object converted = Stapler.CONVERT_UTILS.convert(value, a.getType());
-                if (converted instanceof Collection || !a.isMultiple()) {
+                if (converted instanceof Collection || p.getType().isArray() || !a.isMultiple()) {
                     args[i] = converted;
                 } else if (Set.class.isAssignableFrom(p.getType())) {
                     args[i] = Collections.singleton(converted);

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -264,6 +264,22 @@ public class DataBoundConfiguratorTest {
         assertNotInLog(logging, "mySecretValue");
     }
 
+    @Test
+    public void shouldExportArray() throws Exception {
+        ArrayConstructor obj = new ArrayConstructor(new Foo[]{new Foo("", false, 0)});
+
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+
+        final Configurator c = registry.lookupOrFail(ArrayConstructor.class);
+        final ConfigurationContext context = new ConfigurationContext(registry);
+        CNode node = c.describe(obj, context);
+
+        assertNotNull(node);
+        assertTrue(node instanceof Mapping);
+        Mapping map = (Mapping) node;
+        assertEquals(map.get("anArray").toString(), "[{qix=0, bar=false, foo=}]");
+    }
+
     public static class Foo {
 
         final String foo;
@@ -360,6 +376,15 @@ public class DataBoundConfiguratorTest {
         @DataBoundConstructor
         public SecretHolderWithString(String secret) {
             this.secret = Secret.fromString(secret);
+        }
+    }
+
+    public static class ArrayConstructor {
+        private final Foo[] anArray;
+
+        @DataBoundConstructor
+        public ArrayConstructor(Foo[] anArray) {
+            this.anArray = anArray;
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Using the [custom tool plugin](https://github.com/jenkinsci/custom-tools-plugin), notice that on Jenkins view configuration it failed with `type mismatch`


```
tool:
  customTool:
    installations: |-
      FAILED TO EXPORT
      com.cloudbees.jenkins.plugins.customtools.CustomTool$DescriptorImpl#installations: java.lang.IllegalArgumentException: argument type mismatch
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.describe(DataBoundConfigurator.java:299)
        at io.jenkins.plugins.casc.Attribute._describe(Attribute.java:264)
        at io.jenkins.plugins.casc.Attribute.describe(Attribute.java:239)
        at io.jenkins.plugins.casc.Configurator.describe(Configurator.java:162)
        at io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator.describe(GlobalConfigurationCategoryConfigurator.java:106)
        at io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator.lambda$describe$3(GlobalConfigurationCategoryConfigurator.java:99)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
        at io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator.describe(GlobalConfigurationCategoryConfigurator.java:99)
        at io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator.describe(GlobalConfigurationCategoryConfigurator.java:30)
```

With some debugging I notice that the array argument is passed as a list, added some verification to reuse the same converted value when it is an array


### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
