### PR TITLE
Use annotation class name matching instead of the actual class to avoid license issues.

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.casc.CredentialsRootConfigurator;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.util.Secret;
 import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
@@ -16,7 +17,6 @@ import io.jenkins.plugins.casc.model.Mapping;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
@@ -140,8 +140,8 @@ public class CredentialsTest {
                 new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "1", "2", "3", "4")));
     }
 
-    @Nonnull
-    private <T> Attribute<T,?> getFromDatabound(Class<T> clazz, @Nonnull String attributeName) {
+    @NonNull
+    private <T> Attribute<T,?> getFromDatabound(Class<T> clazz, @NonNull String attributeName) {
         DataBoundConfigurator<T> cfg = new DataBoundConfigurator<>(clazz);
         Set<Attribute<T,?>> attributes = cfg.describe();
         for (Attribute<T,?> a : attributes) {

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -52,11 +52,6 @@
       <version>20190722</version>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
       <version>1.26.1</version>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.casc;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Scalar;
@@ -21,8 +23,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.AccessRestriction;
@@ -364,7 +364,7 @@ public class Attribute<Owner, Type> {
     }
 
     @CheckForNull
-    private static Method locateGetter(Class<?> clazz, @Nonnull String fieldName) {
+    private static Method locateGetter(Class<?> clazz, @NonNull String fieldName) {
         final String upname = StringUtils.capitalize(fieldName);
         final List<String> accessors = Arrays.asList("get" + upname, "is" + upname);
 
@@ -383,12 +383,12 @@ public class Attribute<Owner, Type> {
     }
 
     @CheckForNull
-    private static Field locatePublicField(Class<?> clazz, @Nonnull String fieldName) {
+    private static Field locatePublicField(Class<?> clazz, @NonNull String fieldName) {
         return ExtraFieldUtils.getField(clazz, fieldName, false);
     }
 
     @CheckForNull
-    private static Field locatePrivateFieldInHierarchy(Class<?> clazz, @Nonnull String fieldName) {
+    private static Field locatePrivateFieldInHierarchy(Class<?> clazz, @NonNull String fieldName) {
         return ExtraFieldUtils.getFieldNoForce(clazz, fieldName);
     }
 
@@ -401,7 +401,7 @@ public class Attribute<Owner, Type> {
      *         {@code false} if not or if there is no conclusive answer.
      */
     @Restricted(NoExternalUse.class)
-    public static boolean calculateIfSecret(@CheckForNull Class<?> targetClass, @Nonnull String fieldName) {
+    public static boolean calculateIfSecret(@CheckForNull Class<?> targetClass, @NonNull String fieldName) {
         if (targetClass == Secret.class) { // Class is final, so the check is safe
             LOGGER.log(Level.FINER, "Attribute {0}#{1} is secret, because it has a Secret type",
                     new Object[] {targetClass.getName(), fieldName});

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -1,12 +1,12 @@
 package io.jenkins.plugins.casc;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import io.vavr.Tuple;
 import io.vavr.control.Try;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
-import javax.annotation.CheckForNull;
 import org.apache.commons.lang.text.StrLookup;
 import org.apache.commons.lang.text.StrSubstitutor;
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
@@ -1,13 +1,13 @@
 package io.jenkins.plugins.casc;
 
 import com.google.common.base.Strings;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import java.io.IOException;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
 import javax.servlet.http.HttpServletRequest;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;

--- a/plugin/src/main/java/io/jenkins/plugins/casc/util/ExtraFieldUtils.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/util/ExtraFieldUtils.java
@@ -16,9 +16,9 @@
  */
 package io.jenkins.plugins.casc.util;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.lang.reflect.Field;
 import java.util.Iterator;
-import javax.annotation.CheckForNull;
 import org.apache.commons.lang.ClassUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -73,13 +73,6 @@
       <artifactId>system-rules</artifactId>
       <version>1.19.0</version>
     </dependency>
-
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -73,6 +73,13 @@
       <artifactId>system-rules</artifactId>
       <version>1.19.0</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/jmh/CascJmhBenchmarkState.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/jmh/CascJmhBenchmarkState.java
@@ -1,11 +1,11 @@
 package io.jenkins.plugins.casc.misc.jmh;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.benchmark.jmh.JmhBenchmarkState;
 
@@ -20,7 +20,7 @@ public abstract class CascJmhBenchmarkState extends JmhBenchmarkState {
      *
      * @return String containing the location of YAML file in the classpath
      */
-    @Nonnull
+    @NonNull
     protected abstract String getResourcePath();
 
     /**
@@ -28,7 +28,7 @@ public abstract class CascJmhBenchmarkState extends JmhBenchmarkState {
      *
      * @return the class containing this benchmark state
      */
-    @Nonnull
+    @NonNull
     protected abstract Class<?> getEnclosingClass();
 
     /**

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.casc;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.casc.misc.jmh.CascJmhBenchmarkState;
-import javax.annotation.Nonnull;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.model.Jenkins;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -11,13 +11,13 @@ import static org.junit.Assert.assertEquals;
 @JmhBenchmark
 public class SampleBenchmark {
     public static class MyState extends CascJmhBenchmarkState {
-        @Nonnull
+        @NonNull
         @Override
         protected String getResourcePath() {
             return "benchmarks.yml";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         protected Class<?> getEnclosingClass() {
             return SampleBenchmark.class;

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/ClassParametersAreNonnullByDefault.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/ClassParametersAreNonnullByDefault.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.casc.impl.configurators.nonnull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,7 +14,7 @@ public class ClassParametersAreNonnullByDefault {
     private List<String> strings;
 
     @DataBoundConstructor
-    public ClassParametersAreNonnullByDefault(@Nonnull List<String> strings) {
+    public ClassParametersAreNonnullByDefault(@NonNull List<String> strings) {
         this.strings = strings;
     }
 

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/NonnullParameterConstructor.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/NonnullParameterConstructor.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.casc.impl.configurators.nonnull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -12,7 +12,7 @@ public class NonnullParameterConstructor {
     private Set<String> strings;
 
     @DataBoundConstructor
-    public NonnullParameterConstructor(@Nonnull Set<String> strings) {
+    public NonnullParameterConstructor(@NonNull Set<String> strings) {
         this.strings = strings;
     }
 

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersNonNullCheckForNull.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/nonnull/nonnullparampackage/PackageParametersNonNullCheckForNull.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.util.Secret;
-import javax.annotation.CheckForNull;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**


### PR DESCRIPTION
fixes #1360 

Not sure if there is a better way to encapsulate the method to extract the annotations for the different classes (`Package`, `Parameter`, `AccessibleObject`, `Class<T>`)

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
