### PR TITLE
Replace commons-text with Jenkins plugin

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -668,9 +668,8 @@
         <version>2.6</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>1.9</version>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>commons-text-api</artifactId>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -83,9 +83,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <jenkins.version>2.319.3</jenkins.version>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>
-    <plugin-bom.version>1607.va_c1576527071</plugin-bom.version>
+    <plugin-bom.version>1643.v1cffef51df73</plugin-bom.version>
   </properties>
 
   <name>Configuration as Code Parent</name>


### PR DESCRIPTION
Instead of just updating commons-text, I replaced it with the corresponding Jenkins plugin, which ships 1.10, provided by the BOM.

Downstream of https://github.com/jenkinsci/commons-text-api-plugin/pull/13#issuecomment-1278814319

It's probably worth to cut a release, to silence security scanners and reduce the amount of Jira issues.