### PR TITLE
Fix wrong index for override merge strategy 

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategy.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategy.java
@@ -48,7 +48,7 @@ public class OverrideMergeStrategy implements MergeStrategy {
                                 try {
                                     merge(tuple.getValueNode(), t2.getValueNode(), source);
                                 } catch (ConfiguratorConflictException e) {
-                                    map.getValue().set(i, t2);
+                                    map.getValue().set(map.getValue().indexOf(tuple), t2);
                                 }
                                 map2.getValue().remove(i);
                                 found = true;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategyTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/OverrideMergeStrategyTest.java
@@ -102,9 +102,17 @@ public class OverrideMergeStrategyTest {
         // merge without conflicts, A <- B
         ConfigurationAsCode.get().configure(multipleKeysA, multipleKeysB);
         assertEquals("b", descriptor.getConfigurationPath());
+        assertEquals("unexpected systemMessage with override merge strategy",
+            "hello b", Jenkins.get().getSystemMessage());
+        assertEquals("unexpected numExecutors with override merge strategy",
+        1, Jenkins.get().getNumExecutors());
 
         // merge without conflicts, B <- A
         ConfigurationAsCode.get().configure(multipleKeysB, multipleKeysA);
         assertEquals("a", descriptor.getConfigurationPath());
+        assertEquals("unexpected systemMessage with override merge strategy",
+            "hello a", Jenkins.get().getSystemMessage());
+        assertEquals("unexpected numExecutors with override merge strategy",
+        0, Jenkins.get().getNumExecutors());
     }
 }

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-a.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-a.yml
@@ -1,5 +1,6 @@
 jenkins:
   systemMessage: "hello a"
+  numExecutors: 0
 unclassified:
   casCGlobalConfig:
     configurationPath: "a"

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-b.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/multiple-keys-b.yml
@@ -1,3 +1,6 @@
+jenkins:
+  systemMessage: "hello b"
+  numExecutors: 1
 unclassified:
   casCGlobalConfig:
     configurationPath: "b"

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/systemMessage-a.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/systemMessage-a.yml
@@ -1,2 +1,3 @@
 jenkins:
   systemMessage: "hello a"
+  numExecutors: 0

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/systemMessage-b.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/yaml/systemMessage-b.yml
@@ -1,2 +1,3 @@
 jenkins:
   systemMessage: "hello b"
+  numExecutors: 1


### PR DESCRIPTION
Hi,

This PR update some test of OverrideMergeStrategyTest.

It shows there is still multiple issue with merging for this strategy.

To be honest I have no idea how to fix it :(

FYI https://github.com/jenkinsci/configuration-as-code-plugin/pull/1904

Any idea ? @srz-zumix @LinuxSuRen Is it a supported use case ?

Thanks!

Those test are failing

```
Error:  Failures: 
Error:    OverrideMergeStrategyTest.multipleKeys:105 unexpected systemMessage with override merge strategy expected:<[hello b]> but was:<[overwrite]>
Error:    OverrideMergeStrategyTest.simpleStringValue:75 unexpected systemMessage with override merge strategy expected:<hello b> but was:<null>
```