### PR TITLE
Update Job DSL to 1.82

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -403,14 +403,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>1.81</version>
+      <version>1.82</version>
       <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-all</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- required to satisfy upper bound dependencies -->


### PR DESCRIPTION
Job DSL no longer has a dependency on `groovy-all`.