### PR TITLE
docs: Allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: "❓ Gitter chat"
     url: https://gitter.im/jenkinsci/configuration-as-code-plugin


### PR DESCRIPTION
Sometimes, issues don't fit into predefined categories, therefore a blank template is more beneficial rather than banning the creation of blank issues through the web UI.

Luckily you can work your way around with gh cli https://github.com/jenkinsci/configuration-as-code-plugin/issues/2106 😈 