### PR TITLE
Run only 80% of Windows integration tests on ci.jenkins.io

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/ActiveDirectoryTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ActiveDirectoryTest.java
@@ -3,12 +3,14 @@ package io.jenkins.plugins.casc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.plugins.active_directory.ActiveDirectoryDomain;
 import hudson.plugins.active_directory.ActiveDirectorySecurityRealm;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -18,6 +20,10 @@ import org.junit.rules.RuleChain;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ActiveDirectoryTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables().set("BIND_PASSWORD", "ADMIN123"))

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ArtifactManagerS3Test.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ArtifactManagerS3Test.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.DescriptorExtensionList;
 import io.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig;
@@ -12,10 +13,15 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.ArtifactManagerFactory;
 import jenkins.model.ArtifactManagerFactoryDescriptor;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class ArtifactManagerS3Test {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ArtifactoryTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ArtifactoryTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
@@ -12,6 +13,7 @@ import java.util.List;
 import jenkins.model.Jenkins;
 import org.jfrog.hudson.ArtifactoryBuilder;
 import org.jfrog.hudson.JFrogPlatformInstance;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -22,6 +24,11 @@ public class ArtifactoryTest {
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables().set("ARTIFACTORY_PASSWORD", "password123"))
             .around(new JenkinsConfiguredWithReadmeRule());
+
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Test
     @ConfiguredWithReadme(value = "artifactory/README.md")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/AzureKeyVaultTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/AzureKeyVaultTest.java
@@ -4,12 +4,19 @@ import static io.jenkins.plugins.casc.misc.Util.convertYamlFileToJson;
 import static io.jenkins.plugins.casc.misc.Util.validateSchema;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class AzureKeyVaultTest {
+
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/BuildAgentsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/BuildAgentsTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.Node.Mode;
 import hudson.model.Slave;
@@ -11,10 +12,15 @@ import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.JNLPLauncher;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class BuildAgentsTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ConfigFileProviderTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ConfigFileProviderTest.java
@@ -4,12 +4,14 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -17,6 +19,10 @@ import org.junit.Test;
  * @author <a href="mailto:VictorMartinezRubio@gmail.com">Victor Martinez</a>
  */
 public class ConfigFileProviderTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsReadmeTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsReadmeTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeTrue;
 import static org.jvnet.hudson.test.JenkinsMatchers.hasPlainText;
 
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl;
@@ -34,11 +35,16 @@ import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public class CredentialsReadmeTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     public static final String PASSPHRASE = "passphrase";
     public static final String PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\n"

--- a/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -26,11 +27,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 public class CredentialsTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/Crowd2Test.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/Crowd2Test.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeTrue;
 import static org.jvnet.hudson.test.JenkinsMatchers.hasPlainText;
 
 import de.theit.jenkins.crowd.CrowdSecurityRealm;
@@ -10,12 +11,17 @@ import hudson.security.SecurityRealm;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.RuleChain;
 
 public class Crowd2Test {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     public static final String PASSWORD_123 = "password123";
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/CustomToolsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CustomToolsTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.jenkins.plugins.customtools.CustomTool;
 import com.cloudbees.jenkins.plugins.customtools.CustomTool.DescriptorImpl;
@@ -9,6 +10,7 @@ import hudson.tools.CommandInstaller;
 import hudson.tools.InstallSourceProperty;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +20,10 @@ import org.jvnet.hudson.test.Issue;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class CustomToolsTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/DockerCloudTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/DockerCloudTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
@@ -12,6 +13,7 @@ import hudson.model.Label;
 import io.jenkins.docker.connector.DockerComputerAttachConnector;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -19,6 +21,10 @@ import org.junit.Test;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class DockerCloudTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/DockerWorkflowSymbolTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/DockerWorkflowSymbolTest.java
@@ -7,16 +7,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 public class DockerWorkflowSymbolTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @ClassRule
     @ConfiguredWithCode("DockerWorkflowSymbol.yml")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/DockerWorkflowTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/DockerWorkflowTest.java
@@ -2,14 +2,20 @@ package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class DockerWorkflowTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/EC2CloudTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/EC2CloudTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.amazonaws.services.ec2.model.InstanceType;
 import hudson.model.labels.LabelAtom;
@@ -20,10 +21,15 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class EC2CloudTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/EssentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/EssentialsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -12,10 +13,16 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import java.util.List;
 import jenkins.metrics.api.MetricsAccessKey;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class EssentialsTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
+
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ExternalWorkspaceManagerTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ExternalWorkspaceManagerTest.java
@@ -2,12 +2,14 @@ package io.jenkins.plugins.casc;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.jenkinsci.plugins.ewm.steps.ExwsAllocateStep;
 import org.jenkinsci.plugins.ewm.steps.ExwsStep;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -15,6 +17,10 @@ import org.junit.Test;
  * @author <a href="mailto:VictorMartinezRubio@gmail.com">Victor Martinez</a>
  */
 public class ExternalWorkspaceManagerTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GitHubTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GitHubTest.java
@@ -4,12 +4,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.GlobalConfiguration;
 import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -17,6 +19,10 @@ import org.junit.Test;
  * @author v1v (Victor Martinez)
  */
 public class GitHubTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GitLabConfigurationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GitLabConfigurationTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
@@ -13,6 +14,7 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -22,6 +24,10 @@ import org.junit.rules.RuleChain;
  * @author <a href="osdomin@yahoo.es">osdomin</a>
  */
 public class GitLabConfigurationTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GitTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GitTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.browser.AssemblaWeb;
@@ -14,6 +15,7 @@ import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMRetriever;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -24,6 +26,10 @@ import org.jvnet.hudson.test.LoggerRule;
  * Tests for Git plugin global configurations.
  */
 public class GitTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
     public LoggerRule logging = new LoggerRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GitToolInstallationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GitToolInstallationTest.java
@@ -6,12 +6,14 @@ import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.plugins.git.GitTool;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -19,6 +21,10 @@ import org.junit.Test;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class GitToolInstallationTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @ClassRule
     @ConfiguredWithReadme("git-client/README.md#0")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GiteaOrganisationFolderTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GiteaOrganisationFolderTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -16,10 +17,15 @@ import org.jenkinsci.plugin.gitea.OriginPullRequestDiscoveryTrait;
 import org.jenkinsci.plugin.gitea.SSHCheckoutTrait;
 import org.jenkinsci.plugin.gitea.TagDiscoveryTrait;
 import org.jenkinsci.plugin.gitea.WebhookRegistrationTrait;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class GiteaOrganisationFolderTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GiteaServerTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GiteaServerTest.java
@@ -2,16 +2,22 @@ package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.GlobalConfiguration;
 import org.jenkinsci.plugin.gitea.servers.GiteaServer;
 import org.jenkinsci.plugin.gitea.servers.GiteaServers;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class GiteaServerTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GithubOAuthTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GithubOAuthTest.java
@@ -3,12 +3,14 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.security.SecurityRealm;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.GithubSecurityRealm;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -19,6 +21,10 @@ import org.junit.rules.RuleChain;
  *  Test that we can configure: <a href="https://plugins.jenkins.io/github-oauth"/>
  */
 public class GithubOAuthTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables().set("GITHUB_SECRET", "j985j8fhfhh377"))

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GithubOrganisationFolderTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GithubOrganisationFolderTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.casc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.TopLevelItem;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -10,12 +11,17 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import jenkins.branch.OrganizationFolder;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
+import org.junit.Before;
 import org.junit.Rule;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class GithubOrganisationFolderTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GitscmTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GitscmTest.java
@@ -3,11 +3,13 @@ package io.jenkins.plugins.casc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import hudson.plugins.git.GitSCM;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -15,6 +17,10 @@ import org.junit.Test;
  * @author v1v (Victor Martinez)
  */
 public class GitscmTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -14,6 +15,7 @@ import org.jenkinsci.plugins.github_branch_source.OriginPullRequestDiscoveryTrai
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -22,6 +24,10 @@ import org.jvnet.hudson.test.Issue;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class GlobalLibrariesTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalMatrixAuthorizationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalMatrixAuthorizationTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
@@ -8,6 +9,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -16,6 +18,10 @@ import org.junit.Test;
  * @since 1.0
  */
 public class GlobalMatrixAuthorizationTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
@@ -6,6 +6,7 @@ import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
@@ -17,10 +18,15 @@ import io.jenkins.plugins.casc.model.CNode;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 public class GlobalNodePropertiesTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @ClassRule
     @ConfiguredWithCode("GlobalNodePropertiesTest.yml")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JdkConfiguratorTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JdkConfiguratorTest.java
@@ -6,6 +6,7 @@ import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import hudson.model.JDK;
@@ -14,6 +15,7 @@ import io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import io.jenkins.plugins.casc.model.CNode;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -21,6 +23,10 @@ import org.junit.Test;
  * @author <a href="mailto:vektory79@gmail.com">Viktor Verbitsky</a>
  */
 public class JdkConfiguratorTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @ClassRule
     @ConfiguredWithReadme("jdk/README.md")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsDemoTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsDemoTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import hudson.model.Node.Mode;
@@ -22,6 +23,7 @@ import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jfrog.hudson.ArtifactoryBuilder;
 import org.jfrog.hudson.JFrogPlatformInstance;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -31,6 +33,10 @@ import org.junit.rules.RuleChain;
  * @author v1v (Victor Martinez)
  */
 public class JenkinsDemoTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables().set("ARTIFACTORY_PASSWORD", "password123"))

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsReadmeDemoTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JenkinsReadmeDemoTest.java
@@ -3,11 +3,13 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.Node.Mode;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -15,6 +17,10 @@ import org.junit.Test;
  * @author v1v (Victor Martinez)
  */
 public class JenkinsReadmeDemoTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JiraTest.java
@@ -3,12 +3,14 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.plugins.jira.JiraGlobalConfiguration;
 import hudson.plugins.jira.JiraSite;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -17,6 +19,10 @@ import org.jvnet.hudson.test.Issue;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class JiraTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/JobDslGlobalSecurityConfigurationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/JobDslGlobalSecurityConfigurationTest.java
@@ -3,9 +3,11 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration;
 import jenkins.model.GlobalConfiguration;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
@@ -16,6 +18,10 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
  * Created by odavid on 23/12/2017.
  */
 public class JobDslGlobalSecurityConfigurationTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RestartableJenkinsRule j = new RestartableJenkinsRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/KubernetesCloudTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/KubernetesCloudTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.casc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.Node.Mode;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
@@ -14,6 +15,7 @@ import org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.model.TemplateEnvVar;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume;
 import org.csanchez.jenkins.plugins.kubernetes.volumes.PodVolume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -21,6 +23,10 @@ import org.junit.Test;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class KubernetesCloudTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/LDAPSecurityRealmTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/LDAPSecurityRealmTest.java
@@ -5,10 +5,12 @@ import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -16,6 +18,10 @@ import org.junit.Test;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class LDAPSecurityRealmTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/LDAPTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/LDAPTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.security.LDAPSecurityRealm;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
@@ -10,6 +11,7 @@ import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
 import jenkins.security.plugins.ldap.FromGroupSearchLDAPGroupMembershipStrategy;
 import jenkins.security.plugins.ldap.LDAPConfiguration;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -19,6 +21,10 @@ import org.junit.rules.RuleChain;
  * @author v1v (Victor Martinez)
  */
 public class LDAPTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables().set("LDAP_PASSWORD", "SECRET"))

