### PR TITLE
Added example for credentials certificate

### DIFF
--- a/demos/credentials/credentials.yaml
+++ b/demos/credentials/credentials.yaml
@@ -36,3 +36,11 @@ credentials:
               id: "secret-file"
               fileName: "mysecretfile.txt"
               secretBytes: ${SECRET_FILE_BYTES} # SECRET_FILE_BYTES="$(cat mysecretfile.txt | base64)"
+          - certificate:
+              scope: GLOBAL
+              id: "secret-certificate"
+              password: ${SecretPasswordCert} #Load from Environment Variable
+              description: "my secret cert"
+              keyStoreSource:
+                uploaded:
+                  uploadedKeystore: ${SECRET_CERT_BYTES} # SECRET_CERT_BYTES="$(cat mysecretcert.p12 | base64 -w 0)"


### PR DESCRIPTION
fixes #909

"-w 0" option added to have bytes as oneline string which makes it easier later on to use vaults etc.

<!-- Please describe your pull request here. -->

Added example for adding a certificate via plugin.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.


