### PR TITLE
[JENKINS-73131] Adapt Configuration as Code for Jetty 12 (EE 8)

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/casc/MockHttpServletRequest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/MockHttpServletRequest.java
@@ -1,0 +1,376 @@
+package io.jenkins.plugins.casc;
+
+import java.io.BufferedReader;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+
+public class MockHttpServletRequest implements HttpServletRequest {
+
+    private final String pathInfo;
+
+    public MockHttpServletRequest(String pathInfo) {
+        this.pathInfo = Objects.requireNonNull(pathInfo);
+    }
+
+    @Override
+    public String getAuthType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMethod() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPathInfo() {
+        return pathInfo;
+    }
+
+    @Override
+    public String getPathTranslated() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContextPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getQueryString() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteUser() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServletPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String changeSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void login(String username, String password) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void logout() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Part> getParts() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Part getPart(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getContentLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getParameter(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getProtocol() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getScheme() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getServerPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSecure() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getRemotePort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLocalPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/TokenReloadCrumbExclusionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/TokenReloadCrumbExclusionTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.eclipse.jetty.server.Request;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -14,22 +13,13 @@ public class TokenReloadCrumbExclusionTest {
     @Rule
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-    private Request newRequestWithPath(String hello) {
-        return new Request(null, null) {
-            @Override
-            public String getPathInfo() {
-                return hello;
-            }
-        };
-    }
-
     @Test
     public void crumbExclusionIsDisabledByDefault() throws Exception {
         System.clearProperty("casc.reload.token");
 
         TokenReloadCrumbExclusion crumbExclusion = new TokenReloadCrumbExclusion();
 
-        assertFalse(crumbExclusion.process(newRequestWithPath("/reload-configuration-as-code/"), null, null));
+        assertFalse(crumbExclusion.process(new MockHttpServletRequest("/reload-configuration-as-code/"), null, null));
     }
 
     @Test
@@ -38,7 +28,7 @@ public class TokenReloadCrumbExclusionTest {
 
         TokenReloadCrumbExclusion crumbExclusion = new TokenReloadCrumbExclusion();
 
-        assertFalse(crumbExclusion.process(newRequestWithPath("/reload-configuration-as-code/2"), null, null));
+        assertFalse(crumbExclusion.process(new MockHttpServletRequest("/reload-configuration-as-code/2"), null, null));
     }
 
     @Test
@@ -49,7 +39,7 @@ public class TokenReloadCrumbExclusionTest {
 
         AtomicBoolean callProcessed = new AtomicBoolean(false);
         assertTrue(crumbExclusion.process(
-                newRequestWithPath("/reload-configuration-as-code/"),
+                new MockHttpServletRequest("/reload-configuration-as-code/"),
                 null,
                 (request, response) -> callProcessed.set(true)));
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlSourceTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlSourceTest.java
@@ -2,13 +2,13 @@ package io.jenkins.plugins.casc.yaml;
 
 import static org.junit.Assert.assertEquals;
 
+import io.jenkins.plugins.casc.MockHttpServletRequest;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import javax.servlet.http.HttpServletRequest;
-import org.eclipse.jetty.server.Request;
 import org.junit.Test;
 
 public class YamlSourceTest {
@@ -44,12 +44,7 @@ public class YamlSourceTest {
 
     @Test
     public void shouldHaveInformativeToStringForRequestSource() {
-        Request request = new Request(null, null) {
-            @Override
-            public String getPathInfo() {
-                return "/configuration-as-code/check";
-            }
-        };
+        HttpServletRequest request = new MockHttpServletRequest("/configuration-as-code/check");
         YamlSource<HttpServletRequest> yamlSource = YamlSource.of(request);
         assertEquals("YamlSource: /configuration-as-code/check", yamlSource.toString());
     }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/MockHttpServletRequest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/MockHttpServletRequest.java
@@ -1,0 +1,376 @@
+package io.jenkins.plugins.casc;
+
+import java.io.BufferedReader;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+
+public class MockHttpServletRequest implements HttpServletRequest {
+
+    private final Map<String, String> parameters;
+
+    public MockHttpServletRequest(Map<String, String> parameters) {
+        this.parameters = Objects.requireNonNull(parameters);
+    }
+
+    @Override
+    public String getAuthType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMethod() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPathInfo() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPathTranslated() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContextPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getQueryString() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteUser() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestURI() {
+        return "/";
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServletPath() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSession getSession() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String changeSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void login(String username, String password) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void logout() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Part> getParts() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Part getPart(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getContentLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return parameters.get(name);
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getProtocol() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getScheme() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getServerName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getServerPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSecure() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getRemotePort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLocalPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/MockHttpServletResponse.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/MockHttpServletResponse.java
@@ -1,0 +1,198 @@
+package io.jenkins.plugins.casc;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+public class MockHttpServletResponse implements HttpServletResponse {
+
+    private int error = 200;
+
+    @Override
+    public void addCookie(Cookie cookie) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsHeader(String name) {
+        return false;
+    }
+
+    @Override
+    public String encodeURL(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeRedirectURL(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeUrl(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String encodeRedirectUrl(String url) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendError(int sc, String msg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendError(int sc) {
+        error = sc;
+    }
+
+    @Override
+    public void sendRedirect(String location) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDateHeader(String name, long date) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addDateHeader(String name, long date) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setIntHeader(String name, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addIntHeader(String name, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStatus(int sc) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStatus(int sc, String sm) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getStatus() {
+        return error;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getContentType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PrintWriter getWriter() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String charset) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentLength(int len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentLengthLong(long len) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setContentType(String type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setBufferSize(int size) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getBufferSize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void flushBuffer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resetBuffer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isCommitted() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLocale(Locale loc) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Use generic mock objects rather than Jetty 10-specific ones so that we can upgrade the test harness from Jetty 10 to Jetty 12 EE 8 without breaking this plugin's test suite.