### PR TITLE
Forbid `junit-dep` from `system-rules`

### DIFF
--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -38,6 +38,12 @@
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <version>1.19.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit-dep</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.vladsch.flexmark</groupId>


### PR DESCRIPTION
Seems to prevent an error in a proprietary plugin when trying to `validate` using Maven 4.0.0-rc-1:

```
[ERROR] Failed to execute goal on project xxx: Could not collect dependencies for project xxx:hpi:999999-SNAPSHOT
[ERROR] org.eclipse.aether.resolution.VersionRangeResolutionException: No versions available for junit:junit-dep:jar:[4.9,) within specified range
[ERROR] 	Caused by: No versions available for junit:junit-dep:jar:[4.9,) within specified range
[ERROR] : Failed to collect dependencies at io.jenkins.configuration-as-code:test-harness:jar:1897.v79281e066ea_7 -> com.github.stefanbirkner:system-rules:jar:1.19.0 -> junit:junit-dep:jar:[4.9,)
```

Tried without success to reproduce in an OSS POM; the trigger condition seems to relate to use of a proprietary `<repository>` with snapshots enabled, which I guess causes the resolver to attempt to search for a valid `junit-dep` version? Anyway we definitely do not want this transitive dep, and removing it fixes this error. (I still have other problems with some repos, even this one, using Maven 4.)
