### PR TITLE
Allow configuring CASC Reload Token with environment variable

### DIFF
--- a/docs/features/configurationReload.md
+++ b/docs/features/configurationReload.md
@@ -3,6 +3,22 @@
 You have the following option to trigger a configuration reload:
 
 - via the user interface: `Manage Jenkins -> Configuration -> Reload existing configuration`
+- via http POST to `JENKINS_URL/reload-configuration-as-code/` (note the trailing slash).  
+    It's disabled by default and secured via a token configured either by the environment variable
+    `CASC_RELOAD_TOKEN` or the system property `casc.reload.token`. If both are set, the environment
+    variable takes precedence.  
+    Configuring this token enables this functionality and the requests need to include it as a
+    query parameter named `casc-reload-token`, e.g. `JENKINS_URL/reload-configuration-as-code/?casc-reload-token=someSecretValue`.
+
+```sh
+$ curl -X POST "JENKINS_URL/reload-configuration-as-code/?casc-reload-token=someSecretValue"
+
+# To avoid showing the token on the process list, one can use read the parameter from a secure file:
+$ cat /path/to/secret/file
+casc-reload-token=someSecretValue
+$ curl -X POST -G -d @/path/to/secret/file "JENKINS_URL/reload-configuration-as-code/"
+
+```
 - via http POST to `JENKINS_URL/configuration-as-code/reload`
   Note: this needs to include a valid CRUMB and authentication information e.g. username + token of a user with admin
   permissions. Since Jenkins 2.96 CRUMB is not needed for API tokens.
@@ -16,13 +32,6 @@ reload-jcasc-configuration
     Reload JCasC YAML configuration
 # ...
 ```
-    
-- via http POST to `JENKINS_URL/reload-configuration-as-code`
-  It's disabled by default and secured via a token configured as system property `casc.reload.token`.
-  Setting the system property enables this functionality and the requests need to include the token as
-  query parameter named `casc-reload-token`, i.e. `JENKINS_URL/reload-configuration-as-code/?casc-reload-token=32424324rdsadsa`.
-
-  `curl  -X POST "JENKINS_URL:8080/reload-configuration-as-code/?casc-reload-token=32424324rdsadsa"`
 
 - via Groovy script (not recommended)
   ```groovy

