### PR TITLE
Stop hiding credentials configuration category

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
@@ -34,7 +34,6 @@ import static java.util.Collections.singletonList;
 public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<GlobalConfigurationCategory> implements RootElementConfigurator<GlobalConfigurationCategory> {
 
     private static final Logger LOGGER = Logger.getLogger(GlobalConfigurationCategoryConfigurator.class.getName());
-    private static final String CREDENTIALS_PROVIDER_MANAGER_CONFIGURATION = "com.cloudbees.plugins.credentials.CredentialsProviderManager$Configuration";
 
     private final GlobalConfigurationCategory category;
 
@@ -122,14 +121,7 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
     }
 
     private boolean filterDescriptors(Descriptor d) {
-        if (d.clazz.getName().equals(CREDENTIALS_PROVIDER_MANAGER_CONFIGURATION)) {
-            // CREDENTIALS_PROVIDER_MANAGER_CONFIGURATION is located in the wrong category.
-            // JCasC will also turn the simple name into empty string
-            // It should be a part of the credentials root configurator node.
-            return false;
-        } else {
-            return d.getCategory() == category && d.getGlobalConfigPage() != null;
-        }
+        return d.getCategory() == category && d.getGlobalConfigPage() != null;
     }
 
 }


### PR DESCRIPTION
It was returning empty string because the symbol guessing logic was
stripping everything

A symbol was added in https://github.com/jenkinsci/credentials-plugin/pull/144 back in April 2020

Part of fixing https://github.com/jenkinsci/azure-keyvault-plugin/issues/92 (other part in credentials plugin)