### PR TITLE
Don't increment value outside of range when merging files

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategy.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategy.java
@@ -36,7 +36,7 @@ public class OverrideMergeStrategy implements MergeStrategy {
                 // merge common entries
                 for (int i = 0; i < map2.getValue().size();) {
                     NodeTuple t2 = map2.getValue().get(i);
-                    boolean found = false; 
+                    boolean found = false;
                     for (NodeTuple tuple : map.getValue()) {
 
                         final Node key = tuple.getKeyNode();
@@ -60,7 +60,7 @@ public class OverrideMergeStrategy implements MergeStrategy {
                                     node.getEndMark()));
                         }
                     }
-                    if( !found ) {
+                    if ( !found ) {
                         ++i;
                     }
                 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategy.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategy.java
@@ -36,6 +36,7 @@ public class OverrideMergeStrategy implements MergeStrategy {
                 // merge common entries
                 for (int i = 0; i < map2.getValue().size();) {
                     NodeTuple t2 = map2.getValue().get(i);
+                    boolean found = false; 
                     for (NodeTuple tuple : map.getValue()) {
 
                         final Node key = tuple.getKeyNode();
@@ -50,14 +51,17 @@ public class OverrideMergeStrategy implements MergeStrategy {
                                     map.getValue().set(i, t2);
                                 }
                                 map2.getValue().remove(i);
-                            } else {
-                                i++;
+                                found = true;
+                                break;
                             }
                         } else {
                             throw new ConfiguratorException(
                                 String.format("Found non-mergeable configuration keys %s %s)", source,
                                     node.getEndMark()));
                         }
+                    }
+                    if( !found ) {
+                        ++i;
                     }
                 }
                 // .. and add others

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategyTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategyTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.casc.yaml;
 
+import io.jenkins.plugins.casc.CasCGlobalConfig;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorException;
@@ -93,5 +94,22 @@ public class OverrideMergeStrategyTest {
             agentProtocals.contains("Ping"));
         assertTrue("unexpected sequence merging (missing JNLP4-connect) with override merge strategy",
             agentProtocals.contains("JNLP4-connect"));
+    }
+
+    @Test
+    public void multipleKeys() throws ConfiguratorException {
+        String multipleKeysA = getClass().getResource("multiple-keys-a.yml").toExternalForm();
+        String multipleKeysB = getClass().getResource("multiple-keys-b.yml").toExternalForm();
+
+        CasCGlobalConfig descriptor = (CasCGlobalConfig) j.jenkins.getDescriptor(CasCGlobalConfig.class);
+        assertNotNull(descriptor);
+
+        // merge without conflicts, A <- B
+        ConfigurationAsCode.get().configure(multipleKeysA, multipleKeysB);
+        assertEquals("b", descriptor.getConfigurationPath());
+
+        // merge without conflicts, B <- A
+        ConfigurationAsCode.get().configure(multipleKeysB, multipleKeysA);
+        assertEquals("a", descriptor.getConfigurationPath());
     }
 }

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-a.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-a.yml
@@ -1,0 +1,5 @@
+jenkins:
+  systemMessage: "hello a"
+unclassified:
+  casCGlobalConfig:
+    configurationPath: "a"

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-b.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-b.yml
@@ -1,0 +1,3 @@
+unclassified:
+  casCGlobalConfig:
+    configurationPath: "b"


### PR DESCRIPTION
fix #1832: java.lang.IndexOutOfBoundsException: OverrideMergeStrategy.merge

Fixed an issue where `i` was increment without being found in the first loop, and was remove with an incorrect index if found in subsequent loops.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
