### PR TITLE
Add `decodeBase64` substitutor for reading base64-encoded variables

### DIFF
--- a/demos/credentials/README.md
+++ b/demos/credentials/README.md
@@ -4,7 +4,8 @@ Requires `credentials` >= 2.2.0
 
 All values with `"${SOME_SECRET}"` is resolved by our Secret Sources Resolver you can [read more about which sources are supported](../../docs/features/secrets.adoc#secret-sources)
 
-Since JCasC version v1.42 we have added support for variable expansion for `base64`, `readFileBase64` and `readFile`
+Since JCasC version v1.42 we have added support for variable expansion for `base64`, `readFileBase64` and `readFile`.
+More variable expansion options have been added later.
 [Read more about the syntax](../../docs/features/secrets.adoc#passing-secrets-through-variables)
 
 You can also see an [example below](#example)

--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -50,13 +50,15 @@ For example, `Jenkins: "^${some_var}"` will produce the literal `Jenkins: "${som
 
 === Additional variable substitution
 
-Currently we have `base64`, `readFile` and `readFileBase64` all serving a different purpose.
-`readFileBase64` is useful for credential plugin or any other plugin that needs binary base64 encoding of a file, in this specific case that would be useful for link:https://tools.ietf.org/html/rfc7292[a PKCS#12 certificate file].
+Currently we have `base64`, `readFile`, `readBase64` and `readFileBase64` all serving a different purpose.
+`readBase64` and `readFileBase64` are useful for credential plugin or any other plugin that needs binary base64 encoding of a file, in this specific case that would be useful for link:https://tools.ietf.org/html/rfc7292[a PKCS#12 certificate file].
 
 - `${base64:HELLO WORLD}` into `SEVMTE8gV09STEQ=`
 - `${readFile:/secret/file.txt}` into the content of a file.
 - `${base64:${readFile:/secret/file.txt}` into a base64 representation of the content in a file
 - `${base64:${readFile:${SECRET_FILE_PATH}}` nest it all together with regular secret expansion.
+- `${readBase64:${ENV_VAR}}` decodes environment variables encoded as base64.
+      It might be used for passing multi-line variables like SSH keys through the environment.
 - `${readFileBase64:/secret/certificate.p12}` into a base64 representation of the binary file.
 - `${readFile:/secret/file.txt}` an alias for readFile
 - `${fileBase64:/secret/certificate.p12}` an alias for readFileBase64

--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -50,14 +50,14 @@ For example, `Jenkins: "^${some_var}"` will produce the literal `Jenkins: "${som
 
 === Additional variable substitution
 
-Currently we have `base64`, `readFile`, `readBase64` and `readFileBase64` all serving a different purpose.
-`readBase64` and `readFileBase64` are useful for credential plugin or any other plugin that needs binary base64 encoding of a file, in this specific case that would be useful for link:https://tools.ietf.org/html/rfc7292[a PKCS#12 certificate file].
+Currently we have `base64`, `readFile`, `decodeBase64` and `readFileBase64` all serving a different purpose.
+`decodeBase64` and `readFileBase64` are useful for credential plugin or any other plugin that needs binary base64 encoding of a file, in this specific case that would be useful for link:https://tools.ietf.org/html/rfc7292[a PKCS#12 certificate file].
 
 - `${base64:HELLO WORLD}` into `SEVMTE8gV09STEQ=`
 - `${readFile:/secret/file.txt}` into the content of a file.
 - `${base64:${readFile:/secret/file.txt}` into a base64 representation of the content in a file
 - `${base64:${readFile:${SECRET_FILE_PATH}}` nest it all together with regular secret expansion.
-- `${readBase64:${ENV_VAR}}` decodes environment variables encoded as base64.
+- `${decodeBase64:${ENV_VAR}}` decodes environment variables encoded as base64.
       It might be used for passing multi-line variables like SSH keys through the environment.
 - `${readFileBase64:/secret/certificate.p12}` into a base64 representation of the binary file.
 - `${readFile:/secret/file.txt}` an alias for readFile

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/SSHCredentialsTest_Multiline_Key.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/SSHCredentialsTest_Multiline_Key.yml
@@ -1,0 +1,16 @@
+jenkins:
+  systemMessage: Jenkins with SSH Credentials for JCasC test
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - basicSSHUserPrivateKey:
+              scope: SYSTEM
+              id: "userid2"
+              username: "username-of-userid2"
+              passphrase: "passphrase-of-userid2"
+              description: "the description of userid2"
+              privateKeySource:
+                directEntry:
+                  privateKey: ${MY_PRIVATE_KEY}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/SSHCredentialsTest_Singleline_Key.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/SSHCredentialsTest_Singleline_Key.yml
@@ -13,4 +13,4 @@ credentials:
               description: "the description of userid2"
               privateKeySource:
                 directEntry:
-                  privateKey: ${readBase64:${SSH_AGENT_PRIVATE_KEY_BASE64}}
+                  privateKey: ${decodeBase64:${SSH_AGENT_PRIVATE_KEY_BASE64}}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/SSHCredentialsTest_Singleline_Key.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/SSHCredentialsTest_Singleline_Key.yml
@@ -1,0 +1,16 @@
+jenkins:
+  systemMessage: Jenkins with SSH Credentials for JCasC test
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - basicSSHUserPrivateKey:
+              scope: SYSTEM
+              id: "userid2"
+              username: "username-of-userid2"
+              passphrase: "passphrase-of-userid2"
+              description: "the description of userid2"
+              privateKeySource:
+                directEntry:
+                  privateKey: ${readBase64:${SSH_AGENT_PRIVATE_KEY_BASE64}}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -44,7 +44,7 @@ public class SecretSourceResolver {
                     .put("readFileBase64", FileBase64Lookup.INSTANCE)
                     .put("file", FileStringLookup.INSTANCE)
                     .put("readFile", FileStringLookup.INSTANCE)
-                    .put("readBase64", DecodeBase64Lookup.INSTANCE)
+                    .put("decodeBase64", DecodeBase64Lookup.INSTANCE)
                     .build(),
                 new ConfigurationContextStringLookup(configurationContext), false))
             .setEscapeChar(escapedWith)

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -37,13 +37,15 @@ public class SecretSourceResolver {
 
     public SecretSourceResolver(ConfigurationContext configurationContext) {
         substitutor = new StringSubstitutor(
-            StringLookupFactory.INSTANCE.interpolatorStringLookup(ImmutableMap
-                    .of("base64", Base64Lookup.INSTANCE,
-                        "fileBase64", FileBase64Lookup.INSTANCE,
-                        "readFileBase64", FileBase64Lookup.INSTANCE,
-                        "file", FileStringLookup.INSTANCE,
-                        "readFile", FileStringLookup.INSTANCE
-                    ),
+            StringLookupFactory.INSTANCE.interpolatorStringLookup(
+                ImmutableMap.<String, org.apache.commons.text.lookup.StringLookup> builder()
+                    .put("base64", Base64Lookup.INSTANCE)
+                    .put("fileBase64", FileBase64Lookup.INSTANCE)
+                    .put("readFileBase64", FileBase64Lookup.INSTANCE)
+                    .put("file", FileStringLookup.INSTANCE)
+                    .put("readFile", FileStringLookup.INSTANCE)
+                    .put("readBase64", DecodeBase64Lookup.INSTANCE)
+                    .build(),
                 new ConfigurationContextStringLookup(configurationContext), false))
             .setEscapeChar(escapedWith)
             .setVariablePrefix(enclosedBy)
@@ -162,6 +164,16 @@ public class SecretSourceResolver {
         @Override
         public String lookup(@NonNull final String key) {
             return Base64.getEncoder().encodeToString(key.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    static class DecodeBase64Lookup implements StringLookup {
+
+        static final DecodeBase64Lookup INSTANCE = new DecodeBase64Lookup();
+
+        @Override
+        public String lookup(@NonNull final String key) {
+            return new String(Base64.getDecoder().decode(key.getBytes(StandardCharsets.UTF_8)));
         }
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -173,7 +173,7 @@ public class SecretSourceResolver {
 
         @Override
         public String lookup(@NonNull final String key) {
-            return new String(Base64.getDecoder().decode(key.getBytes(StandardCharsets.UTF_8)));
+            return new String(Base64.getDecoder().decode(key.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         }
     }
 


### PR DESCRIPTION
I have a use-case when a multi-line variable needs to be passed through the environment. The easiest way to do that is to encode the variable as Base64 and to pass it through the environment. A new substitutor would be useful for this purpose.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
