### PR TITLE
Add SystemPropertyLookup resolver to resolve java system properties

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -46,6 +46,7 @@ public class SecretSourceResolver {
         map.put("readFileBase64", FileBase64Lookup.INSTANCE);
         map.put("file", FileStringLookup.INSTANCE);
         map.put("readFile", FileStringLookup.INSTANCE);
+        map.put("sysProp", SystemPropertyLookup.INSTANCE);
         map.put("decodeBase64", DecodeBase64Lookup.INSTANCE);
         map.put("json", JsonLookup.INSTANCE);
         map = Collections.unmodifiableMap(map);
@@ -144,6 +145,21 @@ public class SecretSourceResolver {
                 .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
                 .findFirst()
                 .orElse(null);
+        }
+    }
+
+    static class SystemPropertyLookup implements StringLookup {
+
+        static final SystemPropertyLookup INSTANCE = new SystemPropertyLookup();
+
+        @Override
+        public String lookup(@NonNull final String key) {
+            final String output = System.getProperty(key);
+            if (output == null) {
+                LOGGER.log(Level.WARNING, String.format("Configuration import: System Properties did not contain the specified key '%s'. Will default to empty string.", key));
+                return "";
+            }
+            return output;
         }
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -4,7 +4,6 @@ import io.jenkins.plugins.casc.SecretSourceResolver.Base64Lookup;
 import io.jenkins.plugins.casc.SecretSourceResolver.FileBase64Lookup;
 import io.jenkins.plugins.casc.SecretSourceResolver.FileStringLookup;
 import io.jenkins.plugins.casc.SecretSourceResolver.SystemPropertyLookup;
-
 import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Files;

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.casc;
 import io.jenkins.plugins.casc.SecretSourceResolver.Base64Lookup;
 import io.jenkins.plugins.casc.SecretSourceResolver.FileBase64Lookup;
 import io.jenkins.plugins.casc.SecretSourceResolver.FileStringLookup;
+import io.jenkins.plugins.casc.SecretSourceResolver.SystemPropertyLookup;
+
 import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -46,6 +48,7 @@ public class SecretSourceResolverTest {
     public static final StringLookup DECODE = StringLookupFactory.INSTANCE.base64DecoderStringLookup();
     public static final StringLookup FILE = FileStringLookup.INSTANCE;
     public static final StringLookup BINARYFILE = FileBase64Lookup.INSTANCE;
+    public static final StringLookup SYSPROP = SystemPropertyLookup.INSTANCE;
 
     @Before
     public void initLogging() {
@@ -346,6 +349,24 @@ public class SecretSourceResolverTest {
         assertThat(lookup, equalTo(expected));
         assertThat(actual, equalTo(expected));
         assertThat(actualBytes, equalTo(expectedBytes));
+    }
+
+    @Test
+    public void resolve_SystemProperty() throws Exception {
+        String input = "java.version";
+        String expected = System.getProperty(input);
+        String output = resolve("${sysProp:" + input + "}");
+        assertThat(output, equalTo(SYSPROP.lookup(input)));
+        assertThat(output, equalTo(expected));
+    }
+
+    @Test
+    public void resolve_SystemPropertyNotFound() throws Exception {
+        String input = "java.version.non-existent";
+        String expected = "";
+        String output = resolve("${sysProp:" + input + "}");
+        assertThat(output, equalTo(SYSPROP.lookup(input)));
+        assertThat(output, equalTo(expected));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR adds a new `sysProp` resolver in order to use the values of system properties within the Jenkins configuration. For example:

```yaml
jenkins:
  systemMessage: "Jenkins is running on Java ${sysProp:java.version}\n\n"
```
 
Fixes #2015

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
