### PR TITLE
Allow reloading configuration with Overall/Manage permission

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -46,7 +46,6 @@
     </JavaCodeStyleSettings>
     <XML>
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="CSS">
       <indentOptions>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -151,7 +151,7 @@ public class ConfigurationAsCode extends ManagementLink {
     @NonNull
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.SYSTEM_READ;
+        return Jenkins.READ;
     }
 
     public Date getLastTimeLoaded() {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -165,8 +165,7 @@ public class ConfigurationAsCode extends ManagementLink {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doReload(StaplerRequest request, StaplerResponse response) throws Exception {
-        final Jenkins jenkins = Jenkins.get();
-        if (!jenkins.hasPermission(Jenkins.ADMINISTER) && !jenkins.hasPermission(Jenkins.MANAGE)) {
+        if (!Jenkins.get().hasPermission(Jenkins.MANAGE)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -165,7 +165,8 @@ public class ConfigurationAsCode extends ManagementLink {
     @RequirePOST
     @Restricted(NoExternalUse.class)
     public void doReload(StaplerRequest request, StaplerResponse response) throws Exception {
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        final Jenkins jenkins = Jenkins.get();
+        if (!jenkins.hasPermission(Jenkins.ADMINISTER) && !jenkins.hasPermission(Jenkins.MANAGE)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
-  <l:layout norefresh="true" type="one-column" title="${%Configuration as Code}" permission="${app.MANAGE_AND_SYSTEM_READ}">
+  <l:layout norefresh="true" type="one-column" title="${%Configuration as Code}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
   <l:main-panel>
   <st:adjunct includes="io.jenkins.plugins.casc.assets.index"/>
 

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -39,11 +39,11 @@
     </l:isAdmin>
     <h2>${%Actions}</h2>
 
-    <l:isAdmin>
+    <l:hasAdministerOrManage>
       <f:form method="post" action="reload" name="reload">
         <f:submit name="reload" value="${%Reload existing configuration}"/>
       </f:form>
-    </l:isAdmin>
+    </l:hasAdministerOrManage>
     <f:form method="post" action="export" name="export">
       <f:submit name="export" value="${%Download Configuration}"/>
     </f:form>

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
-  <l:layout norefresh="true" type="one-column" title="${%Configuration as Code}">
+  <l:layout norefresh="true" type="one-column" title="${%Configuration as Code}" permission="${app.SYSTEM_READ}">
   <l:main-panel>
   <st:adjunct includes="io.jenkins.plugins.casc.assets.index"/>
 

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
-  <l:layout norefresh="true" type="one-column" title="${%Configuration as Code}" permission="${app.SYSTEM_READ}">
+  <l:layout norefresh="true" type="one-column" title="${%Configuration as Code}" permission="${app.MANAGE_AND_SYSTEM_READ}">
   <l:main-panel>
   <st:adjunct includes="io.jenkins.plugins.casc.assets.index"/>
 

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -44,22 +44,24 @@
         <f:submit name="reload" value="${%Reload existing configuration}"/>
       </f:form>
     </l:hasAdministerOrManage>
-    <f:form method="post" action="export" name="export">
-      <f:submit name="export" value="${%Download Configuration}"/>
-    </f:form>
-    <f:form method="post" action="viewExport" name="viewExport">
-      <f:submit name="viewExport" value="${%View Configuration}"/>
-    </f:form>
-    <div class="alert alert-warning clear-action-forms">
-      <img src="${rootURL}/images/16x16/warning.png"/>
-      ${%exportWarning}
-    </div>
+    <l:hasPermission permission="${app.SYSTEM_READ}">
+      <f:form method="post" action="export" name="export">
+        <f:submit name="export" value="${%Download Configuration}"/>
+      </f:form>
+      <f:form method="post" action="viewExport" name="viewExport">
+        <f:submit name="viewExport" value="${%View Configuration}"/>
+      </f:form>
+      <div class="alert alert-warning clear-action-forms">
+        <img src="${rootURL}/images/16x16/warning.png"/>
+        ${%exportWarning}
+      </div>
 
-    <h2>${%Reference}</h2>
-    <dt>
-      <dl><a href="reference">${%Documentation}</a></dl>
-      <dl><a href="schema">${%JSON schema}</a></dl>
-    </dt>
+      <h2>${%Reference}</h2>
+      <dt>
+        <dl><a href="reference">${%Documentation}</a></dl>
+        <dl><a href="schema">${%JSON schema}</a></dl>
+      </dt>
+    </l:hasPermission>
 
   </div>
   </div>

--- a/plugin/src/test/java/io/jenkins/plugins/casc/permissions/Action.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/permissions/Action.java
@@ -1,0 +1,16 @@
+package io.jenkins.plugins.casc.permissions;
+
+public enum Action {
+
+    VIEW_CONFIGURATION("View Configuration"),
+    DOWNLOAD_CONFIGURATION("Download Configuration"),
+    APPLY_NEW_CONFIGURATION("Apply new configuration"),
+    RELOAD_EXISTING_CONFIGURATION("Reload existing configuration"),
+    ;
+
+    String buttonText;
+
+    Action(String buttonText) {
+        this.buttonText = buttonText;
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/permissions/PermissionsTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/permissions/PermissionsTest.java
@@ -1,0 +1,146 @@
+package io.jenkins.plugins.casc.permissions;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+
+import static io.jenkins.plugins.casc.permissions.Action.APPLY_NEW_CONFIGURATION;
+import static io.jenkins.plugins.casc.permissions.Action.DOWNLOAD_CONFIGURATION;
+import static io.jenkins.plugins.casc.permissions.Action.RELOAD_EXISTING_CONFIGURATION;
+import static io.jenkins.plugins.casc.permissions.Action.VIEW_CONFIGURATION;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+
+public class PermissionsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void checkPermissionsForSimpleUser() throws Exception {
+        final String USER = "user";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+            .grant(Jenkins.READ).everywhere().to(USER)
+            .grant(Jenkins.SYSTEM_READ).everywhere().to(USER)
+        );
+
+        JenkinsRule.WebClient webClient = j.createWebClient()
+            .withThrowExceptionOnFailingStatusCode(false);
+
+        assertUserPermissions(
+            webClient,
+            USER,
+            ImmutableMap.<Action, Boolean>builder()
+                .put(VIEW_CONFIGURATION, true)
+                .put(DOWNLOAD_CONFIGURATION, true)
+                .put(APPLY_NEW_CONFIGURATION, false)
+                .put(RELOAD_EXISTING_CONFIGURATION, false)
+                .build()
+        );
+    }
+
+    @Test
+    public void checkPermissionsForManager() throws Exception {
+        final String MANAGER = "manager";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+            .grant(Jenkins.READ).everywhere().to(MANAGER)
+            .grant(Jenkins.SYSTEM_READ).everywhere().to(MANAGER)
+            .grant(Jenkins.MANAGE).everywhere().to(MANAGER)
+        );
+
+        JenkinsRule.WebClient webClient = j.createWebClient()
+            .withThrowExceptionOnFailingStatusCode(false);
+
+        assertUserPermissions(
+            webClient,
+            MANAGER,
+            ImmutableMap.<Action, Boolean>builder()
+                .put(VIEW_CONFIGURATION, true)
+                .put(DOWNLOAD_CONFIGURATION, true)
+                .put(APPLY_NEW_CONFIGURATION, false)
+                .put(RELOAD_EXISTING_CONFIGURATION, true)
+                .build()
+        );
+    }
+
+    @Test
+    public void checkPermissionsForAdmin() throws Exception {
+        final String ADMIN = "admin";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+            .grant(Jenkins.ADMINISTER).everywhere().to(ADMIN)
+        );
+
+        JenkinsRule.WebClient webClient = j.createWebClient()
+            .withThrowExceptionOnFailingStatusCode(false);
+
+        assertUserPermissions(
+            webClient,
+            ADMIN,
+            ImmutableMap.<Action, Boolean>builder()
+                .put(VIEW_CONFIGURATION, true)
+                .put(DOWNLOAD_CONFIGURATION, true)
+                .put(APPLY_NEW_CONFIGURATION, true)
+                .put(RELOAD_EXISTING_CONFIGURATION, true)
+                .build()
+        );
+    }
+
+    private void assertUserPermissions(WebClient webClient, String user,
+        Map<Action, Boolean> allowedActions) throws Exception {
+
+        webClient.login(user);
+        assertCascTileShows(webClient);
+
+        HtmlPage cascPage = assertCanAccessPage(webClient, "configuration-as-code");
+        allowedActions.forEach(
+            (action, isAllowed) -> assertActionAvailable(cascPage, action, isAllowed)
+        );
+    }
+
+    private HtmlPage assertCanAccessPage(WebClient webClient, String relativePath)
+        throws Exception {
+        HtmlPage page = webClient.goTo(relativePath);
+        assertEquals(HTTP_OK, page.getWebResponse().getStatusCode());
+        return page;
+    }
+
+    private void assertCascTileShows(WebClient webClient) throws Exception {
+        HtmlPage managePage = assertCanAccessPage(webClient, "manage");
+        final String pageContent = managePage.getWebResponse().getContentAsString();
+        assertThat(
+            "The user should have access to the CasC tile in management page",
+            pageContent,
+            containsString("Configuration as Code")
+        );
+    }
+
+    private void assertActionAvailable(HtmlPage page, Action action, boolean shouldContain) {
+        String responseContent = page.getWebResponse().getContentAsString();
+        if (shouldContain) {
+            assertThat(
+                format("Action %s should be available", action.name()),
+                responseContent,
+                containsString(action.buttonText)
+            );
+        } else {
+            assertThat(
+                format("Action %s should not be available", action.name()),
+                responseContent,
+                not(containsString(action.buttonText))
+            );
+        }
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/permissions/PermissionsTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/permissions/PermissionsTest.java
@@ -87,9 +87,6 @@ public class PermissionsTest {
             webClient,
             MANAGER,
             ImmutableMap.<Action, Boolean>builder()
-                .put(VIEW_CONFIGURATION, true)
-                .put(DOWNLOAD_CONFIGURATION, true)
-                .put(APPLY_NEW_CONFIGURATION, false)
                 .put(RELOAD_EXISTING_CONFIGURATION, true)
                 .build()
         );

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <revision>1.52</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.222.1</jenkins.version>
+    <jenkins.version>2.249.1</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>


### PR DESCRIPTION
### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

This PR allows Jenkins users with `Overall/Manage` permission (see [documentation](https://www.jenkins.io/doc/book/security/access-control/permissions/) to reload the configuration via the GUI or the web API.

It closes to issue #1652.

I ran the test cases before and after the changes and they passed twice, meaning this is probably not tested. I can spend some more time testing but will need guidance on how to do that as I'm a total newbie in Jenkins plugin development.

I tried to test it locally but when I ran the maven phase `hpi:run` as documented in `docs/CONTRIBUTING.md` I got an error `Address already in use` although nothing seems to run on port 8080 on my machine.

> `lsof -i tcp:8080` and `lsof -i udp:8080` show no results

Please help me make sure what I implemented works :pray: