### PR TITLE
Upgrade parent POM from 4.56 to 4.57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.56</version>
+    <version>4.57</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.configuration-as-code</groupId>


### PR DESCRIPTION
This is needed for the forthcoming PCT multi-module mode to pull in the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658) via https://github.com/jenkinsci/maven-hpi-plugin/pull/453. I tested this successfully with the latest update to the multimodule project branch of PCT, which is now doing `mvn process test-classes` rather than `mvn install`, therefore requiring the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658).