### PR TITLE
Bump `artifactory` from 3.4.0 to 3.11.2

### DIFF
--- a/demos/artifactory/README.md
+++ b/demos/artifactory/README.md
@@ -4,6 +4,24 @@ Artifactory plugin configuration belongs under `unclassified` root element
 
 ## sample configuration
 
+Since 3.11.0:
+
+```yaml
+unclassified:
+  artifactorybuilder:
+    useCredentialsPlugin: true
+    jfrogInstances:
+      - instanceId: artifactory
+        url: http://acme.com/artifactory
+        deployerCredentialsConfig:
+          credentialsId: "artifactory"
+        resolverCredentialsConfig:
+          username: artifactory_user
+          password: "${ARTIFACTORY_PASSWORD}"
+```
+
+Before 3.11.0:
+
 ```yaml
 unclassified:
   artifactorybuilder:

--- a/demos/jenkins/jenkins.yaml
+++ b/demos/jenkins/jenkins.yaml
@@ -53,9 +53,9 @@ tool:
 unclassified:
   artifactorybuilder:
     useCredentialsPlugin: true
-    artifactoryServers:
-      - serverId: artifactory
-        artifactoryUrl: http://acme.com/artifactory
+    jfrogInstances:
+      - instanceId: artifactory
+        url: http://acme.com/artifactory
         resolverCredentialsConfig:
           username: artifactory_user
           password: "${ARTIFACTORY_PASSWORD}"

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -16,6 +16,7 @@
     <jackson.version>2.11.3</jackson.version>
     <netty.version>4.1.52.Final</netty.version>
     <jenkins.version>2.289</jenkins.version>
+    <junixsocket.version>2.2.0</junixsocket.version>
   </properties>
 
   <dependencies>
@@ -537,6 +538,16 @@
             <artifactId>jersey-hk2</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.kohlschutter.junixsocket</groupId>
+        <artifactId>junixsocket-common</artifactId>
+        <version>${junixsocket.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.kohlschutter.junixsocket</groupId>
+        <artifactId>junixsocket-native-common</artifactId>
+        <version>${junixsocket.version}</version>
       </dependency>
       <!-- force upper bound dependencies -->
       <dependency>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -664,6 +664,11 @@
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-classworlds</artifactId>
+        <version>2.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
         <version>3.3.0</version>
       </dependency>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -530,7 +530,7 @@
       <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.5</version>
         <exclusions>
           <exclusion> <!-- https://issues.jenkins-ci.org/browse/JENKINS-39689 -->
             <groupId>org.glassfish.jersey.inject</groupId>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -654,6 +654,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>3.5.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
         <version>3.6.3</version>
       </dependency>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -665,7 +665,7 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>3.3.3</version>
+        <version>3.5.4</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>artifactory</artifactId>
-      <version>3.4.0</version>
+      <version>3.11.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion> <!-- Found Banned Dependency: org.sonatype.sisu:sisu-guice:jar:no_aop:3.2.5 -->

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>artifactory</artifactId>
-      <version>3.11.0</version>
+      <version>3.11.x-20210528.151854-1</version> <!-- TODO https://github.com/jfrog/jenkins-artifactory-plugin/pull/455 -->
       <scope>test</scope>
       <exclusions>
         <exclusion> <!-- Found Banned Dependency: org.sonatype.sisu:sisu-guice:jar:no_aop:3.2.5 -->

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>artifactory</artifactId>
-      <version>3.11.x-20210528.151854-1</version> <!-- TODO https://github.com/jfrog/jenkins-artifactory-plugin/pull/455 -->
+      <version>3.11.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion> <!-- Found Banned Dependency: org.sonatype.sisu:sisu-guice:jar:no_aop:3.2.5 -->

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -685,7 +685,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.4</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.modules</groupId>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ArtifactoryTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ArtifactoryTest.java
@@ -5,7 +5,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.jfrog.hudson.ArtifactoryBuilder;
-import org.jfrog.hudson.ArtifactoryServer;
+import org.jfrog.hudson.JFrogPlatformInstance;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -31,13 +31,13 @@ public class ArtifactoryTest {
         final ArtifactoryBuilder.DescriptorImpl descriptor = (ArtifactoryBuilder.DescriptorImpl) jenkins.getDescriptor(ArtifactoryBuilder.class);
         assertTrue(descriptor.getUseCredentialsPlugin());
 
-        final List<ArtifactoryServer> actifactoryServers = descriptor.getArtifactoryServers();
-        assertThat(actifactoryServers, hasSize(1));
-        assertThat(actifactoryServers.get(0).getName(), is(equalTo("artifactory")));
-        assertThat(actifactoryServers.get(0).getUrl(), is(equalTo("http://acme.com/artifactory")));
-        assertThat(actifactoryServers.get(0).getDeployerCredentialsConfig().getCredentialsId(), is(equalTo("artifactory")));
-        assertThat(actifactoryServers.get(0).getResolverCredentialsConfig().getUsername(), is(equalTo("artifactory_user")));
-        assertThat(actifactoryServers.get(0).getResolverCredentialsConfig().getPassword(), is(equalTo("password123")));
+        final List<JFrogPlatformInstance> jfrogInstances = descriptor.getJfrogInstances();
+        assertThat(jfrogInstances, hasSize(1));
+        assertThat(jfrogInstances.get(0).getId(), is(equalTo("artifactory")));
+        assertThat(jfrogInstances.get(0).getUrl(), is(equalTo("http://acme.com/artifactory")));
+        assertThat(jfrogInstances.get(0).getDeployerCredentialsConfig().getCredentialsId(), is(equalTo("artifactory")));
+        assertThat(jfrogInstances.get(0).getResolverCredentialsConfig().getUsername(), is(equalTo("artifactory_user")));
+        assertThat(jfrogInstances.get(0).getResolverCredentialsConfig().getPassword().getPlainText(), is(equalTo("password123")));
 
     }
 }

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsDemoTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsDemoTest.java
@@ -12,7 +12,7 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jfrog.hudson.ArtifactoryBuilder;
-import org.jfrog.hudson.ArtifactoryServer;
+import org.jfrog.hudson.JFrogPlatformInstance;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -71,12 +71,12 @@ public class JenkinsDemoTest {
         final ArtifactoryBuilder.DescriptorImpl artifactory = (ArtifactoryBuilder.DescriptorImpl) jenkins.getDescriptor(ArtifactoryBuilder.class);
         assertTrue(artifactory.getUseCredentialsPlugin());
 
-        final List<ArtifactoryServer> actifactoryServers = artifactory.getArtifactoryServers();
-        assertThat(actifactoryServers, hasSize(1));
-        assertThat(actifactoryServers.get(0).getName(), is(equalTo("artifactory")));
-        assertThat(actifactoryServers.get(0).getUrl(), is(equalTo("http://acme.com/artifactory")));
-        assertThat(actifactoryServers.get(0).getResolverCredentialsConfig().getUsername(), is(equalTo("artifactory_user")));
-        assertThat(actifactoryServers.get(0).getResolverCredentialsConfig().getPassword(), is(equalTo("password123")));
+        final List<JFrogPlatformInstance> jfrogInstances = artifactory.getJfrogInstances();
+        assertThat(jfrogInstances, hasSize(1));
+        assertThat(jfrogInstances.get(0).getId(), is(equalTo("artifactory")));
+        assertThat(jfrogInstances.get(0).getUrl(), is(equalTo("http://acme.com/artifactory")));
+        assertThat(jfrogInstances.get(0).getResolverCredentialsConfig().getUsername(), is(equalTo("artifactory_user")));
+        assertThat(jfrogInstances.get(0).getResolverCredentialsConfig().getPassword().getPlainText(), is(equalTo("password123")));
     }
 
 }

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/ArtifactoryBuilderTest.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/ArtifactoryBuilderTest.yml
@@ -1,10 +1,10 @@
 jenkins:
   artifactorybuilder:
     useCredentialsPlugin: true
-    artifactoryServers:
+    jfrogInstances:
       - name: foo
-        serverId: artifactory
-        artifactoryUrl: http://acme.com/artifactory
+        instanceId: artifactory
+        url: http://acme.com/artifactory
         resolverCredentialsConfig:
           username: artifactory_user
           password: ${ARTIFACTORY_PASSWORD}

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/ArtifactoryBuilderTest.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/ArtifactoryBuilderTest.yml
@@ -1,9 +1,8 @@
-jenkins:
+unclassified:
   artifactorybuilder:
     useCredentialsPlugin: true
     jfrogInstances:
-      - name: foo
-        instanceId: artifactory
+      - instanceId: artifactory
         url: http://acme.com/artifactory
         resolverCredentialsConfig:
           username: artifactory_user


### PR DESCRIPTION
Fixes #1607 and [JENKINS-65687](https://issues.jenkins.io/browse/JENKINS-65687). Supersedes #1608 and #1609.
closes #1608, closes #1609

This PR isn't fully working yet; `MailExtTest.shouldProperlyRoundTripTokenMacro` fails with

```
io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator configurator
        at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:719)
        at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:777)
        at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:762)
        at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:638)
        at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:632)
        at io.jenkins.plugins.casc.MailExtTest.shouldProperlyRoundTripTokenMacro(MailExtTest.java:71)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:601)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:288)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:282)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)
Caused by: io.jenkins.plugins.casc.ConfiguratorException: Cannot find configurator for type class org.jfrog.hudson.ArtifactoryServer
        at io.jenkins.plugins.casc.impl.DefaultConfiguratorRegistry.lookupOrFail(DefaultConfiguratorRegistry.java:69)
        at io.jenkins.plugins.casc.ConfigurationContext.lookupOrFail(ConfigurationContext.java:112)
        at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:337)
        at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:287)
        at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:351)
        at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:287)
        at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$8(ConfigurationAsCode.java:777)
        at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:713)
        ... 18 more
```

I started looking into this and found that the exported config contained

```
unclassified:
  artifactoryBuilder:
    artifactoryServers: |-
      FAILED TO EXPORT
      org.jfrog.hudson.ArtifactoryBuilder$DescriptorImpl#artifactoryServers: No configurator found for type class org.jfrog.hudson.ArtifactoryServer
    jfrogPipelinesServer:
      bypassProxy: false
      connectionRetries: 3
      credentialsConfig:
        overridingCredentials: false
        username: "****"
      timeout: 300
    useCredentialsPlugin: false
```

which was then causing the test to trip up later. Not sure if this can be worked around temporarily or if this will need to be addressed in the Artifactory plugin itself.