### PR TITLE
Documentation only: replace JENKINS_ROOT with JENKINS_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Second, the plugin looks for the `CASC_JENKINS_CONFIG` environment variable. The
 If `CASC_JENKINS_CONFIG` points to a folder, the plugin will recursively traverse the folder to find file (suffix with .yml,.yaml,.YAML,.YML), but doesn't contain hidden files or hidden subdirectories. It doesn't follow symbolic links.
 
 If you do not set the `CASC_JENKINS_CONFIG` environment variable, the plugin will
-default to looking for a single config file in `$JENKINS_ROOT/jenkins.yaml`.
+default to looking for a single config file in `$JENKINS_HOME/jenkins.yaml`.
 
 If everything was setup correctly, you should now be able to browse the Configuration as Code page with `Manage Jenkins` -> `Configuration as Code`.
 

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
  * 2. Check it was configured correctly.
  * 3. Check the configuration is valid via Web UI.
  * 4. Apply the configuration via Web UI.
- * 5. Write the configuration to $JENKINS_ROOT/jenkins.yaml.
+ * 5. Write the configuration to $JENKINS_HOME/jenkins.yaml.
  * 6. Restart Jenkins.
  * 7. Check the {@link #stringInLogExpected()} is set during the restart.
  *
@@ -83,7 +83,7 @@ public abstract class RoundTripAbstractTest {
      * 2. Check it was configured correctly.
      * 3. Check the configuration is valid via Web UI.
      * 4. Apply the configuration via Web UI.
-     * 5. Write the configuration to $JENKINS_ROOT/jenkins.yaml.
+     * 5. Write the configuration to $JENKINS_HOME/jenkins.yaml.
      * 6. Restart Jenkins.
      * 7. Check the {@link #stringInLogExpected()} is set during the restart.
      *


### PR DESCRIPTION
Clarify documentation. As far as I know, there is no such thing as `JENKINS_ROOT`, it's `JENKINS_HOME`.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [N/A] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [N/A] Did you provide a test-case? That demonstrates feature works or fixes the issue.
