### PR TITLE
Showing how to use `subPath` mounts

### DIFF
--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -196,7 +196,23 @@ data:
   filename: {{ "encoded string" | b64enc }}
 ```
 
-can be used as:
+can be used from a pod containing
+
+```yaml
+containers:
+- name: jenkins
+  volumeMounts:
+  - name: filename-secret
+    mountPath: /run/secrets/filename
+    subPath: filename
+    readOnly: true
+volumes:
+- name: filename-secret
+  secret:
+    secretName: secret-name
+```
+
+as:
 
 ```yaml
 - credentials:


### PR DESCRIPTION
The K8s `Secret` instructions could be more helpful since you need to use `subPath` to avoid clashes with built-in mounts like the service account, and to allow multiple secrets of this type. See https://github.com/kubernetes/kubernetes/issues/65835.