### PR TITLE
Include README details of how to set the CasC config location using Java Property instead of Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,17 @@ If `CASC_JENKINS_CONFIG` points to a folder, the plugin will recursively travers
 :x: `/jenkins/.configs/casc_configs/..dir2/config.yaml`  
 </details>
 
-If you do not set the `CASC_JENKINS_CONFIG` environment variable, the plugin will
-default to looking for a single config file in `$JENKINS_HOME/jenkins.yaml`.
+Instead of setting the `CASC_JENKINS_CONFIG` environment variable, you can also define using
+the `casc.jenkins.config` Java property.  This is useful when installing Jenkins via a package
+management tool and can't set an environment variable outside of a package-managed file which could
+be overwritten by an update.  For RHEL/CentOS systems, you can append the following to the
+`JENKINS_JAVA_OPTIONS` entry in `/etc/sysconfig/jenkins`
+ 
+  `-Dcasc.jenkins.config=/jenkins/casc_configs`
+ 
+If you do not set the `CASC_JENKINS_CONFIG` environment variable or the `casc.jenkins.config` Java
+property, the plugin will default to looking for a single config file in
+`$JENKINS_HOME/jenkins.yaml`.
 
 If everything was setup correctly, you should now be able to browse the Configuration as Code page with `Manage Jenkins` -> `Configuration as Code`.
 


### PR DESCRIPTION
To address:  [Issue 1456](https://github.com/jenkinsci/configuration-as-code-plugin/issues/1456)

Update README.md with details of how to set the CasC config location via the casc.jenkins.config Java property instead of using the CASC_JENKINS_CONFIG environment variable as it's IMHO a better solution for configuring the path when installing packaged Jenkins (e.g. RPM) instead of changing a package-managed file which could be updated/replaced when Jenkins is updated as not all of us are blessed with the ability to run Jenkins in a container...yet! :)

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [N/A] Did you provide a test-case? That demonstrates feature works or fixes the issue.
