### PR TITLE
NPE from `ConfigurationAsCode.handleExceptionOnReloading`

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -68,6 +68,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
@@ -204,7 +205,10 @@ public class ConfigurationAsCode extends ManagementLink {
         }
         request.setAttribute("invalidAttribute", cause.getInvalidAttribute());
         request.setAttribute("validAttributes", cause.getValidAttributes());
-        request.getView(ConfigurationAsCode.class, "error.jelly").forward(request, response);
+        RequestDispatcher view = request.getView(ConfigurationAsCode.class, "error.jelly");
+        if (view != null) {
+            view.forward(request, response);
+        }
     }
 
     @RequirePOST


### PR DESCRIPTION
Amending #2352. I deliberately attempted to load an invalid JCasC bundle. I got a `ConfigurationAsCodeBootFailure` as expected. But then periodically (perhaps in response to K8s liveness probes) I saw

```
WARNING	o.e.j.s.h.ContextHandler$Context#log: Error while serving …/oops
java.lang.NullPointerException: Cannot invoke "javax.servlet.RequestDispatcher.forward(javax.servlet.ServletRequest, javax.servlet.ServletResponse)" because the return value of "org.kohsuke.stapler.StaplerRequest.getView(java.lang.Class, String)" is null
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCode.handleExceptionOnReloading(ConfigurationAsCode.java:207)
	at PluginClassLoader for configuration-as-code//io.jenkins.plugins.casc.ConfigurationAsCodeBootFailure.doDynamic(ConfigurationAsCodeBootFailure.java:17)
```

I am not sure exactly why the facet could not be looked up, but it is better to just stick with the 503 response and not throw an exception.
