### PR TITLE
stay compatible for PCT

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -265,9 +265,9 @@ public class ConfigurationAsCode extends ManagementLink {
 
     @POST
     @Restricted(NoExternalUse.class)
-    public FormValidation doCheckNewSource(@QueryParameter String value) {
+    public FormValidation doCheckNewSource(@QueryParameter String newSource) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-        String normalizedSource = Util.fixEmptyAndTrim(value);
+        String normalizedSource = Util.fixEmptyAndTrim(newSource);
         if (normalizedSource == null) {
             return FormValidation.ok(); // empty, do nothing
         }

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/index.jelly
@@ -26,7 +26,7 @@
       <f:form method="post" action="replace" name="replace">
           <h2>${%Replace configuration source with:}</h2>
           <f:entry title="${%Path or URL}" field="newSource" >
-              <f:textbox checkUrl="checkNewSource" checkDependsOn=""/>
+              <f:textbox checkUrl="checkNewSource" checkDependsOn="newSource"/>
           </f:entry>
           <f:block>
             <f:submit name="replace" value="${%Apply new configuration}"/>

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/RoundTripAbstractTest.java
@@ -159,7 +159,7 @@ public abstract class RoundTripAbstractTest {
         // Call the check url
         JenkinsRule.WebClient client = r.j.createWebClient();
         WebRequest request = new WebRequest(client.createCrumbedUrl("configuration-as-code/checkNewSource"), POST);
-        NameValuePair param = new NameValuePair("value", f.toURI().toURL().toExternalForm());
+        NameValuePair param = new NameValuePair("newSource", f.toURI().toURL().toExternalForm());
         request.setRequestParameters(Collections.singletonList(param));
         WebResponse response = client.loadWebResponse(request);
         assertEquals("Failed to POST to " + request.getUrl().toString(), 200, response.getStatusCode());


### PR DESCRIPTION
PCT leads to a mixture of plugin version and test-harness version. So the test will use the old `newSource` but the plugin expects `value` for the checkUrl parameter.

This change will stay with `newSource` as parameter but still removes the inline javascript.

fixes the problems with updating the jenkins/bom as mentioned in #2551

<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
