### PR TITLE
Demos - kubernetes - document more options

### DIFF
--- a/demos/kubernetes/README.md
+++ b/demos/kubernetes/README.md
@@ -27,8 +27,8 @@ jenkins:
         retentionTimeout: 5
         connectTimeout: 10
         readTimeout: 20
-        # POD Yaml is not displayed in each build log
-        showRawYaml: false
+        # Enable whether the POD Yaml is displayed in each build log or not, `true` by default.
+        showRawYaml: true
 
         templates:
           - name: "test"

--- a/demos/kubernetes/README.md
+++ b/demos/kubernetes/README.md
@@ -27,8 +27,6 @@ jenkins:
         retentionTimeout: 5
         connectTimeout: 10
         readTimeout: 20
-        # Enable whether the POD Yaml is displayed in each build log or not, `true` by default.
-        showRawYaml: true
 
         templates:
           - name: "test"
@@ -36,6 +34,9 @@ jenkins:
             instanceCap: 1234
             idleMinutes: 0
             label: "label"
+            # Enable whether the POD Yaml is displayed in each build log or not, `true` by default.
+            showRawYaml: true
+            
             volumes:
               - hostPathVolume:
                   mountPath: "mountPath"

--- a/demos/kubernetes/README.md
+++ b/demos/kubernetes/README.md
@@ -27,6 +27,8 @@ jenkins:
         retentionTimeout: 5
         connectTimeout: 10
         readTimeout: 20
+        # POD Yaml is not displayed in each build log
+        showRawYaml: false
 
         templates:
           - name: "test"
@@ -78,6 +80,11 @@ jenkins:
               - emptyDirVolume:
                   memory: false
                   mountPath: "/tmp"
+              # Mount the content of the ConfigMap `configmap-name` with the data `config`.
+              - configMapVolume:
+                  configMapName: configmap-name
+                  mountPath: /home/jenkins/.aws/config
+                  subPath: config
             idleMinutes: "1"
             activeDeadlineSeconds: "120"
             slaveConnectTimeout: "1000"


### PR DESCRIPTION
Document useful features provided by Kubernetes Plugin:
`showRawYaml` : can be used to remove the POD Yaml configuration in the console log.
`configMapVolume` : allow to mount a ConfigMap file under the container. 
