### PR TITLE
Add a note on reloading from declarative pipelines #1227

### DIFF
--- a/docs/features/configurationReload.md
+++ b/docs/features/configurationReload.md
@@ -29,3 +29,4 @@ reload-jcasc-configuration
   import io.jenkins.plugins.casc.ConfigurationAsCode;
   ConfigurationAsCode.get().configure()
   ```
+  Note that running the above code in a declarative pipeline (either directly or via shared libraries) will put this plugin in a bad state where the configuration cannot be reload at all until Jenkins is restarted.

--- a/docs/features/configurationReload.md
+++ b/docs/features/configurationReload.md
@@ -29,4 +29,4 @@ reload-jcasc-configuration
   import io.jenkins.plugins.casc.ConfigurationAsCode;
   ConfigurationAsCode.get().configure()
   ```
-  Note that running the above code in a declarative pipeline (either directly or via shared libraries) will put this plugin in a bad state where the configuration cannot be reload at all until Jenkins is restarted.
+  Note that running the above code in a declarative pipeline (either directly or via shared libraries) will put this plugin in a bad state where the configuration cannot be reload at all until Jenkins is restarted. See #1227 for more info.


### PR DESCRIPTION
If JCasC is reloaded from a declarative pipeline, Jenkins throws an error due to permission issues. Subsequent reloads of JCasC fail regardless of the mechanisms used to do so, and regardless of user permissions.

This issue probably needs to be addressed correctly so that Jenkins isn't put in an invalid state, as it could potentially have other side effects that hasn't been noticed yet.<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