--- a/integrations/src/test/java/io/jenkins/plugins/casc/LogRecorderTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/LogRecorderTest.java
@@ -5,6 +5,7 @@ import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.logging.LogRecorder;
 import hudson.logging.LogRecorder.Target;
@@ -13,10 +14,15 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import java.util.List;
 import java.util.logging.Level;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 public class LogRecorderTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @ClassRule
     @ConfiguredWithReadme("log-recorder/README.md")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MSBuildTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MSBuildTest.java
@@ -2,16 +2,23 @@ package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import hudson.plugins.msbuild.MsBuildInstallation;
 import hudson.plugins.msbuild.MsBuildInstallation.DescriptorImpl;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class MSBuildTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
+
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MSTestRunnerTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MSTestRunnerTest.java
@@ -3,16 +3,23 @@ package io.jenkins.plugins.casc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.jenkinsci.plugins.MsTestInstallation;
 import org.jenkinsci.plugins.MsTestInstallation.DescriptorImpl;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class MSTestRunnerTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
+
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MailExtTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MailExtTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
@@ -16,6 +17,7 @@ import io.jenkins.plugins.casc.yaml.YamlSource;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.tools.ant.filters.StringInputStream;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -23,6 +25,10 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
 
 public class MailExtTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
     public LoggerRule logging = new LoggerRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MailerTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MailerTest.java
