### PR TITLE
Remove Bootstrap usages

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -1,12 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:st="jelly:stapler">
-  <l:layout norefresh="true" type="one-column" title="${%Configuration as Code}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
+  <l:layout type="one-column" title="${%Configuration as Code}" permissions="${app.MANAGE_AND_SYSTEM_READ}">
   <l:main-panel>
-  <st:adjunct includes="io.jenkins.plugins.casc.assets.index"/>
-
-  <div class="container-fluid">
-  <div class="row">
-  <div class="col-md-24">
+    <st:adjunct includes="io.jenkins.plugins.casc.assets.index"/>
     <h1>${%Configuration as Code}</h1>
 
     <j:choose>
@@ -62,11 +58,6 @@
         <dl><a href="schema">${%JSON schema}</a></dl>
       </dt>
     </l:hasPermission>
-
-  </div>
-  </div>
-  </div>
   </l:main-panel>
   </l:layout>
-
 </j:jelly>


### PR DESCRIPTION
I'm looking to remove Bootstrap 3 from Jenkins, as part of that work I'm updating plugins to remove their usages. This PR is minimal and has little to no impact on the interface - just some very minor padding changes.

**Before**
<img width="1197" alt="image" src="https://github.com/jenkinsci/configuration-as-code-plugin/assets/43062514/f2f2e4fe-0c7b-4358-a4dd-c5ef9a0de303">

**After**
<img width="1217" alt="image" src="https://github.com/jenkinsci/configuration-as-code-plugin/assets/43062514/bb1d1a8b-728d-4a96-bd5b-265d01ca1151">

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
