### PR TITLE
Fix compatibility with core 2.231

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -52,6 +52,11 @@
       <version>20190722</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
       <version>1.26.1</version>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

https://github.com/jenkinsci/jenkins/pull/4604 removed jsr305 dependency from the core war, we have a feature where we check for certain null / non null annotations in the DataBoundConfigurator, https://github.com/jenkinsci/configuration-as-code-plugin/blob/02ca4728571a26465339742f532c9e50fe629b07/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfigurator.java#L118

Without this fix, it breaks with:

```
jenkins    | 2020-04-15 13:20:19.974+0000 [id=32]    WARNING    jenkins.model.Jenkins$5#runTask: ConfigurationAsCode.init failed perhaps due to plugin dependency issues
jenkins    | java.lang.ClassNotFoundException: javax.annotation.Nonnull
jenkins    |     at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1387)
jenkins    |     at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1342)
jenkins    |     at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1089)
jenkins    |     at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
jenkins    | Caused: java.lang.NoClassDefFoundError: javax/annotation/Nonnull
jenkins    |     at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.tryConstructor(DataBoundConfigurator.java:118)
jenkins    |     at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.instance(DataBoundConfigurator.java:77)
jenkins    |     at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:267)
jenkins    |     at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.check(DataBoundConfigurator.java:101)
jenkins    |     at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:344)
jenkins    |     at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:287)
jenkins    |     at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:352)
jenkins    |     at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:287)
jenkins    |     at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$7(ConfigurationAsCode.java:743)
jenkins    |     at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:693)
jenkins    |     at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:743)
jenkins    |     at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:728)
jenkins    |     at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:608)
jenkins    |     at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:291)
jenkins    |     at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:283)
jenkins    | Caused: java.lang.reflect.InvocationTargetException
jenkins    |     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
jenkins    |     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
jenkins    |     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
jenkins    |     at java.lang.reflect.Method.invoke(Method.java:498)
jenkins    |     at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
jenkins    | Caused: java.lang.Error
jenkins    |     at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
jenkins    |     at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
jenkins    |     at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
jenkins    |     at jenkins.model.Jenkins$5.runTask(Jenkins.java:1132)
jenkins    |     at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
jenkins    |     at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
jenkins    |     at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
jenkins    |     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
jenkins    |     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
jenkins    |     at java.lang.Thread.run(Thread.java:748)
```

Minimal reproducer:

```
credentials:
  system:
    domainCredentials:
      - credentials:
          - string:
              scope: GLOBAL
              id: my-test-token
              secret: 'a secret'
              description: Secret token
```
(note that much of jcasc does work, many attributes don't use this configurator but credentials is one that does)

also note that I was unable to reproduce this in hpi:run, but I was able to re-produce it in a standalone jenkins instance and verify it's fixed

I found this when testing an upgrade at work, at least I'm the first one to hit it 🤦.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
