### PR TITLE
Export Float and Double as String

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -559,8 +559,6 @@ public class ConfigurationAsCode extends ManagementLink {
         switch (format) {
             case NUMBER:
                 return Tag.INT;
-            case FLOATING:
-                return Tag.FLOAT;
             case BOOLEAN:
                 return Tag.BOOL;
             case STRING:

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -47,7 +47,7 @@ public final class Scalar implements CNode, CharSequence {
         this.value = String.valueOf(instance);
         this.raw = true;
         if (instance instanceof Float || instance instanceof Double) {
-            this.format = Format.FLOATING;
+            this.format = Format.STRING;
             this.raw = false;
         } else {
             this.format = Format.NUMBER;

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -45,11 +45,10 @@ public final class Scalar implements CNode, CharSequence {
 
     public Scalar(Number instance) {
         this.value = String.valueOf(instance);
-        this.raw = true;
         if (instance instanceof Float || instance instanceof Double) {
             this.format = Format.STRING;
-            this.raw = false;
         } else {
+            this.raw = true;
             this.format = Format.NUMBER;
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/model/Scalar.java
@@ -48,6 +48,7 @@ public final class Scalar implements CNode, CharSequence {
         this.raw = true;
         if (instance instanceof Float || instance instanceof Double) {
             this.format = Format.FLOATING;
+            this.raw = false;
         } else {
             this.format = Format.NUMBER;
         }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -96,7 +96,7 @@ public class DataBoundConfiguratorTest {
         assertEquals(Util.toYamlString(map.get("bar")).trim(), "true");
         assertEquals(Util.toYamlString(map.get("qix")).trim(), "42");
         assertEquals(Util.toYamlString(map.get("zot")).trim(), "\"zot\"");
-        assertEquals(Util.toYamlString(map.get("dbl")).trim(), "12.34");
+        assertEquals(Util.toYamlString(map.get("dbl")).trim(), "\"12.34\"");
         assertFalse(map.containsKey("other"));
     }
 

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -80,6 +80,7 @@ public class DataBoundConfiguratorTest {
         Foo foo = new Foo("foo", true, 42);
         foo.setZot("zot");
         foo.setDbl(12.34);
+        foo.setFlt(1f); // whole numbers are exported as "<number>.0"
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         final Configurator c = registry.lookupOrFail(Foo.class);
         final ConfigurationContext context = new ConfigurationContext(registry);
@@ -92,11 +93,13 @@ public class DataBoundConfiguratorTest {
         assertEquals(map.get("qix").toString(), "42");
         assertEquals(map.get("zot").toString(), "zot");
         assertEquals(map.get("dbl").toString(), "12.34");
+        assertEquals(map.get("flt").toString(), "1.0");
         assertEquals(Util.toYamlString(map.get("foo")).trim(), "\"foo\"");
         assertEquals(Util.toYamlString(map.get("bar")).trim(), "true");
         assertEquals(Util.toYamlString(map.get("qix")).trim(), "42");
         assertEquals(Util.toYamlString(map.get("zot")).trim(), "\"zot\"");
         assertEquals(Util.toYamlString(map.get("dbl")).trim(), "\"12.34\"");
+        assertEquals(Util.toYamlString(map.get("flt")).trim(), "\"1.0\"");
         assertFalse(map.containsKey("other"));
     }
 
@@ -285,6 +288,7 @@ public class DataBoundConfiguratorTest {
         String zot;
         String other;
         double dbl;
+        private float flt;
         boolean initialized;
 
         @DataBoundConstructor
@@ -340,6 +344,11 @@ public class DataBoundConfiguratorTest {
         public double getDbl() {
             return dbl;
         }
+
+        public float getFlt() { return flt; }
+
+        @DataBoundSetter
+        public void setFlt(float flt) { this.flt = flt; }
     }
 
     public static class Bar {

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
@@ -39,9 +39,10 @@ public class DescriptorConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("DescriptorConfiguratorTest_camelCase.yml")
-    public void configurator_shouldResolveDoubleValue() {
+    public void configurator_shouldResolveFloatAndDoubleValues() {
         FooBar descriptor = (FooBar) j.jenkins.getDescriptorOrDie(FooBar.class);
         assertThat(descriptor.getBaz(), equalTo(1.0));
+        assertThat(descriptor.getFlt(), equalTo(1000f));
     }
 
     @Extension
@@ -49,15 +50,17 @@ public class DescriptorConfiguratorTest {
         private String foo;
         private String bar;
         private Double baz;
+        private Float flt;
 
         public FooBar() {
         }
 
         @DataBoundConstructor
-        public FooBar(String foo, String bar, Double baz) {
+        public FooBar(String foo, String bar, Double baz, Float flt) {
             this.foo = foo;
             this.bar = bar;
             this.baz = baz;
+            this.flt = flt;
         }
 
         @NonNull
@@ -85,6 +88,13 @@ public class DescriptorConfiguratorTest {
 
         @DataBoundSetter
         public void setBaz(Double baz) { this.baz = baz; }
+
+        @NonNull
+        public Float getFlt() { return flt; }
+
+        @DataBoundSetter
+        public void setFlt(Float flt) { this.flt = flt; }
+
     }
 
 }

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
@@ -3,4 +3,4 @@ unclassified:
   fooBar:
     foo: "foo"
     bar: "bar"
-    baz: 1.0
+    baz: "1.0"

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest_camelCase.yml
@@ -4,3 +4,4 @@ unclassified:
     foo: "foo"
     bar: "bar"
     baz: "1.0"
+    flt: "1e3"


### PR DESCRIPTION
Possible solution for https://github.com/jenkinsci/configuration-as-code-plugin/pull/1560.

Setting `raw` to `false` for `Float` and `Double` types tells `ConfigurationAsCode#toYaml` to export using the `DOUBLE_QUOTED` style instead of the current `PLAIN` style:
https://github.com/jenkinsci/configuration-as-code-plugin/blob/f9d526bdb1ce95c6c894f7be97bd76417c12e968/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java#L548-L552