### PR TITLE
Adding test coverage for deprecated `JNLPLauncher.tunnel`

### DIFF
--- a/demos/build_agents/README.md
+++ b/demos/build_agents/README.md
@@ -15,6 +15,7 @@ jenkins:
         launcher:
           inbound:
             webSocket: true
+            tunnel: some.proxy
             workDirSettings:
               disabled: true
               failIfWorkDirIsMissing: false

--- a/integrations/src/test/java/io/jenkins/plugins/casc/BuildAgentsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/BuildAgentsTest.java
@@ -32,6 +32,7 @@ public class BuildAgentsTest {
         assertTrue(jnlpLauncher.getWorkDirSettings().isDisabled());
         assertFalse(jnlpLauncher.getWorkDirSettings().isFailIfWorkDirIsMissing());
         assertTrue(jnlpLauncher.isWebSocket());
+        assertThat(jnlpLauncher.tunnel, is("some.proxy"));
 
         assertThat(j.getInstance().getNode("utility-node-2").getNumExecutors(), is(4));
         assertThat(j.getInstance().getNode("utility-node-2").getMode(), is(Mode.NORMAL));


### PR DESCRIPTION
Forgotten in #2430.