### PR TITLE
Reduce GitHub actions testing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 17]
-        os: [ubuntu-latest, windows-latest]
+        java: [17]
+        os: [ubuntu-latest]
 
     steps:
 


### PR DESCRIPTION
Seems to crash in a lot of dependency PRs, and we only really use this for codecov anymore (could remove and switch to code-coverage-api?)

