### PR TITLE
Fixes #1846 by displaying a user-friendly error message instead of a stack trace on boot error

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -734,7 +734,6 @@ public class ConfigurationAsCode extends ManagementLink {
                 LOGGER.log(Level.SEVERE, "No configurator for the following root elements: " + String.join(", ", unknownKeys));
                 throw new ConfiguratorException("Invalid Configuration. Please check your configuration and try again.");
             }
-
         }
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -729,7 +729,6 @@ public class ConfigurationAsCode extends ManagementLink {
                     unknownKeys.add(key);
                 }
             });
-            
             if (!unknownKeys.isEmpty()) {
                 LOGGER.log(Level.SEVERE, "No configurator for the following root elements: " + String.join(", ", unknownKeys));
                 throw new ConfiguratorException("Invalid Configuration. Please check your configuration and try again.");

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -729,10 +729,12 @@ public class ConfigurationAsCode extends ManagementLink {
                     unknownKeys.add(key);
                 }
             });
-
+            
             if (!unknownKeys.isEmpty()) {
-                throw new ConfiguratorException(format("No configurator for the following root elements %s", String.join(", ", unknownKeys)));
+                LOGGER.log(Level.SEVERE, "No configurator for the following root elements: " + String.join(", ", unknownKeys));
+                throw new ConfiguratorException("Invalid Configuration. Please check your configuration and try again.");
             }
+
         }
     }
 


### PR DESCRIPTION
 Fixes issue(https://github.com/jenkinsci/configuration-as-code-plugin/issues/1846) with configurator exception being thrown for unknown keys. Now logs the unknown keys and throws a more informative exception.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [ X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [X ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