@@ -1,11 +1,13 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.tasks.Mailer;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -13,6 +15,10 @@ import org.junit.Test;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class MailerTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MavenConfiguratorTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MavenConfiguratorTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import hudson.tasks.Maven;
@@ -20,12 +21,17 @@ import jenkins.mvn.DefaultSettingsProvider;
 import jenkins.mvn.FilePathGlobalSettingsProvider;
 import jenkins.mvn.FilePathSettingsProvider;
 import jenkins.mvn.GlobalMavenConfig;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 @Issue("JENKINS-62446")
 public class MavenConfiguratorTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MercurialTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MercurialTest.java
@@ -1,11 +1,14 @@
 package io.jenkins.plugins.casc;
 
+import static org.junit.Assume.assumeTrue;
+
 import hudson.plugins.mercurial.MercurialInstallation;
 import hudson.tools.CommandInstaller;
 import hudson.tools.InstallSourceProperty;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -13,6 +16,10 @@ import org.junit.Test;
  * @author <a href="mailto:vektory79@gmail.com">Viktor Verbitsky</a>
  */
 public class MercurialTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MesosTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MesosTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.Node.Mode;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
@@ -15,6 +16,7 @@ import java.util.List;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.mesos.MesosCloud;
 import org.jenkinsci.plugins.mesos.MesosSlaveInfo;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -22,6 +24,10 @@ import org.junit.Test;
  * @author v1v (Victor Martinez)
  */
 public class MesosTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/NodeJSTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/NodeJSTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import hudson.tools.InstallSourceProperty;
