### PR TITLE
[Test only] Double value are loaded as null

### DIFF
--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_extendedClass.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_extendedClass.yml
@@ -1,0 +1,8 @@
+---
+unclassified:
+  config:
+    parent:
+      child:
+        name: "foo"
+        min: 0.0
+        max: 3.14


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR provides the illustration of the potential bug. 

When we have a global configuration that requires a field which can have multiple form (`abstract classes`), and one of the child class has a ` Double` field, that field is not loaded properly.

Note that, in this PR, if you replace the `min: 0.0` by `min: "0.0"` (`String` format), then it works fine. 

I debugged that and noticed the problem could be in SnakeYaml [`BaseConstructor#constructMapping2ndStep` method](https://bitbucket.org/asomov/snakeyaml/src/187d7e47d1e91777238602470ea3f0ce2d480636/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java#lines-464) but I couldn't reproduce the problem with a test there. 

I'm opening this here to have an open discussion about this "problem".

cc @timja as we spoke about this on Gitter

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
