### PR TITLE
Allow multiple YAML sources to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ First, start a Jenkins instance with the [Configuration as Code](https://plugins
 
 - Those running Jenkins as a [Docker](https://github.com/jenkinsci/docker) container (and maybe also [pre-installing plugins](https://github.com/jenkinsci/docker#preinstalling-plugins)), do include [Configuration as Code](https://plugins.jenkins.io/configuration-as-code) plugin.
 
-Second, the plugin looks for the `CASC_JENKINS_CONFIG` environment variable. The variable can point to any of the following:
+Second, the plugin looks for the `CASC_JENKINS_CONFIG` environment variable. The variable points to a comma-separated list of any of the following:
 
 - Path to a folder containing a set of config files. For example, `/var/jenkins_home/casc_configs`.
 - A full path to a single file. For example, `/var/jenkins_home/casc_configs/jenkins.yaml`.
 - A URL pointing to a file served on the web. For example, `https://acme.org/jenkins.yaml`.
 
-If `CASC_JENKINS_CONFIG` points to a folder, the plugin will recursively traverse the folder to find file(s) with .yml,.yaml,.YAML,.YML suffix. It will exclude hidden files or files that contain a hidden folder in **any part** of the full path. It follows symbolic links for both files and directories.
+If an element of `CASC_JENKINS_CONFIG` points to a folder, the plugin will recursively traverse the folder to find file(s) with .yml,.yaml,.YAML,.YML suffix. It will exclude hidden files or files that contain a hidden folder in **any part** of the full path. It follows symbolic links for both files and directories.
 <details><summary>Exclusion examples</summary>
 
 `CASC_JENKINS_CONFIG=/jenkins/casc_configs`  

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -182,16 +182,18 @@ public class ConfigurationAsCode extends ManagementLink {
         String newSource = request.getParameter("_.newSource");
         String normalizedSource = Util.fixEmptyAndTrim(newSource);
         List<String> candidateSources = new ArrayList<>();
-        for (String candidateSource : normalizedSource.split("\\s+")) {
-            if (candidateSource.isEmpty()) {
-                continue;
-            }
-            File file = new File(candidateSource);
-            if (file.exists() || ConfigurationAsCode.isSupportedURI(candidateSource)) {
-                candidateSources.add(candidateSource);
-            } else {
-                LOGGER.log(Level.WARNING, "Source {0} could not be applied", candidateSource);
-                // todo: show message in UI
+        if (normalizedSource != null) {
+            for (String candidateSource : normalizedSource.split("\\s+")) {
+                if (candidateSource.isEmpty()) {
+                    continue;
+                }
+                File file = new File(candidateSource);
+                if (file.exists() || ConfigurationAsCode.isSupportedURI(candidateSource)) {
+                    candidateSources.add(candidateSource);
+                } else {
+                    LOGGER.log(Level.WARNING, "Source {0} could not be applied", candidateSource);
+                    // todo: show message in UI
+                }
             }
         }
         if (!candidateSources.isEmpty()) {

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -175,6 +175,19 @@ public class ConfigurationAsCodeTest {
     }
 
     @Test
+    public void doCheckNewSource_should_support_multiple_sources() {
+        ConfigurationAsCode casc = ConfigurationAsCode.get();
+
+        String configUri =
+                String.format(
+                        " %s , %s ",
+                        getClass().getResource("JenkinsConfigTest.yml").toExternalForm(),
+                        getClass().getResource("folder/jenkins2.yml").toExternalForm());
+
+        assertEquals(casc.doCheckNewSource(configUri).kind, FormValidation.Kind.OK);
+    }
+
+    @Test
     @Issue("Issue #653")
     public void checkWith_should_pass_against_valid_input() throws Exception {
         String rawConf = getClass().getResource("JenkinsConfigTest.yml").toExternalForm();
@@ -206,6 +219,26 @@ public class ConfigurationAsCodeTest {
         j.assertGoodStatus(resultPage);
 
         assertEquals("Configured by Configuration as Code plugin", j.jenkins.getSystemMessage());
+    }
+
+    @Test
+    public void doReplace_should_support_multiple_sources() throws Exception {
+        HtmlPage page = j.createWebClient().goTo("configuration-as-code");
+        j.assertGoodStatus(page);
+
+        HtmlForm form = page.getFormByName("replace");
+        HtmlInput input = form.getInputByName("_.newSource");
+        String configUri =
+                String.format(
+                        " %s , %s ",
+                        getClass().getResource("JenkinsConfigTest.yml").toExternalForm(),
+                        getClass().getResource("folder/jenkins2.yml").toExternalForm());
+        input.setValueAttribute(configUri);
+        HtmlPage resultPage = j.submit(form);
+        j.assertGoodStatus(resultPage);
+
+        assertEquals("configuration as code - JenkinsConfigTest", j.jenkins.getSystemMessage());
+        assertEquals(10, j.jenkins.getQuietPeriod());
     }
 
     @Test

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/JenkinsConfigTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/JenkinsConfigTest.java
@@ -28,7 +28,7 @@ public class JenkinsConfigTest {
 
     @Rule
     public RuleChain chain = RuleChain.outerRule( new EnvironmentVariables()
-            .set("CASC_JENKINS_CONFIG", getClass().getResource("JenkinsConfigTest.yml").toExternalForm()))
+            .set("CASC_JENKINS_CONFIG", String.format("%s,%s", getClass().getResource("JenkinsConfigTest.yml").toExternalForm(), getClass().getResource("folder/jenkins2.yml").toExternalForm())))
             .around(new JenkinsConfiguredWithCodeRule());
 
 

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/JenkinsConfigTest.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/JenkinsConfigTest.yml
@@ -1,3 +1,2 @@
 jenkins:
   systemMessage: "configuration as code - JenkinsConfigTest"
-  quietPeriod: 10


### PR DESCRIPTION
After all these years, we're finally getting around to setting up JCasC on our Jenkins controllers. For a variety of reasons, we'd like to use URLs rather than files/directories to configure our controllers. But we also want to be able to define a primary YAML file with base configuration that applies to all controllers and a secondary YAML file with controller-specific configuration that is unique to each controller. But in the current system, you can only specify a single URL in the YAML source (e.g., `CASC_JENKINS_CONFIG`, `-Dcasc.jenkins.config`, or the text box in the UI's "replace" page) . Wanting to use two YAML files currently seems to preclude one from using a URL as the YAML source.

This PR attempts to solve the problem by allowing the YAML source (e.g., `CASC_JENKINS_CONFIG`, `-Dcasc.jenkins.config`, or the text box in the UI's "replace" page) to be a whitespace-separated list of URLs/files/directories rather than a single URL/file/directory. This preserves compatibility with the existing semantics while also allowing the user to use multiple URLs for multiple YAML files.

I have only done some basic manual testing so far, but if the maintainers are receptive to this PR I will add some automated tests and documentation.