### PR TITLE
Clarified Built-In and GitHub Authorizations for Global Matrix Auth Plugin

### DIFF
--- a/demos/global-matrix-auth/README.md
+++ b/demos/global-matrix-auth/README.md
@@ -17,6 +17,7 @@ jenkins:
         - "Overall/Read:anonymous"
         - "Overall/Administer:authenticated"
 ```
+Permissions must be defined **per line**, meaning each line must grant permission to only a single role, and only a single user or group of users.
 
 ## sample-configuration (project-based matrix)
 

--- a/demos/global-matrix-auth/README.md
+++ b/demos/global-matrix-auth/README.md
@@ -19,7 +19,7 @@ jenkins:
 ```
 Permissions must be defined **per line**, meaning each line must grant permission to only a single role, and only a single user or group of users.
 
-## sample-configuration (project-based matrix)
+## sample-configuration (project based matrix)
 
 ```yaml
 jenkins:

--- a/demos/global-matrix-auth/README.md
+++ b/demos/global-matrix-auth/README.md
@@ -2,6 +2,11 @@
 
 Requires `matrix-auth` >= 2.4
 
+There are a couple of built-in authorizations to consider.
+
+- **anonymous** - anyone who has not logged in. 
+- **authenticated** - anyone who has logged in. 
+
 ## sample-configuration (global matrix)
 
 ```yaml
@@ -13,7 +18,7 @@ jenkins:
         - "Overall/Administer:authenticated"
 ```
 
-## sample-configuration (project based matrix)
+## sample-configuration (project-based matrix)
 
 ```yaml
 jenkins:
@@ -43,3 +48,13 @@ jenkins:
 
 Some permissions depends on actual plugin-usage.  
 For Example: `Release/*:authenticated` is only available if you _use_ the Release plugin in one of your jobs.
+
+## GitHub Authorization
+
+https://plugins.jenkins.io/github-oauth/
+
+You can configure authorization based on GitHub users, organizations, or teams.
+
+- **username** - specific GitHub username.
+- **organization** - every user that belongs to a specific GitHub organization.
+- **organization*team** - specific GitHub team of a GitHub organization.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~~Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- ~~Did you provide a test-case? That demonstrates feature works or fixes the issue.~~

### Description
When persisting Jenkins configuration-as-code, I found it quite difficult to locate information on this plugin's exact available formatting/options. I did some digging and found the official docs for github oauth that make reference to github-based methods of auth within the project-based matrix auth. that this doc refers to: https://plugins.jenkins.io/github-oauth/. I felt that this information was important enough to replicate, and that provision of a source in what must be more than an edge case would be of use to others.
