### PR TITLE
Add unit test for plain Double value

### DIFF
--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
@@ -37,18 +37,27 @@ public class DescriptorConfiguratorTest {
         assertThat(descriptor.getBar(), equalTo("bar"));
     }
 
+    @Test
+    @ConfiguredWithCode("DescriptorConfiguratorTest_camelCase.yml")
+    public void configurator_shouldResolveDoubleValue() {
+        FooBar descriptor = (FooBar) j.jenkins.getDescriptorOrDie(FooBar.class);
+        assertThat(descriptor.getBaz(), equalTo(1.0));
+    }
+
     @Extension
     public static class FooBar extends GlobalConfiguration {
         private String foo;
         private String bar;
+        private Double baz;
 
         public FooBar() {
         }
 
         @DataBoundConstructor
-        public FooBar(String foo, String bar) {
+        public FooBar(String foo, String bar, Double baz) {
             this.foo = foo;
             this.bar = bar;
+            this.baz = baz;
         }
 
         @NonNull
@@ -70,6 +79,12 @@ public class DescriptorConfiguratorTest {
         public void setBar(String bar) {
             this.bar = bar;
         }
+
+        @NonNull
+        public Double getBaz() { return baz; }
+
+        @DataBoundSetter
+        public void setBaz(Double baz) { this.baz = baz; }
     }
 
 }

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
@@ -3,3 +3,4 @@ unclassified:
   fooBar:
     foo: "foo"
     bar: "bar"
+    baz: 1.0


### PR DESCRIPTION
Similar to https://github.com/jenkinsci/configuration-as-code-plugin/pull/1444, this PR demonstrates that plain Double values like `baz: 1.0` can't be used to configure things, despite the fact that Double values are exported that way.

I set a breakpoint [here](https://bitbucket.org/asomov/snakeyaml/src/c0484f9579bc9fdced350766375ecb60f5682c58/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java#lines-176) while debugging and found that the line containing `baz: 1.0` is completely missing from `data`, so this appears to be a bug in snakeyaml, or possibly an expected condition that I'm not familiar with.

The workaround for end users (and the way to make the test pass) is simple: use `baz: "1.0"` (double quotes).

I like the solution that @Vlatombe proposed in https://github.com/jenkinsci/configuration-as-code-plugin/pull/1444#issuecomment-683870293, which is to export Double/Float values as double quoted strings, so that they can be safely re-imported.

I found a simple way to do that and will file a separate PR for it.