### PR TITLE
Cleanup master/slave terminology from documentation + Cleanup "Jenkins master" term from the warning in the Web UI

### DIFF
--- a/demos/external-workspace-manager/README.md
+++ b/demos/external-workspace-manager/README.md
@@ -13,10 +13,10 @@ jenkins:
   nodeProperties:
     - exwsNodeConfigurationDiskPools:
         nodeDiskPools:
-          - diskPoolRefId: "master-node-id"
+          - diskPoolRefId: "controller-node-id"
             nodeDisks:
-              - diskRefId: "master-node-disk"
-                nodeMountPoint: "/tmp/master-node"
+              - diskRefId: "controller-node-disk"
+                nodeMountPoint: "/tmp/controller-node"
 
   nodes:
     - permanent:

--- a/demos/graphite/README.md
+++ b/demos/graphite/README.md
@@ -8,5 +8,5 @@ unclassified:
     servers:
       - hostname: "1.2.3.4"
         port: 2003
-        prefix: jenkins.master.
+        prefix: jenkins.controller.
 ```

--- a/demos/kubernetes-helm/README.md
+++ b/demos/kubernetes-helm/README.md
@@ -3,13 +3,13 @@
 ## Preparation
 
 Jenkins can be installed in Kubernetes using [helm](https://github.com/helm/helm).
-The latest stable helm chart can be found [here](https://github.com/helm/charts/tree/master/stable/jenkins).
+The latest stable helm chart can be found [here](https://github.com/jenkinsci/helm-charts).
 
-Now grab a copy of the helm chart [values file](https://github.com/helm/charts/blob/master/stable/jenkins/values.yaml) and adjust the Master part a little bit:
+Now grab a copy of the helm chart [values file](https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml) and adjust the Master part a little bit:
 
 ```yaml
 master:
-  componentName: jenkins-master
+  componentName: jenkins-controller
   image: 'jenkins/jenkins'
   tag: 'lts'
   imagePullPolicy: 'Always'
@@ -27,7 +27,7 @@ master:
   # Below is the implementation of Jenkins Configuration as Code.  Add a key under ConfigScripts for each configuration area,
   # where each corresponds to a plugin or section of the UI.  Each key (prior to | character) is just a label, and can be any value.
   # Keys are only used to give the section a meaningful name.  The only restriction is they may only contain RFC 1123 \ DNS label
-  # characters: lowercase letters, numbers, and hyphens.  The keys become the name of a configuration YAML file on the master in
+  # characters: lowercase letters, numbers, and hyphens.  The keys become the name of a configuration YAML file on the controller in
   # /var/jenkins_home/casc_configs (by default) and will be processed by the Configuration as Code plugin.  The lines after each |
   # become the content of the configuration YAML file.  The first line after this is a JCasC root element, eg jenkins, credentials,
   # etc.  Best reference is https://<jenkins_url>/configuration-as-code/reference.  The example below creates a welcome message:
@@ -56,7 +56,7 @@ master:
         #     cpu: 50m
         #     memory: 50Mi
       # SSH port value can be set to any unused TCP port.  The default, 1044, is a non-standard SSH port that has been chosen at random.
-      # Is only used to reload JCasC config from the sidecar container running in the Jenkins master pod.
+      # Is only used to reload JCasC config from the sidecar container running in the Jenkins controller pod.
       # This TCP port will not be open in the pod (unless you specifically configure this), so Jenkins will not be
       # accessible via SSH from outside of the pod.  Note if you use non-root pod privileges (RunAsUser & FsGroup),
       # this must be > 1024:
@@ -82,7 +82,7 @@ master:
     # - name: SECRETS
     #   value: /usr/share/jenkins/ref/secrets
 
-  # List of plugins to be install during Jenkins master start
+  # List of plugins to be install during Jenkins controller start
   # mind the last plugin in the list now ;)
   installPlugins:
     - kubernetes:latest
@@ -103,4 +103,4 @@ Once Helm finishes deploying the chart, connect to your Jenkins server in your b
 
 ## Misc
 
