### PR TITLE
Fix erroneous removal of secret prefixes in SecretSource

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -203,6 +203,18 @@ public class SecretSourceResolverTest {
         assertThat(resolve("http://${FOO}:${BAR}"), equalTo("http://www.foo.io:8080"));
     }
 
+    /**
+     * Ensures that prefixes in the secret ID which are not covered by the CasC protocol substitutors (e.g. base64:, file:)
+     * are left untouched and not removed.
+     */
+    @Test
+    public void resolve_preservesPrefixesNotCoveredBySubstitutors() {
+        final String secret = "foobar";
+
+        environment.set("arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret", secret);
+        assertThat(resolve("${arn:aws:secretsmanager:eu-central-1:123456789012:secret:my-secret}"), equalTo(secret));
+    }
+
     @Test
     public void resolve_mixedMultipleEntriesWithDefault() {
         environment.set("FOO", "www.foo.io");


### PR DESCRIPTION
Only remove secret prefixes when they correspond to one of the SecretSource protocol substitutors (e.g. `base64:`, `file:`). If a secret prefix is not handled by the substitutors, leave it alone.

Relates to #1949  

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
