### PR TITLE
Remove deprecated java.level from docs

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -26,12 +26,11 @@ Before you start, make sure the following pre-conditions are met:
 </parent>
 ```
 
-- The Jenkins core version and the Java level of your plugin are aligned with the Configuration as Code plugin versions (also in the [pom.xml](/pom.xml)).
+- The Jenkins core version of your plugin are aligned with the Configuration as Code plugin versions (also in the [pom.xml](/pom.xml)).
 
 ```xml
 <properties>
     <jenkins.version>THE_JENKINS_CORE_VERSION_HERE</jenkins.version>
-    <java.level>THE_JAVA_VERSION_HERE</java.level>
 </properties>
 ```
 


### PR DESCRIPTION
Removes the deprecated `java.level` from Plugin docs.

---------------------------------

<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
