### PR TITLE
Correct spelling of hpi.pluginChangelogUrl tag

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -26,7 +26,7 @@
       In v1.28 we removed vault secret resolver and moved it to the hashicorp-vault-plugin. https://github.com/jenkinsci/hashicorp-vault-plugin
     -->
     <hpi.compatibleSinceVersion>1.28</hpi.compatibleSinceVersion>
-    <hpi.pluginChagelogUrl>https://github.com/jenkinsci/configuration-as-code-plugin/releases</hpi.pluginChagelogUrl>
+    <hpi.pluginChangelogUrl>https://github.com/jenkinsci/configuration-as-code-plugin/releases</hpi.pluginChangelogUrl>
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/configuration-as-code-plugin/master/plugin/src/main/webapp/img/logo-head.svg</hpi.pluginLogoUrl>
   </properties>
 


### PR DESCRIPTION
## Spell hpi.pluginChangelogUrl property correctly

Plugin version 1.35 includes the correct entry in the manifest already, even though the hpi property name is incorrect.  I don't know why that works, but I confirmed that it already works, even without this change.  This change will make the file consistent with the property that is already being written into the manifest.

```
Plugin-ChangelogUrl: https://github.com/jenkinsci/configuration-as-code-plugin/releases
```

See [JENKINS-45740](https://issues.jenkins-ci.org/browse/JENKINS-45740) for details of the commit that provided this originally.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x]  N/A Did you provide a test-case? That demonstrates feature works or fixes the issue.
