### PR TITLE
Allow users with Overall/SystemRead permission to view configuration, schema, and documentation

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -13,6 +13,7 @@ import hudson.model.ManagementLink;
 import hudson.remoting.Which;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.security.Permission;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.casc.impl.DefaultConfiguratorRegistry;
 import io.jenkins.plugins.casc.model.CNode;
@@ -136,6 +137,12 @@ public class ConfigurationAsCode extends ManagementLink {
     @Override
     public String getDescription() {
         return "Reload your configuration or update configuration source";
+    }
+
+    @NonNull
+    @Override
+    public Permission getRequiredPermission() {
+        return Jenkins.SYSTEM_READ;
     }
 
     public Date getLastTimeLoaded() {
@@ -406,8 +413,7 @@ public class ConfigurationAsCode extends ManagementLink {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doExport(StaplerRequest req, StaplerResponse res) throws Exception {
-
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(Jenkins.SYSTEM_READ)) {
             res.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
@@ -423,8 +429,7 @@ public class ConfigurationAsCode extends ManagementLink {
      */
     @Restricted(NoExternalUse.class)
     public void doSchema(StaplerRequest req, StaplerResponse res) throws Exception {
-
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(Jenkins.SYSTEM_READ)) {
             res.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
@@ -436,7 +441,7 @@ public class ConfigurationAsCode extends ManagementLink {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doViewExport(StaplerRequest req, StaplerResponse res) throws Exception {
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(Jenkins.SYSTEM_READ)) {
             res.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
@@ -450,7 +455,7 @@ public class ConfigurationAsCode extends ManagementLink {
 
     @Restricted(NoExternalUse.class)
     public void doReference(StaplerRequest req, StaplerResponse res) throws Exception {
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        if (!Jenkins.get().hasPermission(Jenkins.SYSTEM_READ)) {
             res.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -26,20 +26,24 @@
       </j:otherwise>
     </j:choose>
 
-    <f:form method="post" action="replace" name="replace">
-        <h2>${%Replace configuration source with:}</h2>
-        <f:entry title="${%Path or URL}" field="newSource" >
-            <f:textbox checkUrl="'checkNewSource?newSource='+this.value" checkMethod="post" />
-        </f:entry>
-        <f:bottomButtonBar>
-            <f:submit name="replace" value="${%Apply new configuration}"/>
-        </f:bottomButtonBar>
-    </f:form>
+    <l:isAdmin>
+      <f:form method="post" action="replace" name="replace">
+          <h2>${%Replace configuration source with:}</h2>
+          <f:entry title="${%Path or URL}" field="newSource" >
+              <f:textbox checkUrl="'checkNewSource?newSource='+this.value" checkMethod="post" />
+          </f:entry>
+          <f:bottomButtonBar>
+              <f:submit name="replace" value="${%Apply new configuration}"/>
+          </f:bottomButtonBar>
+      </f:form>
+    </l:isAdmin>
     <h2>${%Actions}</h2>
-    
-    <f:form method="post" action="reload" name="reload">
-      <f:submit name="reload" value="${%Reload existing configuration}"/>
-    </f:form>
+
+    <l:isAdmin>
+      <f:form method="post" action="reload" name="reload">
+        <f:submit name="reload" value="${%Reload existing configuration}"/>
+      </f:form>
+    </l:isAdmin>
     <f:form method="post" action="export" name="export">
       <f:submit name="export" value="${%Download Configuration}"/>
     </f:form>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <jenkins.version>2.222</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
+    <useBeta>true</useBeta>
   </properties>
 
   <name>Configuration as Code Parent</name>


### PR DESCRIPTION
Allow users with Overall/SystemRead permission to view configuration, schema, and documentation

<!-- Please describe your pull request here. -->
Fixes https://github.com/jenkinsci/configuration-as-code-plugin/issues/9

You can use script console to enable the new permission: 

`Jenkins.SYSTEM_READ.enabled = true`

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

<details>
<summary>Screenshot</summary>


![image](https://user-images.githubusercontent.com/21194782/75611720-f0769c00-5b14-11ea-8492-9c02bfd98bd2.png)


</details>



### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