-Check the [Configuration as Code](https://github.com/helm/charts/tree/master/stable/jenkins#configuration-as-code) section in the Jenkins Helm chart repo for more information.
+Check the [Configuration as Code](https://github.com/jenkinsci/helm-charts/tree/main/charts/jenkins#configuration-as-code) section in the Jenkins Helm chart repo for more information.

--- a/demos/kubernetes-helm/values.yaml
+++ b/demos/kubernetes-helm/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 master:
-  componentName: jenkins-master
+  componentName: jenkins-controller
   image: "jenkins/jenkins"
   tag: "lts"
   imagePullPolicy: "Always"
@@ -28,7 +28,7 @@ master:
   # Below is the implementation of Jenkins Configuration as Code.  Add a key under ConfigScripts for each configuration area,
   # where each corresponds to a plugin or section of the UI.  Each key (prior to | character) is just a label, and can be any value.
   # Keys are only used to give the section a meaningful name.  The only restriction is they may only contain RFC 1123 \ DNS label
-  # characters: lowercase letters, numbers, and hyphens.  The keys become the name of a configuration YAML file on the master in
+  # characters: lowercase letters, numbers, and hyphens.  The keys become the name of a configuration YAML file on the controller in
   # /var/jenkins_home/casc_configs (by default) and will be processed by the Configuration as Code plugin.  The lines after each |
   # become the content of the configuration YAML file.  The first line after this is a JCasC root element, eg jenkins, credentials,
   # etc.  Best reference is https://<jenkins_url>/configuration-as-code/reference.  The example below creates a welcome message:
@@ -57,7 +57,7 @@ master:
       #     cpu: 50m
       #     memory: 50Mi
       # SSH port value can be set to any unused TCP port.  The default, 1044, is a non-standard SSH port that has been chosen at random.
-      # Is only used to reload JCasC config from the sidecar container running in the Jenkins master pod.
+      # Is only used to reload JCasC config from the sidecar container running in the Jenkins controller pod.
       # This TCP port will not be open in the pod (unless you specifically configure this), so Jenkins will not be
       # accessible via SSH from outside of the pod.  Note if you use non-root pod privileges (RunAsUser & FsGroup),
       # this must be > 1024:
@@ -83,7 +83,7 @@ master:
   #   -Dcom.sun.management.jmxremote.authenticate=false
   #   -Dcom.sun.management.jmxremote.ssl=false
   # JMXPort: 4000
-  # List of plugins to be install during Jenkins master start
+  # List of plugins to be install during Jenkins controller start
   installPlugins:
     - kubernetes:latest
     - kubernetes-credentials:latest
@@ -98,7 +98,7 @@ master:
   # ScriptApproval:
   #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"
   #   - "new groovy.json.JsonSlurperClassic"
-  # List of groovy init scripts to be executed during Jenkins master start
+  # List of groovy init scripts to be executed during Jenkins controller start
   initScripts:
   #  - |
   #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'

--- a/demos/kubernetes/README.md
+++ b/demos/kubernetes/README.md
@@ -66,7 +66,7 @@ jenkins:
             nodeUsageMode: EXCLUSIVE
             containers:
               - name: "jnlp"
-                image: "jenkinsci/inbound-agent:latest"
+                image: "jenkins/inbound-agent:latest"
                 alwaysPullImage: true
                 workingDir: "/home/jenkins"
                 ttyEnabled: true

--- a/demos/kubernetes/README.md
+++ b/demos/kubernetes/README.md
@@ -60,13 +60,13 @@ jenkins:
                   key: "FOO"
                   value: "BAR"
 
-          - name: "k8s-slave"
+          - name: "k8s-agent"
             namespace: "default"
             label: "linux-x86_64"
             nodeUsageMode: EXCLUSIVE
             containers:
               - name: "jnlp"
-                image: "jenkinsci/jnlp-slave:latest"
+                image: "jenkinsci/inbound-agent:latest"
                 alwaysPullImage: true
                 workingDir: "/home/jenkins"
                 ttyEnabled: true

--- a/demos/kubernetes/adv_config.yml
+++ b/demos/kubernetes/adv_config.yml
@@ -25,7 +25,7 @@ data:
             maxRequestsPerHostStr: 64
             retentionTimeout: 5
             templates:
-              - name: "k8s-slave"
+              - name: "k8s-agent"
                 namespace: "default"
                 label: "linux-x86_64"
                 nodeUsageMode: EXCLUSIVE

--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -198,7 +198,7 @@ Environment variables can be directly read by JCasC when loading configurations.
 Secrets can be also injected using an environment variables.
 Note that such approach implies security risks,
 because the environment variables can be read by 
-Jenkins admins and jobs running on the Jenkins master.
+Jenkins admins and jobs running on the Jenkins controller.
 
 ==== Using properties file
 

--- a/docs/seed-jobs.md
+++ b/docs/seed-jobs.md
@@ -2,12 +2,12 @@
 
 Requires `job-dsl` >= 1.74
 
-Configuration is not just about setting up Jenkins master, it's also about creating an initial set of jobs.
+Configuration is not just about setting up Jenkins controller, it's also about creating an initial set of jobs.
 For this purpose, we delegate to the popular [job-dsl-plugin](https://plugins.jenkins.io/job-dsl)
 and run a job-dsl script to create an initial set of jobs.
 
 Typical usage is to rely on a multi-branch, or organization folder job type, so further jobs will be dynamically
-created. So a multi-branch seed job will prepare a master to be fully configured for CI/CD targeting a repository
+created. So a multi-branch seed job will prepare a controller to be fully configured for CI/CD targeting a repository
 or organization.
 
 Job-DSL plugin uses groovy syntax for its job configuration DSL, so you'll have to mix YAML and groovy within your

--- a/docs/usageScenarios.md
+++ b/docs/usageScenarios.md
@@ -8,15 +8,15 @@ In the early stage of the project, we use the scenarios to detect the most impor
 
 ## Manage and version control Jenkins global configuration
 
-A small group of devops engineers are maintaining the company's Jenkins installations. There are a handful of Jenkins masters, and a few hundred agents.
+A small group of devops engineers are maintaining the company's Jenkins installations. There are a handful of Jenkins controllers, and a few hundred agents.
 In general the devops team has full access to all the relevant infrastructure and is responsible for the documentation, compliance, maintenance and continued operation.
 
 From their IT department they are supplied with base server or client installations for servers and clients, and they apply configuration management practices to maintain the infrastructure.
 
-For their Jenkins masters the only configuration not under version control is the Jenkins global configuration. The devops engineers maintain that, together with a set of trusted lead developers.
+For their Jenkins controllers the only configuration not under version control is the Jenkins global configuration. The devops engineers maintain that, together with a set of trusted lead developers.
 
 Their global configuration is most frequently changed related to (in order of most changed first): agent configuration, Jenkins plug-in updates, Jenkins global configuration changes.
-All their Jenkins masters have pieces in common (e.g. Artifactory plugin configuration or mail setup) and some instance specific configuration because not all masters are used for the same kind of software development, so plug-ins differ.
+All their Jenkins controllers have pieces in common (e.g. Artifactory plugin configuration or mail setup) and some instance specific configuration because not all masters are used for the same kind of software development, so plug-ins differ.
 
 In general the devops team agrees that the running instances serve as documentation of the configuration themselves - one can always look in the UI. And they can restore from backup.
 Their problems are always related to changes, where they update a plug-in or change a global configuration that gives unexpected side-effects and is rather hard to debug for the users or devops team members that do not know about it.
@@ -24,7 +24,7 @@ They try to remember to ping each other on their chat to inform about changes.
 
 The devops team would like more traceability around changes, by completely moving to manage the Jenkins global configuration as code and put it under version control. They will like to benefit also from having it as code to be able to spin up test environments and re-use common configuration across instances.
 
-**With Jenkins Configuration as Code plug-in** installed on their master, the devops team will describe all the configuration in the `jenkins.yml` and maintain it through a git repository. Whenever they want to change anything, they will edit the file in git and their production server will refresh the configuration or the list of installed plug-ins.
+**With Jenkins Configuration as Code plug-in** installed on their controllers, the devops team will describe all the configuration in the `jenkins.yml` and maintain it through a git repository. Whenever they want to change anything, they will edit the file in git and their production server will refresh the configuration or the list of installed plug-ins.
 
 From that point on they all have full traceability of all the changes made, and they are able to roll it back easily by reverting commits. They can review the changes simply by looking at the git diffs on commits.
 
@@ -42,19 +42,19 @@ _Migration step-by-step guide:_ For the exact steps, see this part of the migrat
 - [#32 where to draft a migration to Jenkins Configuration as Code guide](https://github.com/jenkinsci/configuration-as-code-plugin/issues/32)
 - [#65 helping users migrate by export existing configuration](https://github.com/jenkinsci/configuration-as-code-plugin/issues/65)
 
-## Jenkins master already in docker
+## Jenkins controller already in docker
 
-A small full stack developer team has their single Jenkins master running in a container and they orchestrate and deploy it using one of the many container orchestration tools.
-Their Jenkins global configuration is the only piece not under version control, so they depend on the current data in `JENKINS_HOME` to persist the Jenkins global configuration and be able to redeploy the Jenkins master with existing installed plug-ins. They do not care about their historic build data.
+A small full stack developer team has their single Jenkins controller running in a container and they orchestrate and deploy it using one of the many container orchestration tools.
+Their Jenkins global configuration is the only piece not under version control, so they depend on the current data in `JENKINS_HOME` to persist the Jenkins global configuration and be able to redeploy the Jenkins controller with existing installed plug-ins. They do not care about their historic build data.
 
-**With Jenkins Configuration as Code plug-in** they can get their missing configuration under version control as well and their installed plug-in combinations and for this little full stack developer team it means they can always just redeploy their Jenkins, should something be wrong or failing, and their container orchestration tool will keep their Jenkins master always running for them completely automatically.
+**With Jenkins Configuration as Code plug-in** they can get their missing configuration under version control as well and their installed plug-in combinations and for this little full stack developer team it means they can always just redeploy their Jenkins, should something be wrong or failing, and their container orchestration tool will keep their Jenkins controller always running for them completely automatically.
 
 **Migrating to use the Jenkins Configuration as Code plug-in** is easy if they can live with doing just few manual steps before it is all automated. 
-They need to install the Jenkins Configuration as Code plug-in on their current master, 
+They need to install the Jenkins Configuration as Code plug-in on their current controller, 
 then use the [export functionality](/docs/features/configExport.md) to create the `jenkins.yml` file for them, which they need to add to a git repository.
 Then the last thing they need to do is to update their deployment recipe to use the customized Jenkins where the Jenkins Configuration as Code plug-in comes pre-installed, and have the recipe pass the URI to the `jenkins.yml` file when starting Jenkins.
 
-After that they only do changes in the configuration file through git, and Jenkins Configuration as Code will refresh global configuration. Should their infrastructure fail their orchestration tool will recreate their master from scratch, but still with the same configuration and without depending on old data sets.
+After that they only do changes in the configuration file through git, and Jenkins Configuration as Code will refresh global configuration. Should their infrastructure fail their orchestration tool will recreate their controller from scratch, but still with the same configuration and without depending on old data sets.
 
 Notice a slight difference between `plugins.yml` as part of the Configuration as Code vs `plugins.txt` known from the Jenkins container setups. The latter one will need to contain all plugins and their dependencies and will usually be auto generated to support starting a Jenkins container with all the plug-ins one likes. The `plugin.yml` takes the approach of only mentioning the plugin and their version (or latest) the user really cares about, and Configuration as Code will resolve dependencies for the user.
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <name>Configuration as Code Plugin</name>
-  <description>Manage Jenkins controller configuration as code</description>
+  <description>Manage Jenkins configuration as code</description>
   <url>https://github.com/jenkinsci/configuration-as-code-plugin</url>
 
   <properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,7 +14,7 @@
   <packaging>hpi</packaging>
 
   <name>Configuration as Code Plugin</name>
-  <description>Manage Jenkins master configuration as code</description>
+  <description>Manage Jenkins controller configuration as code</description>
   <url>https://github.com/jenkinsci/configuration-as-code-plugin</url>
 
   <properties>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -292,7 +292,7 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
      * Run configuration process on the target instance
      * @param config configuration to apply. Can be partial if {@link #instance(Mapping, ConfigurationContext)} did already used some entries
      * @param instance target instance to configure
-     * @param dryrun only check configuration is valid regarding target component. Don't actually apply changes to jenkins master instance
+     * @param dryrun only check configuration is valid regarding target component. Don't actually apply changes to jenkins controller instance
      * @param context
      * @throws ConfiguratorException something went wrong...
      */

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -734,8 +734,8 @@ public class ConfigurationAsCode extends ManagementLink {
         // Initialize secret sources
         SecretSource.all().forEach(SecretSource::init);
 
-        // Check input before actually applying changes,
-        // so we don't let master in a weird state after some ConfiguratorException has been thrown
+        // Check input before actually applying changes, so we don't let controller in a
+        //weird state after some ConfiguratorException has been thrown
         final Mapping clone = entries.clone();
         checkWith(clone, context);
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Configurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Configurator.java
@@ -163,7 +163,8 @@ public interface Configurator<T> {
 
     /**
      * Run the same logic as {@link #configure(CNode, ConfigurationContext)} in dry-run mode.
-     * Used to verify configuration is fine before being actually applied to a live jenkins master.
+     * Used to verify configuration is fine before being actually applied to a
+     * live jenkins controller.
      * @param config
      * @param context
      * @throws ConfiguratorException

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -11,7 +11,7 @@
 
     <j:choose>
       <j:when test="${empty it.sources}">
-        <p>${%Master has no configuration as code file set.}</p>
+        <p>${%Controller has no configuration as code file set.}</p>
       </j:when>
       <j:otherwise>
         ${%Configuration loaded from :}


### PR DESCRIPTION
Partially addresses  #1465
Also updated Halm charts [link ](https://github.com/jenkinsci/configuration-as-code-plugin/compare/master...akatsadimas:cleanupMasterSlaveTerminology?expand=1#diff-ea15cec6747d8ff46bf708cbf047e931L6)since it has changed.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
