### PR TITLE
Add support for symbolic linked directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Second, the plugin looks for the `CASC_JENKINS_CONFIG` environment variable. The
 - A full path to a single file. For example, `/var/jenkins_home/casc_configs/jenkins.yaml`.
 - A URL pointing to a file served on the web. For example, `https://acme.org/jenkins.yaml`.
 
-If `CASC_JENKINS_CONFIG` points to a folder, the plugin will recursively traverse the folder to find file (suffix with .yml,.yaml,.YAML,.YML), but doesn't contain hidden files or hidden subdirectories. It doesn't follow symbolic links.
+If `CASC_JENKINS_CONFIG` points to a folder, the plugin will recursively traverse the folder to find file (suffix with .yml,.yaml,.YAML,.YML), but doesn't contain hidden files or hidden subdirectories. It follows symbolic links for both files and directories.
 
 If you do not set the `CASC_JENKINS_CONFIG` environment variable, the plugin will
 default to looking for a single config file in `$JENKINS_HOME/jenkins.yaml`.

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -35,6 +35,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -659,7 +660,7 @@ public class ConfigurationAsCode extends ManagementLink {
 
         final PathMatcher matcher = FileSystems.getDefault().getPathMatcher(YAML_FILES_PATTERN);
         try (Stream<Path> stream = Files.find(Paths.get(path), Integer.MAX_VALUE,
-                (next, attrs) -> !attrs.isDirectory() && !isHidden(next) && matcher.matches(next))) {
+                (next, attrs) -> !attrs.isDirectory() && !isHidden(next) && matcher.matches(next), FileVisitOption.FOLLOW_LINKS)) {
             return stream.sorted().collect(toList());
         } catch (IOException e) {
             throw new IllegalStateException("failed config scan for " + path, e);

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -85,9 +85,15 @@ public class ConfigurationAsCodeTest {
         Files.createSymbolicLink(Paths.get(tempFolder.getRoot().getAbsolutePath(), "jenkins_6.yaml"),
                                  data.resolve("jenkins_6.yaml"));
 
+        // Create a symbolic linked folder with 1 configuration file
+        final File folderLinkTarget = tempFolder.newFolder("..2019_11_26_16_29_08.094515937");
+        new File(folderLinkTarget, "jenkins_7.yaml").createNewFile();
+        Files.createSymbolicLink(Paths.get(tempFolder.getRoot().getAbsolutePath(), "linked_folder"),
+            folderLinkTarget.toPath());
+
         assertThat(casc.configs(exactFile.getAbsolutePath()), hasSize(1));
         final List<Path> foo = casc.configs(tempFolder.getRoot().getAbsolutePath());
-        assertThat("failed to find 6 configs in " + Arrays.toString(tempFolder.getRoot().list()), foo, hasSize(6));
+        assertThat("failed to find 7 configs in " + Arrays.toString(tempFolder.getRoot().list()), foo, hasSize(7));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ x ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
This PR adds support for symbolic linked directories as referenced in https://github.com/jenkinsci/configuration-as-code-plugin/issues/1371

We have found it much easier to maintain a form of inheritance between our various types on Jenkins configuration as code configured servers using the folder structures described in the referenced issue/feature request.

Tests have been modified to for support of following symbolic links 