--- a/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
@@ -21,6 +21,7 @@ public class TokenReloadAction implements UnprotectedRootAction {
     public static final String URL_NAME = "reload-configuration-as-code";
     public static final String RELOAD_TOKEN_PROPERTY = "casc.reload.token";
     public static final String RELOAD_TOKEN_QUERY_PARAMETER = "casc-reload-token";
+    public static final String CASC_RELOAD_TOKEN_ENV = "CASC_RELOAD_TOKEN";
 
     @CheckForNull
     @Override
@@ -42,7 +43,7 @@ public class TokenReloadAction implements UnprotectedRootAction {
 
     @RequirePOST
     public void doIndex(StaplerRequest request, StaplerResponse response) throws IOException {
-        String token = getReloadTokenProperty();
+        String token = getReloadToken();
 
         if (token == null || token.isEmpty()) {
             response.sendError(404);
@@ -68,12 +69,17 @@ public class TokenReloadAction implements UnprotectedRootAction {
         return request.getParameter(RELOAD_TOKEN_QUERY_PARAMETER);
     }
 
-    private static String getReloadTokenProperty() {
+    private static String getReloadToken() {
+        final String envToken = System.getenv(CASC_RELOAD_TOKEN_ENV);
+        if (envToken != null && !envToken.isEmpty()) {
+            return envToken;
+        }
+
         return System.getProperty(RELOAD_TOKEN_PROPERTY);
     }
 
     public static boolean tokenReloadEnabled() {
-        String token = getReloadTokenProperty();
+        String token = getReloadToken();
         return token != null && !token.isEmpty();
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.casc;
 
+import io.jenkins.plugins.casc.misc.Env;
+import io.jenkins.plugins.casc.misc.EnvVarsRule;
+import io.jenkins.plugins.casc.misc.Envs;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import java.io.IOException;
 import java.util.Collections;
@@ -13,6 +16,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.RuleChain;
 import org.jvnet.hudson.test.LoggerRule;
 import org.kohsuke.stapler.RequestImpl;
 import org.kohsuke.stapler.ResponseImpl;
@@ -33,8 +37,14 @@ public class TokenReloadActionTest {
     @Rule
     public final LoggerRule loggerRule = new LoggerRule();
 
-    @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    public EnvVarsRule environment = new EnvVarsRule();
+
+    @Rule
+    public RuleChain chain = RuleChain
+        .outerRule(environment)
+        .around(j);
 
     private ServletResponseSpy response;
 
@@ -81,6 +91,28 @@ public class TokenReloadActionTest {
         return !lastTimeLoaded.equals(ConfigurationAsCode.get().getLastTimeLoaded());
     }
 
+    private void assertConfigReloaded() {
+        assertEquals(200, response.getStatus());
+
+        assertTrue(configWasReloaded());
+
+        List<LogRecord> messages = loggerRule.getRecords();
+        assertEquals(1, messages.size());
+        assertEquals("Configuration reload triggered via token", messages.get(0).getMessage());
+        assertEquals(Level.INFO, messages.get(0).getLevel());
+    }
+
+    private void assertConfigNotReloadedInvalidToken() {
+        assertEquals(401, response.getStatus());
+
+        assertFalse(configWasReloaded());
+
+        List<LogRecord> messages = loggerRule.getRecords();
+        assertEquals(1, messages.size());
+        assertEquals("Invalid token received, not reloading configuration", messages.get(0).getMessage());
+        assertEquals(Level.WARNING, messages.get(0).getLevel());
+    }
+
     @Before
     public void setUp() {
         tokenReloadAction = new TokenReloadAction();
@@ -113,14 +145,7 @@ public class TokenReloadActionTest {
         RequestImpl request = newRequest(null);
         tokenReloadAction.doIndex(request, new ResponseImpl(null, response));
 
-        assertEquals(401, response.getStatus());
-
-        assertFalse(configWasReloaded());
-
-        List<LogRecord> messages = loggerRule.getRecords();
-        assertEquals(1, messages.size());
-        assertEquals("Invalid token received, not reloading configuration", messages.get(0).getMessage());
-        assertEquals(Level.WARNING, messages.get(0).getLevel());
+        assertConfigNotReloadedInvalidToken();
     }
 
     @Test
@@ -129,14 +154,29 @@ public class TokenReloadActionTest {
 
         tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
 
-        assertEquals(200, response.getStatus());
+        assertConfigReloaded();
+    }
 
-        assertTrue(configWasReloaded());
+    @Test
+    @Envs({
+        @Env(name = "CASC_RELOAD_TOKEN", value = "someSecretValue")
+    })
+    public void reloadReturnsOkWhenCalledWithValidTokenSetByEnvVar() throws IOException {
+        tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
 
-        List<LogRecord> messages = loggerRule.getRecords();
-        assertEquals(1, messages.size());
-        assertEquals("Configuration reload triggered via token", messages.get(0).getMessage());
-        assertEquals(Level.INFO, messages.get(0).getLevel());
+        assertConfigReloaded();
+    }
+
+    @Test
+    @Envs({
+        @Env(name = "CASC_RELOAD_TOKEN", value = "someSecretValue")
+    })
+    public void reloadShouldNotUseTokenFromPropertyIfEnvVarIsSet() throws IOException {
+        System.setProperty("casc.reload.token", "otherSecretValue");
+
+        tokenReloadAction.doIndex(newRequest("otherSecretValue"), new ResponseImpl(null, response));
+
+        assertConfigNotReloadedInvalidToken();
     }
 
     @Test

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
@@ -180,6 +180,18 @@ public class TokenReloadActionTest {
     }
 
     @Test
+    @Envs({
+        @Env(name = "CASC_RELOAD_TOKEN", value = "")
+    })
+    public void reloadShouldUsePropertyAsTokenIfEnvVarIsEmpty() throws IOException {
+        System.setProperty("casc.reload.token", "someSecretValue");
+
+        tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
+
+        assertConfigReloaded();
+    }
+
+    @Test
     public void displayName() {
         assertEquals("Reload Configuration as Code", tokenReloadAction.getDisplayName());
     }


### PR DESCRIPTION
This PR adds the following:

* The ability to configure the CASC Reload Token using the `CASC_RELOAD_TOKEN` environment variable.
* Said environment variable takes precedence over the `casc.reload.token` system property.
* Two tests were created to verify the two features above.
* The documentation was updated to reflect these changes. Also, a note was added on the required trailing slash on the reload endpoint and some extra tips on how to hide the token from the process list. The section on reloading with this token was also moved up, since it appears to be the easiest way to perform this operation.

Closes #1839 

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->

