### PR TITLE
Add possibility to reload secrets from properties file with JCasC reload

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
@@ -4,8 +4,13 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,5 +39,37 @@ public class PropertiesSecretSourceTest {
         // https://leahneukirchen.org/blog/archive/2019/10/ken-thompson-s-unix-password.html
         assertEquals("ken", credentials.getUsername());
         assertEquals("p/q2-q4!", credentials.getPassword().getPlainText());
+    }
+
+    @Test
+    @ConfiguredWithCode("PropertiesSecretSourceTest.yaml")
+    public void testSecretsFromPropertiesAreUpdatedAfterReload() throws Exception {
+        File secretsFile =  new File(getClass().getResource("secrets.properties").getFile());
+        Properties secrets = new Properties();
+        InputStream inputStream = new FileInputStream(secretsFile);
+        secrets.load(inputStream);
+
+        FileWriter fileWriter = new FileWriter(secretsFile);
+
+        String secretName = "testuser";
+        String updatedTestUserSecret = "charmander";
+        secrets.setProperty(secretName, updatedTestUserSecret);
+        try {
+            secrets.store(fileWriter, "store to properties file");
+
+            ConfigurationAsCode.get().configure(this.getClass().getResource("PropertiesSecretSourceTest.yaml").toString());
+
+            List<UsernamePasswordCredentials> credentialList = CredentialsProvider
+                .lookupCredentials(UsernamePasswordCredentials.class,
+                    Jenkins.getInstanceOrNull(), null, Collections.emptyList());
+            assertEquals(1, credentialList.size());
+
+            UsernamePasswordCredentials credentials = credentialList.get(0);
+
+            assertEquals(updatedTestUserSecret, credentials.getUsername());
+        } finally {
+            secrets.setProperty(secretName, "ken");
+            secrets.store(fileWriter, "store to properties file");
+        }
     }
 }

--- a/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
@@ -23,7 +23,7 @@ public class PropertiesSecretSourceTest {
 
     @Test
     @ConfiguredWithCode("PropertiesSecretSourceTest.yaml")
-    public void test_reading_secrets_from_properties() throws Exception {
+    public void testReadingSecretsFromProperties() throws Exception {
         List<UsernamePasswordCredentials> credentialList = CredentialsProvider
             .lookupCredentials(UsernamePasswordCredentials.class,
                 Jenkins.getInstanceOrNull(), null, Collections.emptyList());

--- a/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 
 public class PropertiesSecretSourceTest {
 
+    private static final String USERNAME_SECRET = "ken";
+
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
         .set("SECRETS_FILE", getClass().getResource("secrets.properties").getFile()))
@@ -37,7 +39,7 @@ public class PropertiesSecretSourceTest {
         UsernamePasswordCredentials credentials = credentialList.get(0);
 
         // https://leahneukirchen.org/blog/archive/2019/10/ken-thompson-s-unix-password.html
-        assertEquals("ken", credentials.getUsername());
+        assertEquals(USERNAME_SECRET, credentials.getUsername());
         assertEquals("p/q2-q4!", credentials.getPassword().getPlainText());
     }
 
@@ -68,7 +70,7 @@ public class PropertiesSecretSourceTest {
 
             assertEquals(updatedTestUserSecret, credentials.getUsername());
         } finally {
-            secrets.setProperty(secretName, "ken");
+            secrets.setProperty(secretName, USERNAME_SECRET);
             secrets.store(fileWriter, "store to properties file");
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/PropertiesSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/PropertiesSecretSource.java
@@ -32,30 +32,26 @@ public class PropertiesSecretSource extends SecretSource {
      */
     public static final String SECRETS_DEFAULT_PATH = "/run/secrets/secrets.properties";
 
-    private Properties secrets;
+    private final Properties secrets = new Properties();
 
     @Override
     public Optional<String> reveal(String secret) {
-        // lazy initialization
-        if (secrets == null) {
-            secrets = new Properties();
-            final String secretsEnv = System.getenv("SECRETS_FILE");
-            final String secretsPath = secretsEnv == null ? SECRETS_DEFAULT_PATH : secretsEnv;
-            final File secretsFile = new File(secretsPath);
-            if (secretsFile.exists() && secretsFile.isFile()) {
-                try (InputStream input = new FileInputStream(secretsFile)) {
-                    secrets.load(input);
-                } catch (IOException ioe) {
-                    LOGGER.log(Level.WARNING,
-                        "Source properties file " + secretsPath + " could not be loaded", ioe);
-                }
-            }
-        }
+        return Optional.ofNullable(secrets.getProperty(secret));
+    }
 
-        if (secrets.getProperty(secret) == null) {
-            return Optional.empty();
-        } else {
-            return Optional.of(secrets.getProperty(secret));
+    @Override
+    public void init() {
+        final String secretsEnv = System.getenv("SECRETS_FILE");
+        final String secretsPath = secretsEnv == null ? SECRETS_DEFAULT_PATH : secretsEnv;
+        final File secretsFile = new File(secretsPath);
+        if (secretsFile.exists() && secretsFile.isFile()) {
+            try (InputStream input = new FileInputStream(secretsFile)) {
+                secrets.clear();
+                secrets.load(input);
+            } catch (IOException ioe) {
+                LOGGER.log(Level.WARNING,
+                    "Source properties file " + secretsPath + " could not be loaded", ioe);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org) - https://github.com/jenkinsci/configuration-as-code-plugin/issues/1555
- [X] Did you provide a test-case? That demonstrates feature works or fixes the issue. - checked by changing the properties file

<!--
Put an `x` into the [ ] to show you have filled the information
-->
