### PR TITLE
Prepare sunset of superseded PNG icons from core

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -52,7 +52,7 @@
         <f:submit name="viewExport" value="${%View Configuration}"/>
       </f:form>
       <div class="alert alert-warning clear-action-forms">
-        <img src="${rootURL}/images/16x16/warning.png"/>
+        <l:icon class="icon-warning icon-sm"/>
         ${%exportWarning}
       </div>
 


### PR DESCRIPTION
Preparation of https://github.com/jenkinsci/jenkins/pull/5778, which gets a rid of PNG icons that are superseded by SVG icons.
The change proposed picks the PNG icon on older Jenkins versions and the SVG one on newer versions.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did