### PR TITLE
Partial revert of "Test with Java 21 (#2384)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
-// Windows controller tests crash with unexpected errors
-buildPlugin(useContainerAgent: true, forkCount: '0.5C', timeout: 360, configurations: [
+buildPlugin(useContainerAgent: true, forkCount: '1C', timeout: 180, configurations: [
     [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    // Integration tests fail in unexpected ways with Java 17 on Windows
+    // https://github.com/jenkinsci/configuration-as-code-plugin/pull/2392
+    // Switch to Java 17 on Windows when unexpected failures are resolved
+    [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
## Partial revert of "Test with Java 21 (#2384)"

Integration tests on Java 17 fail in unexpected ways on Windows.  https://bugs.openjdk.org/browse/JDK-8233525 looks similar to the failures.

Retains execution of Java 21 tests on Linux.

This reverts Windows portion of commit 097dcd0951febe91f3d4e468e9394bfdde3d0f87.

### Testing done

Confirmed that automated tests pass consistently with Java 17 on Linux.  Issue seems to be specific to Windows or more readily see on Windows.  I'm running tests on two Windows machines with Java 11 to confirm that they run reliably on Windows with Java 11.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
