### PR TITLE
Only load a secret which is a file

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
@@ -36,6 +36,8 @@ public class DockerSecretSource extends SecretSource {
         if (file.isFile()) {
             return Optional.of(
                     FileUtils.readFileToString(file, StandardCharsets.UTF_8).trim());
+        } else if (file.exists()) {
+            throw new IOException("Cannot load non-file " + file);
         }
         return Optional.empty();
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/secrets/DockerSecretSource.java
@@ -33,7 +33,7 @@ public class DockerSecretSource extends SecretSource {
             return Optional.empty();
         }
         final File file = new File(secrets, secret);
-        if (file.exists()) {
+        if (file.isFile()) {
             return Optional.of(
                     FileUtils.readFileToString(file, StandardCharsets.UTF_8).trim());
         }


### PR DESCRIPTION
If you try to use a secret in K8s which is mounted as `optional` and the `Secret` does not in fact exist, K8s will make an empty directory and you get an opaque error

```
SEVERE	hudson.util.BootFailure#publish: Failed to initialize Jenkins
java.io.IOException: Is a directory
	at java.base/sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at java.base/sun.nio.ch.FileDispatcherImpl.read(FileDispatcherImpl.java:48)
	at java.base/sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:330)
	at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:296)
	at java.base/sun.nio.ch.IOUtil.read(IOUtil.java:273)
	at java.base/sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:232)
	at java.base/sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:65)
	at java.base/sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:107)
	at java.base/sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:101)
	at java.base/sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:281)
	at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:324)
	at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:189)
	at java.base/java.io.InputStreamReader.read(InputStreamReader.java:177)
	at java.base/java.io.Reader.read(Reader.java:250)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1608)
	at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1587)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:1382)
	at org.apache.commons.io.IOUtils.copy(IOUtils.java:1155)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3151)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3222)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3196)
	at org.apache.commons.io.FileUtils.readFileToString(FileUtils.java:2686)
	at io.jenkins.plugins.casc.impl.secrets.DockerSecretSource.reveal(DockerSecretSource.java:38)
	at io.jenkins.plugins.casc.SecretSourceResolver$ConfigurationContextStringLookup.lambda$lookup$ad236547$1(SecretSourceResolver.java:142)
	at io.vavr.CheckedFunction0.lambda$unchecked$52349c75$1(CheckedFunction0.java:247)
	at io.jenkins.plugins.casc.SecretSourceResolver$ConfigurationContextStringLookup.lambda$lookup$0(SecretSourceResolver.java:142)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1602)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at io.jenkins.plugins.casc.SecretSourceResolver$ConfigurationContextStringLookup.lookup(SecretSourceResolver.java:144)
	at io.jenkins.plugins.casc.FixedInterpolatorStringLookup.lookup(FixedInterpolatorStringLookup.java:280)
	at org.apache.commons.text.StringSubstitutor.resolveVariable(StringSubstitutor.java:1151)
	at …
```

Not sure yet what this looks like with the patch, but I hope more informative.
