### PR TITLE
doc: add infos on reloading with the Jenkins CLI

### DIFF
--- a/docs/features/configurationReload.md
+++ b/docs/features/configurationReload.md
@@ -6,7 +6,17 @@ You have the following option to trigger a configuration reload:
 - via http POST to `JENKINS_URL/configuration-as-code/reload`
   Note: this needs to include a valid CRUMB and authentication information e.g. username + token of a user with admin
   permissions. Since Jenkins 2.96 CRUMB is not needed for API tokens.
-- via Jenkins CLI
+- via [Jenkins CLI](https://www.jenkins.io/doc/book/managing/cli/): with the Jenkins CLI (either with SSH or JAR), the command `java -jar jenkins-cli.jar -s ${JENKINS_URL} reload-jcasc-configuration` triggers a configuration reload (which is faster and more efficient than a `safe-restart` when the configuration was changed)
+  This Jenkins CLI command is only present when the plugin `configuration-as-code` is installed, and reported in the help message:
+  
+```shell
+$ java -jar jenkins-cli.jar -s ${JENKINS_URL} help
+# ...
+reload-jcasc-configuration
+    Reload JCasC YAML configuration
+# ...
+```
+    
 - via http POST to `JENKINS_URL/reload-configuration-as-code`
   It's disabled by default and secured via a token configured as system property `casc.reload.token`.
   Setting the system property enables this functionality and the requests need to include the token as

--- a/docs/features/configurationReload.md
+++ b/docs/features/configurationReload.md
@@ -6,7 +6,7 @@ You have the following option to trigger a configuration reload:
 - via http POST to `JENKINS_URL/configuration-as-code/reload`
   Note: this needs to include a valid CRUMB and authentication information e.g. username + token of a user with admin
   permissions. Since Jenkins 2.96 CRUMB is not needed for API tokens.
-- via [Jenkins CLI](https://www.jenkins.io/doc/book/managing/cli/): with the Jenkins CLI (either with SSH or JAR), the command `java -jar jenkins-cli.jar -s ${JENKINS_URL} reload-jcasc-configuration` triggers a configuration reload (which is faster and more efficient than a `safe-restart` when the configuration was changed)
+- via [Jenkins CLI](https://www.jenkins.io/doc/book/managing/cli/): with the Jenkins CLI (either with SSH or JAR), the command `java -jar jenkins-cli.jar -s ${JENKINS_URL} reload-jcasc-configuration` triggers a configuration reload.
   This Jenkins CLI command is only present when the plugin `configuration-as-code` is installed, and reported in the help message:
   
 ```shell


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/jenkins-infra/pull/1817 , I was pointed to the Jenkins CLI command `reload-jcasc-configuration` by @timja . It felt like that the documentation could be improved to help the end user and point them to the same knowledge.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~[ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)~
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~[ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.~
