### PR TITLE
Enable plugin updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,16 +6,3 @@ update_configs:
   ignored_updates:
     - match:
         dependency_name: "org.jenkins-ci.main:jenkins-core"
-    - match:
-        dependency_name: "org.jenkins-ci.plugins*"
-    - match:
-        dependency_name: "org.jenkinsci.plugins*"
-    - match:
-        dependency_name: "io.jenkins.plugins*"
-    - match:
-        dependency_name: "io.jenkins.docker:docker-plugin"
-    - match:
-        dependency_name: "com.cloudbees.jenkins.plugins*"
-    - match:
-        dependency_name: "org.csanchez.jenkins.plugins*"
-  


### PR DESCRIPTION
Given we don't depend on any plugins I don't see why we don't enable this

Better to have our integration tests up to date to catch issues sooner