@@ -8,10 +9,15 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.plugins.nodejs.tools.NodeJSInstallation;
 import jenkins.plugins.nodejs.tools.NodeJSInstaller;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class NodeJSTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ProjectMatrixAuthorizationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ProjectMatrixAuthorizationTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -8,6 +9,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -15,6 +17,10 @@ import org.junit.Test;
  * Created by mads on 2/22/18.
  */
 public class ProjectMatrixAuthorizationTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/PropertiesSecretSourceTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
@@ -14,12 +15,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.RuleChain;
 
 public class PropertiesSecretSourceTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     private static final String USERNAME_SECRET = "ken";
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ProxyTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ProxyTest.java
@@ -3,12 +3,14 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 import static org.jvnet.hudson.test.JenkinsMatchers.hasPlainText;
 
 import hudson.ProxyConfiguration;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -16,6 +18,10 @@ import org.junit.Test;
  * @author v1v (Victor Martinez)
  */
 public class ProxyTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/RoleStrategyTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/RoleStrategyTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.michelin.cio.hudson.plugins.rolestrategy.Role;
@@ -25,6 +26,7 @@ import io.jenkins.plugins.casc.model.CNode;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -34,6 +36,10 @@ import org.jvnet.hudson.test.Issue;
  * @since 1.0
  */
 public class RoleStrategyTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/RoundTripMailerTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/RoundTripMailerTest.java
@@ -1,13 +1,20 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.tasks.Mailer;
 import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class RoundTripMailerTest extends RoundTripAbstractTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
