### PR TITLE
Bump config-file-provider-plugin to 3.6.3

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>3.4.1</version>
+      <version>3.6.3</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
When running hpi:run on integrations module you get a plugin load conflict between nodejs and config-file-provider

Could really use a plugin load test for our integrations module 😰

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
