### PR TITLE
Update broken link in Secrets documentation

### DIFF
--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -218,7 +218,7 @@ This is an additional engine which uses the link:https://javadoc.jenkins-ci.org/
 * Encryption is done using the Jenkins-internal secret key
   which is unique for every Jenkins instance.
   It means that the credentials are not portable between instances.
-* Encrypted credential values can be exported using the link:./configExport.adoc[configuration export] feature.
+* Encrypted credential values can be exported using the link:./configExport.md[configuration export] feature.
 
 NOTE: There is an open feature request for supporting portable credentials.
 See link:https://github.com/jenkinsci/configuration-as-code-plugin/issues/1141[JCasC #1141].


### PR DESCRIPTION
`configExport.adoc` was converted to Markdown but link in base Secrets doc was not updated.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
