### PR TITLE
Use HTTPS SCM URL

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -106,7 +106,7 @@
     </plugins>
   </build>
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/configuration-as-code-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/configuration-as-code-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/configuration-as-code-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/configuration-as-code-plugin</url>
     <tag>${scmTag}</tag>


### PR DESCRIPTION
The old protocol is [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).