### PR TITLE
Add Gitter Q&A tab to the New Issue dialog

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "❓ Gitter chat"
+    url: https://gitter.im/jenkinsci/configuration-as-code-plugin
+    about: Please ask and answer questions here.
+  - name: "🔒 Report a vulnerability"
+    url: https://jenkins.io/security/#reporting-vulnerabilities
+    about: "Do not report security issues in public, we have a process for it!"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: "❓ Gitter chat"
     url: https://gitter.im/jenkinsci/configuration-as-code-plugin
     about: Please ask and answer questions here.
-  - name: "🔒 Report a vulnerability"
-    url: https://jenkins.io/security/#reporting-vulnerabilities
-    about: "Do not report security issues in public, we have a process for it!"


### PR DESCRIPTION
Submitting it to get a feedback. I used a new GitHub feature to make the Vulnerability Reporting process and Q&A more visible on the new Issue creation dialog.

Before merging, we need to agree whether the `question` template is still needed

Sample from WinSW:

![image](https://user-images.githubusercontent.com/3000480/78048866-a33b5380-737a-11ea-8be0-0c2c1c2878c9.png)


<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress put the construction emoji 🚧 in your title. (hint: copy it)
Helps us to block accidental merges of unfinished work.
-->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
