### PR TITLE
Check only input YAML in doCheck

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -618,7 +618,7 @@ public class ConfigurationAsCode extends ManagementLink {
 
     @Restricted(NoExternalUse.class)
     public Map<Source, String> checkWith(YamlSource source) throws ConfiguratorException {
-        final List<YamlSource> sources = getStandardConfigSources();
+        List<YamlSource> sources = new ArrayList<>();
         sources.add(source);
         return checkWith(sources);
     }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -10,6 +10,8 @@ import hudson.util.FormValidation;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Source;
+import io.jenkins.plugins.casc.yaml.YamlSource;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,6 +21,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -169,6 +172,25 @@ public class ConfigurationAsCodeTest {
         String configUri = getClass().getResource("merge3.yml").toExternalForm();
 
         assertEquals(casc.doCheckNewSource("  " + configUri + "  ").kind, FormValidation.Kind.OK);
+    }
+
+    @Test
+    @Issue("Issue #653")
+    public void checkWith_should_pass_against_valid_input() throws Exception {
+        String rawConf = getClass().getResource("JenkinsConfigTest.yml").toExternalForm();
+        YamlSource input = YamlSource.of(rawConf);
+        Map<Source, String> actual = ConfigurationAsCode.get().checkWith(input);
+        assertThat(actual.size(), is(0));
+    }
+
+    @Test
+    @Issue("Issue #653")
+    @ConfiguredWithCode("aNonEmpty.yml")
+    public void checkWith_should_pass_against_input_which_has_same_entries_with_initial_config() throws Exception {
+        String rawConf = getClass().getResource("JenkinsConfigTest.yml").toExternalForm();
+        YamlSource input = YamlSource.of(rawConf);
+        Map<Source, String> actual = ConfigurationAsCode.get().checkWith(input);
+        assertThat(actual.size(), is(0));
     }
 
     @Test


### PR DESCRIPTION
In real use-case, It almost always fails to check input configuration due to call getStandardConfigSources for now.
So use only input configuration for validating YAML.

Resolve: #653

### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.