### PR TITLE
Upgrade metrics-plugin

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>metrics</artifactId>
-      <version>3.1.2.12</version>
+      <version>4.0.2.6</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
When executing the tests with java 11, we get the following warning:

```
8.903 [id=907]	WARNING	h.ExtensionFinder$GuiceFinder$FaultTolerantScope$1#error: Failed to instantiate Key[type=jenkins.metrics.impl.VMMetricProviderImpl, annotation=[none]]; skipping this component
java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getProcessCpuTime() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @6c2f1700
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:340)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:280)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:198)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:192)
	at jenkins.metrics.impl.VMMetricProviderImpl$CpuUsageGauge.<init>(VMMetricProviderImpl.java:226)
	at jenkins.metrics.impl.VMMetricProviderImpl.<init>(VMMetricProviderImpl.java:71)
	at jenkins.metrics.impl.VMMetricProviderImpl$$FastClassByGuice$$bd4f8b03.newInstance(<generated>)
	at com.google.inject.internal.cglib.reflect.$FastConstructor.newInstance(FastConstructor.java:40)
	at com.google.inject.internal.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:61)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:105)
	at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:32)
	at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:89)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:115)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.onProvision(ExtensionFinder.java:577)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:126)
	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:68)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:87)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:267)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1103)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
Caused: com.google.inject.ProvisionException: Unable to provision, see the following errors:
1) Error injecting constructor, java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getProcessCpuTime() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @6c2f1700
  at jenkins.metrics.impl.VMMetricProviderImpl.<init>(VMMetricProviderImpl.java:61)
1 error
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:52)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:145)
	at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:440)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1016)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1012)
	at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:402)
	at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:393)
	at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:344)
	at hudson.ExtensionList.load(ExtensionList.java:381)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:317)
	at hudson.ExtensionList.iterator(ExtensionList.java:172)
	at hudson.ExtensionList.get(ExtensionList.java:149)
	at jenkins.metrics.impl.JenkinsMetricProviderImpl.instance(JenkinsMetricProviderImpl.java:461)
	at jenkins.metrics.impl.JenkinsMetricProviderImpl$PeriodicWorkImpl.doRun(JenkinsMetricProviderImpl.java:640)
	at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:91)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:58)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
It's fixed in the latest version of `metrics-plugin`



### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
