### PR TITLE
sort Attributes and RootElementConfigurator according to Extension ordinal

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -410,8 +410,9 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
     private List<Attribute<T, ?>> sortAttributes(Set<Attribute<T, ?>> attributes) {
         Comparator<Attribute<T,?>> attributeComparator = Comparator.comparingDouble(a -> {
             Annotation annotation = a.type.getAnnotation(Extension.class);
-            if (annotation == null)
+            if (annotation == null) {
                 return Double.MIN_VALUE;
+            }
             Extension extension = (Extension) annotation;
             return extension.ordinal();
         });

--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.casc;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
-import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Saveable;
 import hudson.util.DescribableList;
@@ -13,7 +12,6 @@ import io.jenkins.plugins.casc.impl.attributes.PersistedListAttribute;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -27,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -301,7 +298,7 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
      */
     protected void configure(Mapping config, T instance, boolean dryrun, ConfigurationContext context) throws ConfiguratorException {
         final Set<Attribute<T,?>> attributes = describe();
-        List<Attribute<T, ?>> sortedAttributes = sortAttributes(attributes);
+        List<Attribute<T, ?>> sortedAttributes = attributes.stream().sorted(Configurator.extensionOrdinalSort()).collect(Collectors.toList());
         for (Attribute<T,?> attribute : sortedAttributes) {
 
             final String name = attribute.getName();
@@ -405,18 +402,6 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
             }
         }
         return null;
-    }
-
-    private List<Attribute<T, ?>> sortAttributes(Set<Attribute<T, ?>> attributes) {
-        Comparator<Attribute<T,?>> attributeComparator = Comparator.comparingDouble(a -> {
-            Annotation annotation = a.type.getAnnotation(Extension.class);
-            if (annotation == null) {
-                return Double.MIN_VALUE;
-            }
-            Extension extension = (Extension) annotation;
-            return extension.ordinal();
-        });
-        return attributes.stream().sorted(attributeComparator.reversed()).collect(Collectors.toList());
     }
 
     public static final class TypePair {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Configurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Configurator.java
@@ -225,7 +225,7 @@ public interface Configurator<T> {
     static double extractExtensionOrdinal(Class clazz) {
         Extension extension = (Extension) clazz.getAnnotation(Extension.class);
         if (extension == null) {
-            return Double.MIN_VALUE;
+            return 0.0;
         }
         return extension.ordinal();
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Configurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Configurator.java
@@ -23,6 +23,7 @@ package io.jenkins.plugins.casc;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
 import hudson.ExtensionPoint;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
@@ -207,6 +208,30 @@ public interface Configurator<T> {
             }
         }
         return mapping;
+    }
+
+    static double extractExtensionOrdinal(Object obj) {
+        if (obj instanceof Attribute<?, ?>) {
+            return extractExtensionOrdinal((Attribute<?, ?>) obj);
+        } else {
+            return extractExtensionOrdinal(obj.getClass());
+        }
+    }
+
+    static double extractExtensionOrdinal(Attribute<?, ?> attribute) {
+        return extractExtensionOrdinal(attribute.type);
+    }
+
+    static double extractExtensionOrdinal(Class clazz) {
+        Extension extension = (Extension) clazz.getAnnotation(Extension.class);
+        if (extension == null) {
+            return Double.MIN_VALUE;
+        }
+        return extension.ordinal();
+    }
+
+    static Comparator<Object> extensionOrdinalSort() {
+        return Comparator.comparingDouble(Configurator::extractExtensionOrdinal).reversed();
     }
 
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/RootElementConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/RootElementConfigurator.java
@@ -1,10 +1,12 @@
 package io.jenkins.plugins.casc;
 
+import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.ManagementLink;
 import io.jenkins.plugins.casc.impl.configurators.DescriptorConfigurator;
 import io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
@@ -32,6 +34,14 @@ public interface RootElementConfigurator<T> extends Configurator<T> {
             if (descriptor != null)
                 configurators.add(new DescriptorConfigurator(descriptor));
         }
+
+        configurators.sort(Comparator.comparingDouble(c -> {
+            Extension extension = c.getClass().getAnnotation(Extension.class);
+            if (extension == null) {
+                return Double.MIN_VALUE;
+            }
+            return extension.ordinal();
+        }).reversed());
 
         return configurators;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/RootElementConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/RootElementConfigurator.java
@@ -1,12 +1,10 @@
 package io.jenkins.plugins.casc;
 
-import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.ManagementLink;
 import io.jenkins.plugins.casc.impl.configurators.DescriptorConfigurator;
 import io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
@@ -35,13 +33,7 @@ public interface RootElementConfigurator<T> extends Configurator<T> {
                 configurators.add(new DescriptorConfigurator(descriptor));
         }
 
-        configurators.sort(Comparator.comparingDouble(c -> {
-            Extension extension = c.getClass().getAnnotation(Extension.class);
-            if (extension == null) {
-                return Double.MIN_VALUE;
-            }
-            return extension.ordinal();
-        }).reversed());
+        configurators.sort(Configurator.extensionOrdinalSort());
 
         return configurators;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
@@ -29,7 +29,7 @@ import static io.jenkins.plugins.casc.Attribute.noop;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-@Extension
+@Extension(ordinal = 1)
 @Restricted(NoExternalUse.class)
 public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements RootElementConfigurator<Jenkins> {
 


### PR DESCRIPTION
This ensures for instance Credentials are loaded first.
Jenkins Configurator is loaded second.
Seed Job is loaded last.

Testing this is pretty hard due to how Jenkins Test harness fixes the Jenkins location url 😓
But as shown below the sorting works and should allow some sense of order when configuring location and resourceRoot.

Before:
![image](https://user-images.githubusercontent.com/1661688/82293555-09247e80-99ad-11ea-9fef-f97c6c7e297c.png)

After:
![image](https://user-images.githubusercontent.com/1661688/82293629-222d2f80-99ad-11ea-9646-e029c8a81987.png)

Here you have RootElementConfigurator after, just imagine the the before as an totally unsorted list 🤣
![image](https://user-images.githubusercontent.com/1661688/82323100-dba0fa80-99d7-11ea-94f7-29b1bafc4028.png)


fixes #1383
fixes #619
fixes #876

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
