### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -13,16 +13,14 @@
   <properties>
     <!-- no need to be deployed during release, this is a test-only module -->
     <maven.deploy.skip>true</maven.deploy.skip>
-    <!-- I give up, too much effort to maintain enforcer here, should probably try clear out all enforcer only deps and see if it works -->
-    <enforcer.skip>true</enforcer.skip>
-    <jenkins.version>2.440.2</jenkins.version>
+    <jenkins.version>2.452.1</jenkins.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.440.x</artifactId>
+        <artifactId>bom-2.452.x</artifactId>
         <version>${plugin-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -107,13 +105,6 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!-- Provided by Jenkins core -->
-        <exclusion>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
@@ -135,41 +126,12 @@
       <artifactId>artifactory</artifactId>
       <version>4.0.6</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- RequireUpperBoundDeps with apache-httpcomponents-client-4-api plugin -->
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <!-- RequireUpperBoundDeps with pipeline-groovy-lib plugin -->
-        <exclusion>
-          <groupId>org.apache.ivy</groupId>
-          <artifactId>ivy</artifactId>
-        </exclusion>
-        <!-- Provided by bouncycastle-api-plugin -->
-        <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcpkix-jdk15on</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Found Banned Dependency: org.sonatype.sisu:sisu-guice:jar:no_aop:3.2.5 -->
-          <groupId>org.jfrog.buildinfo</groupId>
-          <artifactId>build-info-extractor-maven3</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>azure-keyvault</artifactId>
       <version>251.vcfe31c013dc7</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- RequireUpperBoundDeps with docker-plugin -->
-        <exclusion>
-          <groupId>com.azure</groupId>
-          <artifactId>azure-core-http-netty</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -288,13 +250,6 @@
       <artifactId>mesos</artifactId>
       <version>1.0.0</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- RequireUpperBoundDeps with sonar plugin -->
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -362,13 +317,6 @@
       <artifactId>terraform</artifactId>
       <version>1.0.10</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- Exclude Banned Dependency -->
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -385,18 +333,6 @@
       <artifactId>statistics-gatherer</artifactId>
       <version>2.0.3</version>
       <scope>test</scope>
-      <exclusions>
-        <!-- Provided by aws-java-sdk-sns plugin -->
-        <exclusion>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-sns</artifactId>
-        </exclusion>
-        <!-- RequireUpperBoundDeps with apache-httpcomponents-client-4-api plugin -->
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -66,11 +66,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
     </dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -56,7 +56,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.414.x</artifactId>
+        <artifactId>bom-2.426.x</artifactId>
         <version>${plugin-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,10 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/configuration-as-code-plugin</gitHubRepo>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>
-    <plugin-bom.version>2982.vdce2153031a_0</plugin-bom.version>
+    <plugin-bom.version>3041.ve87ce2cdf223</plugin-bom.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -50,30 +50,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-commons</artifactId>
     </dependency>
     <!-- Needed for AgentProtocolsTest -->
     <dependency>

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.414.x</artifactId>
+        <artifactId>bom-2.426.x</artifactId>
         <version>${plugin-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

[Installation statistics](https://stats.jenkins.io/pluginversions/configuration-as-code.html) show that 93% of installations of the most recent release of configuration as code plugin are already running Jenkins 2.426.3 or newer.

[SECURITY-3314](https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314) advises administrators to install Jenkins 2.426.3 or newer to resolve that critical security vulnerability.

[Installation statistics](https://stats.jenkins.io/pluginversions/configuration-as-code.html) also show that 50% of all installations of configuration as code plugin are already running Jenkins 2.426.3 or newer.

[Choosing a baseline](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) recommends Jenkins 2.426.3 or Jenknis 2.440.3 as recommended base version.

Also includes changes to simplify the pom files:

- Remove JSR-305 dependency that is not needed
- Remove junit dependencies that are provided by the parent pom
- Run integration tests with Jenkins 2.452.1

<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
