### PR TITLE
build: Update bom to oldest included version

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -48,7 +48,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
+        <artifactId>bom-2.319.x</artifactId>
         <version>${plugin-bom.version}</version>
         <scope>import</scope>
         <type>pom</type>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -88,7 +88,7 @@ public class SecretSourceResolver {
      * resolved they will be defaulted to default value defined by ':-', otherwise default to empty
      * String. Secrets are defined as anything enclosed by '${}'
      * @since 1.42
-     * @deprecated use ${link {@link ConfigurationContext#getSecretSourceResolver()#resolve(String)}} instead.
+     * @deprecated use {@link #resolve(String)}} instead.
      */
     @Deprecated
     @Restricted(DoNotUse.class)

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang.StringUtils;
 
 /**
  * {@link SecretSource} implementation relying on <a href="https://docs.docker.com/engine/swarm/secrets">docker secrets</a>.
- * The path to secret directory can be overridden by setting environment variable <tt>SECRETS</tt>.
+ * The path to secret directory can be overridden by setting environment variable <code>SECRETS</code>.
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Extension

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/configuration-as-code-plugin</gitHubRepo>
-    <jenkins.version>2.289.3</jenkins.version>
+    <jenkins.version>2.319.3</jenkins.version>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>
-    <plugin-bom.version>1500.ve4d05cd32975</plugin-bom.version>
+    <plugin-bom.version>1580.v47b_429a_c853a</plugin-bom.version>
   </properties>
 
   <name>Configuration as Code Parent</name>

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -18,7 +18,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
+        <artifactId>bom-2.319.x</artifactId>
         <version>${plugin-bom.version}</version>
         <scope>import</scope>
         <type>pom</type>

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorTest.java
@@ -16,6 +16,7 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.util.Objects;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.Symbol;
@@ -72,8 +73,8 @@ public class JenkinsConfiguratorTest {
     @Test
     @ConfiguredWithCode("ConfigureLabels.yml")
     public void shouldExportLabelAtoms() throws Exception {
-        DescribableList properties = Jenkins.get().getLabelAtom("label1").getProperties();
-        properties.add(new TestProperty(1));
+        Objects.requireNonNull(Jenkins.get().getLabelAtom("label1"))
+            .getProperties().add(new TestProperty(1));
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         ConfigurationAsCode.get().export(out);

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/core/ExpectedLabelsConfiguration.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/core/ExpectedLabelsConfiguration.yml
@@ -1,4 +1,5 @@
 labelAtoms:
+  - name: "built-in"
   - name: "label1"
     properties:
     - myProperty:
@@ -11,3 +12,4 @@ labelAtoms:
     properties:
     - myProperty:
         value: 3
+  - name: "myNode"


### PR DESCRIPTION
(Possible) prerequisite for https://github.com/jenkinsci/configuration-as-code-plugin/pull/2093 and newer changes, while retaining compatibility with the oldest bom profile.

Alternatively, integration tests could use a newer bom, but 2.289.x is a pretty conservative baseline.