### PR TITLE
Escape newSource field when checking it's value via Ajax.

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -30,7 +30,7 @@
       <f:form method="post" action="replace" name="replace">
           <h2>${%Replace configuration source with:}</h2>
           <f:entry title="${%Path or URL}" field="newSource" >
-              <f:textbox checkUrl="'checkNewSource?newSource='+this.value" checkMethod="post" />
+              <f:textbox checkUrl="'checkNewSource?newSource='+escape(this.value)" checkMethod="post" />
           </f:entry>
           <f:bottomButtonBar>
               <f:submit name="replace" value="${%Apply new configuration}"/>


### PR DESCRIPTION
URLs with special characters need to be escaped when checking the Yaml they are pointing to.
Example of such URL are S3 presigned URL: `https://jenkins-jcas-185562170416.s3.amazonaws.com/jenkins-conf.yml?AWSAccessKeyId=AKE123456789&Signature=HelloWorldJ%2F5QKc6TlbeHw%3D&Expires=1590364679`.

Fixes #1401

<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
