### PR TITLE
sort RootElementConfigurators according to ordinal

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/RootElementConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/RootElementConfigurator.java
@@ -1,10 +1,12 @@
 package io.jenkins.plugins.casc;
 
+import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.ManagementLink;
 import io.jenkins.plugins.casc.impl.configurators.DescriptorConfigurator;
 import io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
@@ -32,6 +34,14 @@ public interface RootElementConfigurator<T> extends Configurator<T> {
             if (descriptor != null)
                 configurators.add(new DescriptorConfigurator(descriptor));
         }
+
+        configurators.sort(Comparator.comparingDouble(c -> {
+            Extension extension = c.getClass().getAnnotation(Extension.class);
+            if (extension == null) {
+                return Double.MIN_VALUE;
+            }
+            return extension.ordinal();
+        }).reversed());
 
         return configurators;
     }


### PR DESCRIPTION
Similar to #1394 just for `RootElementConfigurators`

I know in all possible root element configurations we tried to control order with the ordinal setting.

![image](https://user-images.githubusercontent.com/1661688/82297863-8eab2d00-99b3-11ea-8458-21912bd9a519.png)

fixes #619
fixes #876

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
