### PR TITLE
Automatically request code reviews from all JCasC plugin developers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+* @jenkinsci/configuration-as-code-plugin-developers
 .github/settings.yml @casz


### PR DESCRIPTION
Follow-up to the today's project meeting. After this change the @jenkinsci/configuration-as-code-plugin-developers team will be requested to review the changes. Now there are 9 team members, including former maintainers and contributors. 