### PR TITLE
Use Caffeine again but without recursion

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -47,6 +47,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>caffeine-api</artifactId>
+      <version>2.9.0-17.v79e9099a51e3</version>
+    </dependency>
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20201115</version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
-      <version>2.9.0-17.v79e9099a51e3</version>
+      <version>2.9.1-23.v51c4e2c879c8</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <revision>1.50</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.222</jenkins.version>
+    <jenkins.version>2.222.1</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>


### PR DESCRIPTION
Reverts #1596, to once again use Caffeine, but this time without recursion on `Collection<SomeType>`: even if `lookup(SomeType.class)` happens to have been processed already, we will compute that again.
