### PR TITLE
Update the integration test for active-directory

### DIFF
--- a/demos/active-directory/README.md
+++ b/demos/active-directory/README.md
@@ -16,14 +16,14 @@ jenkins:
           site: "site"
           bindName: "admin"
           bindPassword: "${BIND_PASSWORD}"
+          tlsConfiguration: JDK_TRUSTSTORE
       groupLookupStrategy: "RECURSIVE"
       removeIrrelevantGroups: true
       customDomain: true
       cache:
-        size: 4096
-        ttl: 30
+        size: 500
+        ttl: 600
       startTls: true
-      tlsConfiguration: JDK_TRUSTSTORE
       internalUsersDatabase:
         jenkinsInternalUser: "jenkins"
 ```

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>active-directory</artifactId>
-      <version>2.6</version>
+      <version>2.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ActiveDirectoryTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ActiveDirectoryTest.java
@@ -11,6 +11,7 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.RuleChain;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -38,5 +39,9 @@ public class ActiveDirectoryTest {
 
         assertTrue(realm.removeIrrelevantGroups);
         assertTrue(realm.startTls);
+        assertNotNull(realm.getCache());
+        assertEquals(500, realm.getCache().getSize());
+        assertEquals(600, realm.getCache().getTtl());
+
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I've realised the documentation about how to configure the `active-directory-plugin` is a bit out-of-date. That documentation (and the integration test) works on older versions, but in newer ones, the TLS configuration has been moved from to each domain and the recommended configuration will fail.

I've also updated the value for the cache to valid values from the UI

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