+
     @Override
     protected void assertConfiguredAsExpected(RestartableJenkinsRule j, String configContent) {
         final Jenkins jenkins = Jenkins.get();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SSHCredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SSHCredentialsTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.Credentials;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -29,6 +31,10 @@ import org.jvnet.hudson.test.TestExtension;
  * Integration tests for the SSH Credentials Plugin.
  */
 public class SSHCredentialsTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
     public LoggerRule logging = new LoggerRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SbtTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SbtTest.java
@@ -6,12 +6,14 @@ import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import hudson.tools.InstallSourceProperty;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import io.jenkins.plugins.casc.model.CNode;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.plugins.SbtPluginBuilder;
@@ -22,6 +24,10 @@ import org.jvnet.hudson.plugins.SbtPluginBuilder.SbtInstaller;
  * @author v1v (Victor Martinez)
  */
 public class SbtTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @ClassRule
     @ConfiguredWithReadme("sbt/README.md")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/Security1446Test.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/Security1446Test.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -20,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -27,6 +29,10 @@ import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.Node;
 
 public class Security1446Test {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -15,6 +16,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -24,6 +26,10 @@ import org.jvnet.hudson.test.JenkinsRule;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class SeedJobTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     private JenkinsRule j;
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ShouldRun.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ShouldRun.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins.casc;
+
+import java.io.File;
+
+/* intentionally package protected so that not accessible outside this package */
+class ShouldRun {
+    private static boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
+
+    private static int testCounter = 0;
+    private static int buildNumber = -1;
+
+    /** Return true if this test should be executed
+     * @return true if this test should be executed
+     */
+    public static boolean thisTest() {
+        if (!isWindows()) {
+            return true; // Tests are fast enough on Linux, run them all
+        }
+        if (buildNumber < 0) {
+            String buildNumberStr = System.getenv("BUILD_NUMBER");
+            if (buildNumberStr == null) {
+                buildNumberStr = "1";
+            }
+            buildNumber = Integer.parseInt(buildNumberStr);
+        }
+        testCounter++;
+        // Run 80% of tests
+        // Use buildNumber as an offset so that ci.jenkins.io cycles through all tests
+        return (buildNumber + testCounter) % 5 < 4;
+    }
+}

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SimpleThemeTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SimpleThemeTest.java
@@ -1,11 +1,13 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.codefirst.SimpleThemeDecorator;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -13,6 +15,10 @@ import org.junit.Test;
  * @author v1v (Victor Martinez)
  */
 public class SimpleThemeTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SlackTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SlackTest.java
@@ -5,11 +5,13 @@ import static io.jenkins.plugins.casc.misc.Util.validateSchema;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.plugins.slack.SlackNotifier;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -19,6 +21,10 @@ import org.junit.rules.RuleChain;
  * @author v1v (Victor Martinez)
  */
 public class SlackTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables().set("SLACK_TOKEN", "ADMIN123"))

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SonarQubeTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SonarQubeTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.plugins.sonar.SonarGlobalConfiguration;
 import hudson.plugins.sonar.SonarInstallation;
@@ -13,6 +14,7 @@ import hudson.plugins.sonar.model.TriggersConfig;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.GlobalConfiguration;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,6 +23,10 @@ import org.junit.Test;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class SonarQubeTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/StatisticsGathererTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/StatisticsGathererTest.java
@@ -5,14 +5,20 @@ import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.jenkins.plugins.statistics.gatherer.StatisticsConfiguration;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class StatisticsGathererTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SystemCredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SystemCredentialsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey.DirectEntryPrivateKeySource;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -31,6 +33,10 @@ import org.jvnet.hudson.test.LoggerRule;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class SystemCredentialsTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public LoggerRule log = new LoggerRule()

--- a/integrations/src/test/java/io/jenkins/plugins/casc/TerraformTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/TerraformTest.java
@@ -6,6 +6,7 @@ import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.ExtensionList;
 import hudson.tools.InstallSourceProperty;
@@ -14,6 +15,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import org.jenkinsci.plugins.terraform.TerraformInstallation;
 import org.jenkinsci.plugins.terraform.TerraformInstaller;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -21,6 +23,10 @@ import org.junit.Test;
  * @author v1v (Victor Martinez)
  */
 public class TerraformTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @ClassRule
     @ConfiguredWithReadme("terraform/README.md")

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ToolDefaultPropertiesExportIgnoreListTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ToolDefaultPropertiesExportIgnoreListTest.java
@@ -5,15 +5,21 @@ import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 public class ToolDefaultPropertiesExportIgnoreListTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/TopReadmeTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/TopReadmeTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey.DirectEntryPrivateKeySource;
@@ -16,6 +17,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -25,6 +27,10 @@ import org.junit.rules.RuleChain;
  * @author v1v (Victor Martinez)
  */
 public class TopReadmeTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ViewJobFiltersTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ViewJobFiltersTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import hudson.model.Descriptor;
 import hudson.model.ListView;
@@ -15,10 +16,15 @@ import hudson.views.ViewJobFilter;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.Jenkins;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class ViewJobFiltersTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j = new JenkinsConfiguredWithReadmeRule();

--- a/integrations/src/test/java/io/jenkins/plugins/casc/WorkflowCpsGlobalLibTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/WorkflowCpsGlobalLibTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
@@ -8,6 +9,7 @@ import jenkins.plugins.git.GitSCMSource;
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -15,6 +17,10 @@ import org.junit.Test;
  * @author <a href="mailto:VictorMartinezRubio@gmail.com">Victor Martinez</a>
  */
 public class WorkflowCpsGlobalLibTest {
+    @Before
+    public void shouldThisRun() {
+        assumeTrue(ShouldRun.thisTest());
+    }
 
     @Rule
     public JenkinsConfiguredWithReadmeRule j2 = new JenkinsConfiguredWithReadmeRule();


### PR DESCRIPTION
## Run only 80% of Windows integration tests on ci.jenkins.io

Reduce the risk of test timeout on ci.jenkins.io and reduce the cost of test execution.

Rotates which 80% of tests are executed based on the build number so that every test will be executed 4 times in a series of 5 runs on ci.jenkins.io.

If a test is skipped and that hides a failure, the next run of the ci.jenkins.io job will show the failure.

Ran the tests on my Windows computer and confirmed that tests were skipped as expected.  Ran the tests on my Linux computer and confirmed that none of the guarded tests were skipped.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
