### PR TITLE
doc: rewrite JDK installation example using AdoptOpenJDK installer

### DIFF
--- a/demos/jdk/README.md
+++ b/demos/jdk/README.md
@@ -1,6 +1,6 @@
 # Configure JDK
 
-Basic configuration of the [JDK](https://plugins.jenkins.io/jdk-tool)
+Basic configuration of the [JDK](https://plugins.jenkins.io/jdk-tool), using [AdoptOpenJDK installer](https://plugins.jenkins.io/adoptopenjdk/)
 
 ## sample configuration
 
@@ -8,12 +8,11 @@ Basic configuration of the [JDK](https://plugins.jenkins.io/jdk-tool)
 tool:
   jdk:
     installations:
-      - name: jdk8
+      - name: jdk11
         home: "/jdk"
         properties:
           - installSource:
               installers:
-                - jdkInstaller:
-                    id: "jdk-8u181-oth-JPR"
-                    acceptLicense: true
+                - adoptOpenJdkInstaller:
+                    id: "jdk-11.0.14+9"
 ```

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -386,6 +386,13 @@
 
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>adoptopenjdk</artifactId>
+      <version>1.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>sge-cloud-plugin</artifactId>
       <version>1.22</version>
       <scope>test</scope>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JdkConfiguratorTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JdkConfiguratorTest.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.casc;
 import hudson.ExtensionList;
 import hudson.model.JDK;
 import hudson.tools.InstallSourceProperty;
-import hudson.tools.JDKInstaller;
+import io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import io.jenkins.plugins.casc.model.CNode;
@@ -16,7 +16,6 @@ import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:vektory79@gmail.com">Viktor Verbitsky</a>
@@ -33,15 +32,14 @@ public class JdkConfiguratorTest {
         assertEquals(1, descriptor.getInstallations().length);
 
         JDK jdk = descriptor.getInstallations()[0];
-        assertEquals("jdk8", jdk.getName());
+        assertEquals("jdk11", jdk.getName());
         assertEquals("/jdk", jdk.getHome());
 
         InstallSourceProperty installSourceProperty = jdk.getProperties().get(InstallSourceProperty.class);
         assertEquals(1, installSourceProperty.installers.size());
 
-        JDKInstaller installer = installSourceProperty.installers.get(JDKInstaller.class);
-        assertEquals("jdk-8u181-oth-JPR", installer.id);
-        assertTrue(installer.acceptLicense);
+        AdoptOpenJDKInstaller installer = installSourceProperty.installers.get(AdoptOpenJDKInstaller.class);
+        assertEquals("jdk-11.0.14+9", installer.id);
     }
 
     @Test

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/JdkConfiguratorTestExpected.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/JdkConfiguratorTestExpected.yml
@@ -1,9 +1,8 @@
 installations:
 - home: "/jdk"
-  name: "jdk8"
+  name: "jdk11"
   properties:
   - installSource:
       installers:
-      - jdkInstaller:
-          acceptLicense: true
-          id: "jdk-8u181-oth-JPR"
+      - adoptOpenJdkInstaller:
+          id: "jdk-11.0.14+9"


### PR DESCRIPTION
rewrite JDK installation example using AdoptOpenJDK installer, as Oracle installer is deprecated

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
