### PR TITLE
SnakeYaml loader options to allow configuration of CodePointLimit for YAML input files

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -17,6 +17,8 @@ public class ConfigurationContext implements ConfiguratorRegistry {
 
     public static final String CASC_YAML_MAX_ALIASES_ENV = "CASC_YAML_MAX_ALIASES";
     public static final String CASC_YAML_MAX_ALIASES_PROPERTY = "casc.yaml.max.aliases";
+    public static final String CASC_YAML_CODE_POINT_LIMIT_ENV = "CASC_YAML_CODE_POINT_LIMIT";
+    public static final String CASC_YAML_CODE_POINT_LIMIT_PROPERTY = "casc.yaml.code_point_limit";
     public static final String CASC_MERGE_STRATEGY_ENV = "CASC_MERGE_STRATEGY";
     public static final String CASC_MERGE_STRATEGY_PROPERTY = "casc.merge.strategy";
     private Deprecation deprecation = Deprecation.reject;
@@ -24,6 +26,7 @@ public class ConfigurationContext implements ConfiguratorRegistry {
     private Unknown unknown = Unknown.reject;
     private String mergeStrategy;
     private final transient int yamlMaxAliasesForCollections;
+    private final transient int yamlCodePointLimit;
 
     /**
      * the model-introspection model to be applied by configuration-as-code.
@@ -45,6 +48,8 @@ public class ConfigurationContext implements ConfiguratorRegistry {
         this.registry = registry;
         String prop = getPropertyOrEnv(CASC_YAML_MAX_ALIASES_ENV, CASC_YAML_MAX_ALIASES_PROPERTY);
         yamlMaxAliasesForCollections = NumberUtils.toInt(prop, 50);
+        prop = getPropertyOrEnv(CASC_YAML_CODE_POINT_LIMIT_ENV, CASC_YAML_CODE_POINT_LIMIT_PROPERTY);
+        yamlCodePointLimit = NumberUtils.toInt(prop, 3) * 1024 * 1024;
         secretSourceResolver = new SecretSourceResolver(this);
         mergeStrategy = getPropertyOrEnv(CASC_MERGE_STRATEGY_ENV, CASC_MERGE_STRATEGY_PROPERTY);
     }
@@ -109,6 +114,10 @@ public class ConfigurationContext implements ConfiguratorRegistry {
 
     public int getYamlMaxAliasesForCollections() {
         return yamlMaxAliasesForCollections;
+    }
+
+    public int getYamlCodePointLimit() {
+        return yamlCodePointLimit;
     }
 
     // --- delegate methods for ConfigurationContext

--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
@@ -56,6 +56,9 @@ public final class YamlUtils {
 
     public static Node read(YamlSource source, Reader reader, ConfigurationContext context) throws IOException {
         LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(context.getYamlCodePointLimit());
+        LOGGER.info("configuration-as-code yaml Code Point Limit 1" + context.getYamlCodePointLimit());
+        LOGGER.info("configuration-as-code yaml Code Point Limit 2" + loaderOptions.getCodePointLimit());
         loaderOptions.setMaxAliasesForCollections(context.getYamlMaxAliasesForCollections());
         Composer composer = new Composer(
                 new ParserImpl(new StreamReaderWithSource(source, reader), loaderOptions),
@@ -112,6 +115,9 @@ public final class YamlUtils {
     private static Mapping loadFrom(Node node, ConfigurationContext context) {
         final LoaderOptions loaderOptions = new LoaderOptions();
         loaderOptions.setMaxAliasesForCollections(context.getYamlMaxAliasesForCollections());
+        loaderOptions.setCodePointLimit(context.getYamlCodePointLimit());
+        LOGGER.info("configuration-as-code yaml Code Point Limit 1" + context.getYamlCodePointLimit());
+        LOGGER.info("configuration-as-code yaml Code Point Limit 2" + loaderOptions.getCodePointLimit());
         final ModelConstructor constructor = new ModelConstructor(loaderOptions);
         constructor.setComposer(
                 new Composer(

--- a/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlUtils.java
@@ -57,8 +57,6 @@ public final class YamlUtils {
     public static Node read(YamlSource source, Reader reader, ConfigurationContext context) throws IOException {
         LoaderOptions loaderOptions = new LoaderOptions();
         loaderOptions.setCodePointLimit(context.getYamlCodePointLimit());
-        LOGGER.info("configuration-as-code yaml Code Point Limit 1" + context.getYamlCodePointLimit());
-        LOGGER.info("configuration-as-code yaml Code Point Limit 2" + loaderOptions.getCodePointLimit());
         loaderOptions.setMaxAliasesForCollections(context.getYamlMaxAliasesForCollections());
         Composer composer = new Composer(
                 new ParserImpl(new StreamReaderWithSource(source, reader), loaderOptions),
@@ -116,8 +114,6 @@ public final class YamlUtils {
         final LoaderOptions loaderOptions = new LoaderOptions();
         loaderOptions.setMaxAliasesForCollections(context.getYamlMaxAliasesForCollections());
         loaderOptions.setCodePointLimit(context.getYamlCodePointLimit());
-        LOGGER.info("configuration-as-code yaml Code Point Limit 1" + context.getYamlCodePointLimit());
-        LOGGER.info("configuration-as-code yaml Code Point Limit 2" + loaderOptions.getCodePointLimit());
         final ModelConstructor constructor = new ModelConstructor(loaderOptions);
         constructor.setComposer(
                 new Composer(

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
@@ -1,0 +1,47 @@
+package io.jenkins.plugins.casc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import io.jenkins.plugins.casc.misc.EnvVarsRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.RuleChain;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class YamlCodePointLimitTest {
+
+    private JenkinsRule j;
+
+    private EnvVarsRule env;
+
+    @Rule
+    public RuleChain rc = RuleChain.outerRule(env = new EnvVarsRule())
+            .around(new RestoreSystemProperties())
+            .around(j = new JenkinsRule());
+
+    @Test
+    public void testCodePointLimitSetFifty() throws ConfiguratorException {
+        System.setProperty(ConfigurationContext.CASC_YAML_CODE_POINT_LIMIT_PROPERTY, "50");
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        assertEquals(50 * 1024 * 1024, context.getYamlCodePointLimit());
+    }
+
+    @Test
+    public void invalidCodePointLimitSetToDefault() throws ConfiguratorException {
+        System.setProperty(ConfigurationContext.CASC_YAML_CODE_POINT_LIMIT_PROPERTY, "HELLO");
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        assertEquals(3 * 1024 * 1024, context.getYamlCodePointLimit());
+    }
+    @Test
+
+    public void defaultCodePointLimit() throws ConfiguratorException {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        assertEquals(3 * 1024 * 1024, context.getYamlCodePointLimit());
+    }
+}

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
@@ -1,13 +1,11 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 
 import io.jenkins.plugins.casc.misc.EnvVarsRule;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.RuleChain;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -37,8 +35,8 @@ public class YamlCodePointLimitTest {
         ConfigurationContext context = new ConfigurationContext(registry);
         assertEquals(3 * 1024 * 1024, context.getYamlCodePointLimit());
     }
-    @Test
 
+    @Test
     public void defaultCodePointLimit() throws ConfiguratorException {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.casc;
 import static org.junit.Assert.assertEquals;
 
 import io.jenkins.plugins.casc.misc.EnvVarsRule;
-import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/YamlCodePointLimitTest.java
@@ -6,6 +6,7 @@ import io.jenkins.plugins.casc.misc.EnvVarsRule;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.RuleChain;
 import org.jvnet.hudson.test.JenkinsRule;
 


### PR DESCRIPTION
The goal of this PR is to provide a configurable option for snakeyaml to read yaml files larger than 3MB as outlined in #2131 . 

Fixes #2131 

I added a Jenkins property that you can pass in via the command line, and an environment variable which allows you to globally set the snakeyaml code point limit.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
