### PR TITLE
Depend on commons-text-api

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -83,9 +83,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
+      <version>1.9-5.v7ea_44fe6061c</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hi,

I have introduced `commons-text-api`, which in turn depends on `commons-lang3-api`. This PR replaces the dependency on the commons-text jar with the plugin, and now both jars are absent from the hpi:

```
$ zipinfo -1 plugin/target/configuration-as-code.hpi
META-INF/
META-INF/MANIFEST.MF
WEB-INF/
WEB-INF/lib/
img/
META-INF/maven/
META-INF/maven/io.jenkins/
META-INF/maven/io.jenkins/configuration-as-code/
WEB-INF/lib/vavr-match-0.10.4.jar
WEB-INF/lib/json-20211205.jar
WEB-INF/lib/configuration-as-code.jar
WEB-INF/lib/jsr305-3.0.2.jar
WEB-INF/lib/vavr-0.10.4.jar
WEB-INF/licenses.xml
img/logo-head.svg
img/logo.png
img/logo.eps
META-INF/maven/io.jenkins/configuration-as-code/pom.xml
META-INF/maven/io.jenkins/configuration-as-code/pom.properties
```
 
<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue. (existing tests still pass)

<!--
Put an `x` into the [ ] to show you have filled the information
-->
