### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CredentialsTest.java
@@ -4,9 +4,10 @@ import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -20,24 +21,22 @@ import hudson.util.Secret;
 import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
-public class CredentialsTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class CredentialsTest {
 
     @ConfiguredWithCode("GlobalCredentials.yml")
     @Test
-    public void testGlobalScopedCredentials() throws Exception {
+    void testGlobalScopedCredentials(JenkinsConfiguredWithCodeRule j) throws Exception {
         List<StandardUsernamePasswordCredentials> creds = CredentialsProvider.lookupCredentials(
                 StandardUsernamePasswordCredentials.class, Jenkins.getInstanceOrNull(), null, Collections.emptyList());
         assertThat(creds.size(), is(1));
@@ -60,7 +59,7 @@ public class CredentialsTest {
 
     @ConfiguredWithCode("CredentialsWithDomain.yml")
     @Test
-    public void testDomainScopedCredentials() throws Exception {
+    void testDomainScopedCredentials(JenkinsConfiguredWithCodeRule j) throws Exception {
         List<StandardUsernamePasswordCredentials> creds = CredentialsProvider.lookupCredentials(
                 StandardUsernamePasswordCredentials.class, Jenkins.getInstanceOrNull(), null, Collections.emptyList());
         assertThat(creds.size(), is(1));
@@ -71,7 +70,7 @@ public class CredentialsTest {
 
     @Test
     @ConfiguredWithCode("GlobalCredentials.yml")
-    public void testExportFileCredentials() throws Exception {
+    void testExportFileCredentials(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CredentialsRootConfigurator root = ExtensionList.lookupSingleton(CredentialsRootConfigurator.class);
@@ -101,7 +100,7 @@ public class CredentialsTest {
 
     @ConfiguredWithCode("GlobalCredentials.yml")
     @Test
-    public void testExportSSHCredentials() throws Exception {
+    void testExportSSHCredentials(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CredentialsRootConfigurator root = ExtensionList.lookupSingleton(CredentialsRootConfigurator.class);
@@ -149,11 +148,11 @@ public class CredentialsTest {
 
     @Test
     @Issue("SECURITY-1404")
-    public void checkUsernamePasswordIsSecret() throws Exception {
+    void checkUsernamePasswordIsSecret(JenkinsConfiguredWithCodeRule j) throws Exception {
         Attribute a = getFromDatabound(UsernamePasswordCredentialsImpl.class, "password");
         assertTrue(
-                "Attribute 'password' should be secret",
-                a.isSecret(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "1", "2", "3", "4")));
+                a.isSecret(new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "1", "2", "3", "4")),
+                "Attribute 'password' should be secret");
     }
 
     @NonNull
@@ -165,6 +164,6 @@ public class CredentialsTest {
                 return a;
             }
         }
-        throw new AssertionError("Cannot find databound attribute " + attributeName + " in " + clazz);
+        return fail("Cannot find databound attribute " + attributeName + " in " + clazz);
     }
 }

--- a/integrations/src/test/java/io/jenkins/plugins/casc/CustomToolsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/CustomToolsTest.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.cloudbees.jenkins.plugins.customtools.CustomTool;
 import com.cloudbees.jenkins.plugins.customtools.CustomTool.DescriptorImpl;
@@ -9,24 +9,22 @@ import hudson.tools.CommandInstaller;
 import hudson.tools.InstallSourceProperty;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class CustomToolsTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class CustomToolsTest {
 
     @Test
     @Issue("#97")
-    @Ignore
+    @Disabled
     @ConfiguredWithCode(value = "CustomToolsTest.yml")
-    public void configure_custom_tools() {
+    void configure_custom_tools(JenkinsConfiguredWithCodeRule j) {
         DescriptorImpl descriptor = (DescriptorImpl) j.jenkins.getDescriptorOrDie(CustomTool.class);
         assertEquals(1, descriptor.getInstallations().length);
         final CustomTool customTool = descriptor.getInstallations()[0];

--- a/integrations/src/test/java/io/jenkins/plugins/casc/DockerWorkflowSymbolTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/DockerWorkflowSymbolTest.java
@@ -5,26 +5,24 @@ import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
-public class DockerWorkflowSymbolTest {
-
-    @ClassRule
-    @ConfiguredWithCode("DockerWorkflowSymbol.yml")
-    public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class DockerWorkflowSymbolTest {
 
     @Test
     @Issue("1260")
-    public void configure_global_definition() {
+    @ConfiguredWithCode("DockerWorkflowSymbol.yml")
+    void configure_global_definition(JenkinsConfiguredWithCodeRule j) {
         GlobalConfig config = GlobalConfig.get();
 
         assertNotNull(config);
@@ -35,7 +33,8 @@ public class DockerWorkflowSymbolTest {
 
     @Test
     @Issue("1260")
-    public void export_global_definition() throws Exception {
+    @ConfiguredWithCode("DockerWorkflowSymbol.yml")
+    void export_global_definition(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute = getUnclassifiedRoot(context).get("pipeline-model-docker");

--- a/integrations/src/test/java/io/jenkins/plugins/casc/EssentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/EssentialsTest.java
@@ -3,25 +3,24 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.List;
 import jenkins.metrics.api.MetricsAccessKey;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EssentialsTest {
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class EssentialsTest {
 
     @Test
     @ConfiguredWithCode("EssentialsTest.yml")
-    public void essentialsTest() {
+    void essentialsTest(JenkinsConfiguredWithCodeRule j) {
         final Jenkins jenkins = Jenkins.get();
         assertEquals("Welcome to Jenkins Essentials!", jenkins.getSystemMessage());
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GitTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GitTest.java
@@ -1,11 +1,12 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.browser.AssemblaWeb;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.GlobalConfiguration;
@@ -13,28 +14,23 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMRetriever;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.LogRecorder;
 
 /**
  * Tests for Git plugin global configurations.
  */
-public class GitTest {
+@WithJenkinsConfiguredWithCode
+class GitTest {
 
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
-    public LoggerRule logging = new LoggerRule();
+    private final LogRecorder logging = new LogRecorder()
+            .record(Logger.getLogger(Attribute.class.getName()), Level.INFO)
+            .capture(2048);
 
-    @Rule
-    public RuleChain chain = RuleChain.outerRule(logging.record(Logger.getLogger(Attribute.class.getName()), Level.INFO)
-                    .capture(2048))
-            .around(j);
-
-    @After
-    public void dumpLogs() {
+    @AfterEach
+    void dumpLogs() {
         for (String message : logging.getMessages()) {
             System.out.println(message);
         }
@@ -43,7 +39,7 @@ public class GitTest {
     @Test
     @Issue("JENKINS-57604")
     @ConfiguredWithCode("GitTest.yml")
-    public void checkAssemblaWebIsLoaded() {
+    void checkAssemblaWebIsLoaded(JenkinsConfiguredWithCodeRule j) {
         final Jenkins jenkins = Jenkins.get();
         final GlobalLibraries libs =
                 jenkins.getExtensionList(GlobalConfiguration.class).get(GlobalLibraries.class);

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GiteaOrganisationFolderTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GiteaOrganisationFolderTest.java
@@ -1,10 +1,11 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.List;
 import jenkins.branch.OrganizationFolder;
 import jenkins.scm.api.trait.SCMTrait;
@@ -16,17 +17,14 @@ import org.jenkinsci.plugin.gitea.OriginPullRequestDiscoveryTrait;
 import org.jenkinsci.plugin.gitea.SSHCheckoutTrait;
 import org.jenkinsci.plugin.gitea.TagDiscoveryTrait;
 import org.jenkinsci.plugin.gitea.WebhookRegistrationTrait;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GiteaOrganisationFolderTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule r = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class GiteaOrganisationFolderTest {
 
     @Test
     @ConfiguredWithCode("SeedJobTest_withGiteaOrganisation.yml")
-    public void configure_gitea_organisation_folder_seed_job() {
+    void configure_gitea_organisation_folder_seed_job(JenkinsConfiguredWithCodeRule r) {
         OrganizationFolder folder = (OrganizationFolder) r.jenkins.getItem("Gitea Organization Folder");
         assertNotNull(folder);
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GithubOrganisationFolderTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GithubOrganisationFolderTest.java
@@ -1,32 +1,32 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import hudson.model.TopLevelItem;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import jenkins.branch.OrganizationFolder;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
-import org.junit.Rule;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class GithubOrganisationFolderTest {
+@WithJenkinsConfiguredWithCode
+class GithubOrganisationFolderTest {
 
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
-
-    // @Test
-    // Fails as Items do override submit() with manual data-binding implementation
+    @Test
+    @Disabled("Fails as Items do override submit() with manual data-binding implementation")
     @ConfiguredWithCode("GithubOrganisationFolderTest.yml")
-    public void configure_github_organisation_folder_seed_job() {
+    void configure_github_organisation_folder_seed_job(JenkinsConfiguredWithCodeRule j) {
         final TopLevelItem job = Jenkins.get().getItem("ndeloof");
         assertNotNull(job);
-        assertTrue(job instanceof OrganizationFolder);
+        assertInstanceOf(OrganizationFolder.class, job);
         OrganizationFolder folder = (OrganizationFolder) job;
         assertEquals(1, folder.getNavigators().size());
         final GitHubSCMNavigator github = folder.getNavigators().get(GitHubSCMNavigator.class);

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalLibrariesTest.java
@@ -2,10 +2,11 @@ package io.jenkins.plugins.casc;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait;
 import org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait;
 import org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait.TrustPermission;
@@ -14,22 +15,19 @@ import org.jenkinsci.plugins.github_branch_source.OriginPullRequestDiscoveryTrai
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class GlobalLibrariesTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class GlobalLibrariesTest {
 
     @Issue("JENKINS-57557")
     @Test
     @ConfiguredWithCode("GlobalLibrariesGitHubTest.yml")
-    public void configure_global_library_using_github() {
+    void configure_global_library_using_github(JenkinsConfiguredWithCodeRule j) {
         assertEquals(1, GlobalLibraries.get().getLibraries().size());
         final LibraryConfiguration library =
                 GlobalLibraries.get().getLibraries().get(0);

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
@@ -5,7 +5,7 @@ import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
@@ -13,21 +13,19 @@ import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.DescribableList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class GlobalNodePropertiesTest {
-
-    @ClassRule
-    @ConfiguredWithCode("GlobalNodePropertiesTest.yml")
-    public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class GlobalNodePropertiesTest {
 
     @Test
-    public void configure() {
+    @ConfiguredWithCode("GlobalNodePropertiesTest.yml")
+    void configure(JenkinsConfiguredWithCodeRule j) {
         final Jenkins jenkins = Jenkins.get();
 
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties = jenkins.getGlobalNodeProperties();
@@ -43,7 +41,8 @@ public class GlobalNodePropertiesTest {
     }
 
     @Test
-    public void export() throws Exception {
+    @ConfiguredWithCode("GlobalNodePropertiesTest.yml")
+    void export(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute = getJenkinsRoot(context).get("globalNodeProperties");

--- a/integrations/src/test/java/io/jenkins/plugins/casc/LDAPSecurityRealmTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/LDAPSecurityRealmTest.java
@@ -8,21 +8,19 @@ import static org.hamcrest.core.Is.is;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class LDAPSecurityRealmTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class LDAPSecurityRealmTest {
 
     @Test
     @ConfiguredWithCode("LDAPSecurityRealmTestNoSecret.yml")
-    public void export_ldap_no_secret() throws Exception {
+    void export_ldap_no_secret(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute =

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MailExtTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MailExtTest.java
@@ -6,39 +6,34 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.plugins.emailext.ExtendedEmailPublisher;
 import hudson.plugins.emailext.ExtendedEmailPublisherDescriptor;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.yaml.YamlSource;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.tools.ant.filters.StringInputStream;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.LogRecorder;
 
-public class MailExtTest {
+@WithJenkinsConfiguredWithCode
+class MailExtTest {
 
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
-    public LoggerRule logging = new LoggerRule();
-
-    @Rule
-    public RuleChain chain = RuleChain.outerRule(
-                    logging.record(Logger.getLogger(Attribute.class.getName()), Level.FINER)
-                            .capture(2048))
-            .around(j);
+    private final LogRecorder logging = new LogRecorder()
+            .record(Logger.getLogger(Attribute.class.getName()), Level.FINER)
+            .capture(2048);
 
     private static final String SMTP_PASSWORD = "myPassword";
 
     @Test
     @ConfiguredWithCode("MailExtTest.yml")
     @Issue("SECURITY-1404")
-    public void shouldNotExportOrLogCredentials() throws Exception {
+    void shouldNotExportOrLogCredentials(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertEquals(
                 SMTP_PASSWORD,
                 ExtendedEmailPublisher.descriptor().getSmtpPassword().getPlainText());
@@ -56,7 +51,7 @@ public class MailExtTest {
 
     @Test
     @Issue("SECURITY-1446")
-    public void shouldProperlyRoundTripTokenMacro() throws Exception {
+    void shouldProperlyRoundTripTokenMacro(JenkinsConfiguredWithCodeRule j) throws Exception {
         final String defaultBody = "${PROJECT_NAME} - Build # ${BUILD_NUMBER} - ${BUILD_STATUS}:\n"
                 + "Check console output at $BUILD_URL to view the results.";
         // This string contains extra escaping

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ProjectMatrixAuthorizationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ProjectMatrixAuthorizationTest.java
@@ -1,31 +1,29 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.ArrayList;
 import java.util.List;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by mads on 2/22/18.
  */
-public class ProjectMatrixAuthorizationTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class ProjectMatrixAuthorizationTest {
 
     @Test
     @ConfiguredWithCode("ProjectMatrixStrategy.yml")
-    public void checkCorrectlyConfiguredPermissions() {
+    void checkCorrectlyConfiguredPermissions(JenkinsConfiguredWithCodeRule j) {
         assertEquals(
-                "The configured instance must use the Global Matrix Authentication Strategy",
                 ProjectMatrixAuthorizationStrategy.class,
-                Jenkins.get().getAuthorizationStrategy().getClass());
+                Jenkins.get().getAuthorizationStrategy().getClass(),
+                "The configured instance must use the Global Matrix Authentication Strategy");
         ProjectMatrixAuthorizationStrategy gms =
                 (ProjectMatrixAuthorizationStrategy) Jenkins.get().getAuthorizationStrategy();
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/RoleStrategyTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/RoleStrategyTest.java
@@ -21,27 +21,25 @@ import hudson.model.User;
 import hudson.security.AuthorizationStrategy;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import java.util.Map;
 import java.util.Set;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Oleg Nenashev
  * @since 1.0
  */
-public class RoleStrategyTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class RoleStrategyTest {
 
     @Test
     @Issue("Issue #48")
     @ConfiguredWithCode("RoleStrategy1.yml")
-    public void shouldReadRolesCorrectly() throws Exception {
+    void shouldReadRolesCorrectly(JenkinsConfiguredWithCodeRule j) throws Exception {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         User admin = User.getById("admin", false);
         User user1 = User.getById("user1", false);
@@ -95,7 +93,7 @@ public class RoleStrategyTest {
 
     @Test
     @ConfiguredWithCode("RoleStrategy1.yml")
-    public void shouldExportRolesCorrect() throws Exception {
+    void shouldExportRolesCorrect(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute = getJenkinsRoot(context).get("authorizationStrategy");
@@ -109,7 +107,7 @@ public class RoleStrategyTest {
     @Test
     @Issue("Issue #214")
     @ConfiguredWithCode("RoleStrategy2.yml")
-    public void shouldHandleNullItemsAndAgentsCorrectly() {
+    void shouldHandleNullItemsAndAgentsCorrectly(JenkinsConfiguredWithCodeRule j) {
         AuthorizationStrategy s = j.jenkins.getAuthorizationStrategy();
         assertThat(
                 "Authorization Strategy has been read incorrectly",

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SSHCredentialsTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SSHCredentialsTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.Credentials;
@@ -13,30 +13,26 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.TestExtension;
 
 /**
  * Integration tests for the SSH Credentials Plugin.
  */
-public class SSHCredentialsTest {
+@WithJenkinsConfiguredWithCode
+class SSHCredentialsTest {
 
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
-    public LoggerRule logging = new LoggerRule();
-
-    @Rule
-    public RuleChain chain = RuleChain.outerRule(logging.record("io.jenkins.plugins.casc.Attribute", Level.INFO)
-                    .capture(2048))
-            .around(j);
+    private final LogRecorder logging = new LogRecorder()
+            .record("io.jenkins.plugins.casc.Attribute", Level.INFO)
+            .capture(2048);
 
     private static final String CREDENTIALS_PASSWORD = "password-of-userid";
     private static final String PRIVATE_KEY = "sp0ds9d+skkfjf";
@@ -44,7 +40,7 @@ public class SSHCredentialsTest {
     @Test
     @ConfiguredWithCode("SSHCredentialsTest.yml")
     @Issue("SECURITY-1279")
-    public void shouldNotExportOrLogCredentials() throws Exception {
+    void shouldNotExportOrLogCredentials(JenkinsConfiguredWithCodeRule j) throws Exception {
         StandardUsernamePasswordCredentials creds = getCredentials(StandardUsernamePasswordCredentials.class);
         assertEquals(CREDENTIALS_PASSWORD, creds.getPassword().getPlainText());
         assertNotInLog(logging, CREDENTIALS_PASSWORD);
@@ -69,7 +65,7 @@ public class SSHCredentialsTest {
     @Test
     @ConfiguredWithCode("SSHCredentialsTest_Multiline_Key.yml")
     @Issue("https://github.com/jenkinsci/configuration-as-code-plugin/issues/1189")
-    public void shouldSupportMultilineCertificates() {
+    void shouldSupportMultilineCertificates(JenkinsConfiguredWithCodeRule j) {
         BasicSSHUserPrivateKey certKey = getCredentials(BasicSSHUserPrivateKey.class);
         assertThat(
                 "Private key roundtrip failed",
@@ -80,7 +76,7 @@ public class SSHCredentialsTest {
     @Test
     @ConfiguredWithCode("SSHCredentialsTest_Singleline_Key.yml")
     @Issue("https://github.com/jenkinsci/configuration-as-code-plugin/issues/1189")
-    public void shouldSupportSinglelineBase64Certificates() {
+    void shouldSupportSinglelineBase64Certificates(JenkinsConfiguredWithCodeRule j) {
         BasicSSHUserPrivateKey certKey = getCredentials(BasicSSHUserPrivateKey.class);
         assertThat(
                 "Private key roundtrip failed",
@@ -91,7 +87,7 @@ public class SSHCredentialsTest {
     private <T extends Credentials> T getCredentials(Class<T> clazz) {
         List<T> creds = CredentialsProvider.lookupCredentials(
                 clazz, Jenkins.getInstanceOrNull(), null, Collections.emptyList());
-        assertEquals("There should be only one credential", 1, creds.size());
+        assertEquals(1, creds.size(), "There should be only one credential");
         return creds.get(0);
     }
 

--- a/integrations/src/test/java/io/jenkins/plugins/casc/Security1446Test.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/Security1446Test.java
@@ -4,7 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -13,6 +13,7 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -20,16 +21,13 @@ import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.Node;
 
-public class Security1446Test {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class Security1446Test {
 
     private static final String PATH_PATTERN = "path = \\$\\{PATH\\}";
     private static final String JAVA_HOME_PATTERN = "java-home = \\$\\{JAVA_HOME\\}";
@@ -37,17 +35,17 @@ public class Security1446Test {
     @ConfiguredWithCode("Security1446Test.yml")
     @Test
     @Issue("SECURITY-1446")
-    public void testImportWithEnvVar() {
+    void testImportWithEnvVar(JenkinsConfiguredWithCodeRule j) {
         List<StandardUsernamePasswordCredentials> userPasswCred = CredentialsProvider.lookupCredentials(
                 StandardUsernamePasswordCredentials.class, Jenkins.getInstanceOrNull(), null, Collections.emptyList());
         assertThat(userPasswCred.size(), is(1));
         for (StandardUsernamePasswordCredentials cred : userPasswCred) {
             assertTrue(
-                    "The JAVA_HOME environment variable should not be resolved",
-                    cred.getUsername().matches(JAVA_HOME_PATTERN));
+                    cred.getUsername().matches(JAVA_HOME_PATTERN),
+                    "The JAVA_HOME environment variable should not be resolved");
             assertTrue(
-                    "The PATH environment variable should not be resolved",
-                    cred.getDescription().matches(PATH_PATTERN));
+                    cred.getDescription().matches(PATH_PATTERN),
+                    "The PATH environment variable should not be resolved");
         }
 
         List<StringCredentials> stringCred = CredentialsProvider.lookupCredentials(
@@ -55,14 +53,14 @@ public class Security1446Test {
         assertThat(stringCred.size(), is(1));
         for (StringCredentials cred : stringCred) {
             assertTrue(
-                    "The PATH environment variable should not be resolved",
-                    cred.getDescription().matches(PATH_PATTERN));
+                    cred.getDescription().matches(PATH_PATTERN),
+                    "The PATH environment variable should not be resolved");
         }
     }
 
     @Test
     @Issue("SECURITY-1446")
-    public void testExportWithEnvVar() throws Exception {
+    void testExportWithEnvVar(JenkinsConfiguredWithCodeRule j) throws Exception {
         final String message = "Hello, world! PATH=${PATH} JAVA_HOME=^${JAVA_HOME}";
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);

--- a/integrations/src/test/java/io/jenkins/plugins/casc/ToolDefaultPropertiesExportIgnoreListTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/ToolDefaultPropertiesExportIgnoreListTest.java
@@ -8,20 +8,18 @@ import static org.hamcrest.core.Is.is;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
-public class ToolDefaultPropertiesExportIgnoreListTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class ToolDefaultPropertiesExportIgnoreListTest {
 
     @Test
     @Issue("JENKINS-57122")
     @ConfiguredWithCode("ToolDefaultPropertiesExportIgnoreList.yml")
-    public void export_tool_configuration() throws Exception {
+    void export_tool_configuration(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute = getToolRoot(context);

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
@@ -3,36 +3,37 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class ErrorPageTest {
+@WithJenkins
+class ErrorPageTest {
 
-    @ClassRule
-    public static JenkinsRule r = new JenkinsRule();
+    private JenkinsRule r;
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    public File folder;
 
     private Path cascFile;
 
-    @Before
-    public void setup() throws IOException {
-        cascFile = folder.newFile("jenkins.yaml").toPath();
+    @BeforeEach
+    void setup(JenkinsRule r) throws IOException {
+        this.r = r;
+        cascFile = File.createTempFile("jenkins.yaml", null, folder).toPath();
     }
 
     @Test
-    public void reloadSimple() throws Exception {
+    void reloadSimple() throws Exception {
         Files.write(cascFile, "jenkins:\n  systemMessage2: Hello World\n".getBytes());
 
         String pageContent = reloadConfiguration();
@@ -56,7 +57,7 @@ public class ErrorPageTest {
     }
 
     @Test
-    public void noConfigurator() throws Exception {
+    void noConfigurator() throws Exception {
         Files.write(cascFile, "invalid:\n  systemMessage2: Hello World\n".getBytes());
 
         String pageContent = reloadConfiguration();
@@ -65,7 +66,7 @@ public class ErrorPageTest {
     }
 
     @Test
-    public void noImplementationFoundForSymbol() throws Exception {
+    void noImplementationFoundForSymbol() throws Exception {
         String content = "jenkins:\n" + "  securityRealm:\n" + "    unknown:\n" + "      username: \"world\"\n";
 
         Files.write(cascFile, content.getBytes());

--- a/plugin/src/test/java/io/jenkins/plugins/casc/IgnoreAliasEntryTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/IgnoreAliasEntryTest.java
@@ -3,22 +3,22 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IgnoreAliasEntryTest {
+class IgnoreAliasEntryTest {
 
     @Test
-    public void aliasKeyIsNull() {
+    void aliasKeyIsNull() {
         assertThat(ConfigurationAsCode.isNotAliasEntry(null), is(false));
     }
 
     @Test
-    public void aliasKeyStartsWithX() {
+    void aliasKeyStartsWithX() {
         assertThat(ConfigurationAsCode.isNotAliasEntry("x-hello"), is(false));
     }
 
     @Test
-    public void UnknownRootElementShouldReturnTrue() {
+    void UnknownRootElementShouldReturnTrue() {
         assertThat(ConfigurationAsCode.isNotAliasEntry("bob"), is(true));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
@@ -2,36 +2,35 @@ package io.jenkins.plugins.casc;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class UnknownRootElementTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class UnknownRootElementTest {
 
     @Test
-    public void oneUnknown() {
+    void oneUnknown(JenkinsRule j) {
         assertThrows(
-                "No configurator for the following root elements alice",
                 ConfiguratorException.class,
                 () -> ConfigurationAsCode.get()
-                        .configure(getClass().getResource("unknown1.yml").toExternalForm()));
+                        .configure(getClass().getResource("unknown1.yml").toExternalForm()),
+                "No configurator for the following root elements alice");
     }
 
     @Test
-    public void twoUnknown() {
+    void twoUnknown(JenkinsRule j) {
         assertThrows(
-                "No configurator for the following root elements bob, alice",
                 ConfiguratorException.class,
                 () -> ConfigurationAsCode.get()
-                        .configure(getClass().getResource("unknown2.yml").toExternalForm()));
+                        .configure(getClass().getResource("unknown2.yml").toExternalForm()),
+                "No configurator for the following root elements bob, alice");
     }
 
     @Test
-    public void ignoreKnownAlias() throws Exception {
+    void ignoreKnownAlias(JenkinsRule j) throws Exception {
         ConfigurationAsCode.get().configure(getClass().getResource("known.yml").toExternalForm());
         assertThat(j.jenkins.getSystemMessage(), is("Configured by Configuration as Code plugin"));
     }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/jmh/BenchmarkRunner.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/jmh/BenchmarkRunner.java
@@ -2,16 +2,16 @@ package io.jenkins.plugins.casc.jmh;
 
 import java.util.concurrent.TimeUnit;
 import jenkins.benchmark.jmh.BenchmarkFinder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-public final class BenchmarkRunner {
+class BenchmarkRunner {
     @Test
-    public void runJmhBenchmarks() throws Exception {
+    void runJmhBenchmarks() throws Exception {
         ChainedOptionsBuilder options = new OptionsBuilder()
                 .mode(Mode.AverageTime)
                 .warmupIterations(2)

--- a/plugin/src/test/java/io/jenkins/plugins/casc/model/MappingTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/model/MappingTest.java
@@ -1,15 +1,15 @@
 package io.jenkins.plugins.casc.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MappingTest {
+class MappingTest {
 
     @Test
-    public void empty() {
+    void empty() {
         Mapping mapping = new Mapping();
         String aKey = "aKey";
         mapping.put(aKey, (CNode) null);
@@ -19,7 +19,7 @@ public class MappingTest {
     }
 
     @Test
-    public void notEmpty() throws Exception {
+    void notEmpty() throws Exception {
         Mapping mapping = new Mapping();
         String aKey = "aKey";
         String aValue = "aValue";

--- a/plugin/src/test/java/io/jenkins/plugins/casc/permissions/PermissionsTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/permissions/PermissionsTest.java
@@ -11,28 +11,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import jenkins.model.Jenkins;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class PermissionsTest {
+@WithJenkins
+class PermissionsTest {
 
     private static final String RELATIVE_PATH_MANAGE_PAGE = "manage";
     private static final String RELATIVE_PATH_CASC_PAGE = "configuration-as-code";
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void checkPermissionsForReader() throws Exception {
+    void checkPermissionsForReader(JenkinsRule j) throws Exception {
         final String READER = "reader";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(
@@ -46,7 +44,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void checkPermissionsForSystemReader() throws Exception {
+    void checkPermissionsForSystemReader(JenkinsRule j) throws Exception {
         final String SYSTEM_READER = "systemReader";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
@@ -71,7 +69,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void checkPermissionsForManager() throws Exception {
+    void checkPermissionsForManager(JenkinsRule j) throws Exception {
         final String MANAGER = "manager";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
@@ -93,7 +91,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void checkPermissionsForAdmin() throws Exception {
+    void checkPermissionsForAdmin(JenkinsRule j) throws Exception {
         final String ADMIN = "admin";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/ErrorOnConflictMergeStrategyTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/ErrorOnConflictMergeStrategyTest.java
@@ -1,22 +1,20 @@
 package io.jenkins.plugins.casc.yaml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfiguratorException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class ErrorOnConflictMergeStrategyTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class ErrorOnConflictMergeStrategyTest {
 
     @Test
-    public void merge() throws ConfiguratorException {
+    void merge(JenkinsRule j) throws ConfiguratorException {
         String normalSource = getClass().getResource("normal.yml").toExternalForm();
         String overwriteSource = getClass().getResource("overwrite.yml").toExternalForm();
         String conflictsSource = getClass().getResource("conflicts.yml").toExternalForm();
@@ -25,23 +23,25 @@ public class ErrorOnConflictMergeStrategyTest {
         ConfigurationAsCode.get().configure(normalSource, overwriteSource);
 
         // merge with conflicts
-        assertThrows("Merging two conflict config files", ConfiguratorException.class, () -> ConfigurationAsCode.get()
-                .configure(normalSource, conflictsSource));
+        assertThrows(
+                ConfiguratorException.class,
+                () -> ConfigurationAsCode.get().configure(normalSource, conflictsSource),
+                "Merging two conflict config files");
     }
 
     @Test
-    public void incompatible() throws ConfiguratorException {
+    void incompatible(JenkinsRule j) throws ConfiguratorException {
         String normalSource = getClass().getResource("normal.yml").toExternalForm();
         String incompatibleSource = getClass().getResource("incompatible.yml").toExternalForm();
 
         assertThrows(
-                "Incompatible config files merging process",
                 ConfiguratorException.class,
-                () -> ConfigurationAsCode.get().configure(normalSource, incompatibleSource));
+                () -> ConfigurationAsCode.get().configure(normalSource, incompatibleSource),
+                "Incompatible config files merging process");
     }
 
     @Test
-    public void hasCorrectDefaultName() {
+    void hasCorrectDefaultName(JenkinsRule j) {
         MergeStrategy strategy = MergeStrategyFactory.getMergeStrategyOrDefault(null);
         assertNotNull(strategy);
         assertEquals(MergeStrategy.DEFAULT_STRATEGY, strategy.getName());

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/ExportTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/ExportTest.java
@@ -12,10 +12,10 @@ import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
 import io.jenkins.plugins.casc.model.CNode;
 import java.io.IOException;
 import java.io.StringWriter;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.Node;
@@ -23,13 +23,11 @@ import org.yaml.snakeyaml.nodes.Node;
 /**
  * Contains tests for particular export cases.
  */
-public class ExportTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class ExportTest {
 
     @Test
-    public void shouldNotExportValuesWithSecretGetters() throws Exception {
+    void shouldNotExportValuesWithSecretGetters(JenkinsRule j) throws Exception {
         DataBoundConfigurator<DataBoundSecret> c = new DataBoundConfigurator<>(DataBoundSecret.class);
         String res = export(c, new DataBoundSecret("test"));
         assertThat(res, not(containsString("test")));
@@ -37,7 +35,7 @@ public class ExportTest {
 
     @Test
     @Issue("SECURITY-1458")
-    public void shouldNotExportValuesWithSecretFields() throws Exception {
+    void shouldNotExportValuesWithSecretFields(JenkinsRule j) throws Exception {
         DataBoundConfigurator<DataBoundSecretField> c = new DataBoundConfigurator<>(DataBoundSecretField.class);
         String res = export(c, new DataBoundSecretField("test"));
         assertThat(res, not(containsString("test")));
@@ -45,7 +43,7 @@ public class ExportTest {
 
     @Test
     @Issue("SECURITY-1458")
-    public void shouldNotExportValuesWithSecretConstructors() throws Exception {
+    void shouldNotExportValuesWithSecretConstructors(JenkinsRule j) throws Exception {
         DataBoundConfigurator<DataBoundSecretConstructor> c =
                 new DataBoundConfigurator<>(DataBoundSecretConstructor.class);
         String res = export(c, new DataBoundSecretConstructor(Secret.fromString("test")));

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/MergeStrategyActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/MergeStrategyActionTest.java
@@ -1,8 +1,8 @@
 package io.jenkins.plugins.casc.yaml;
 
 import static org.htmlunit.HttpMethod.GET;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.net.URL;
@@ -10,17 +10,15 @@ import java.text.MessageFormat;
 import net.sf.json.JSONObject;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class MergeStrategyActionTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class MergeStrategyActionTest {
 
     @Test
-    public void test() throws IOException {
+    void test(JenkinsRule j) throws IOException {
         URL apiURL =
                 new URL(MessageFormat.format("{0}cascMergeStrategy", j.getURL().toString()));
         WebRequest request = new WebRequest(apiURL, GET);
@@ -29,8 +27,8 @@ public class MergeStrategyActionTest {
         String strategies = response.getContentAsString();
 
         JSONObject strategiesJSON = JSONObject.fromObject(strategies);
-        assertEquals("The request should be ok", "ok", strategiesJSON.getString("status"));
-        assertNotNull("Should have data field", strategiesJSON.getJSONArray("data"));
+        assertEquals("ok", strategiesJSON.getString("status"), "The request should be ok");
+        assertNotNull(strategiesJSON.getJSONArray("data"), "Should have data field");
         for (Object item : strategiesJSON.getJSONArray("data")) {
             String name = JSONObject.fromObject(item).getString("name");
             assertEquals(

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/MergeStrategyTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/MergeStrategyTest.java
@@ -1,25 +1,23 @@
 package io.jenkins.plugins.casc.yaml;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import hudson.ExtensionList;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class MergeStrategyTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class MergeStrategyTest {
 
     @Test
-    public void haveTheDefaultStrategy() {
+    void haveTheDefaultStrategy(JenkinsRule j) {
         ExtensionList<MergeStrategy> strategyExtensionList = Jenkins.get().getExtensionList(MergeStrategy.class);
 
-        assertTrue("should have at least one strategy", strategyExtensionList.size() > 0);
+        assertFalse(strategyExtensionList.isEmpty(), "should have at least one strategy");
         assertNotNull(
-                "default merge strategy should not be null", MergeStrategyFactory.getMergeStrategyOrDefault(null));
+                MergeStrategyFactory.getMergeStrategyOrDefault(null), "default merge strategy should not be null");
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlExportTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlExportTest.java
@@ -2,28 +2,26 @@ package io.jenkins.plugins.casc.yaml;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.AttributeTest;
 import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
 import java.util.Set;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Contains tests for particular export cases.
  */
-public class YamlExportTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class YamlExportTest {
 
     @Test
     @Issue("SECURITY-1458")
-    public void shouldDiscoverSecretsBasedOnTheAttributeType() {
+    void shouldDiscoverSecretsBasedOnTheAttributeType(JenkinsRule j) {
         DataBoundConfigurator c =
                 new DataBoundConfigurator<>(AttributeTest.SecretRenamedFieldFithSecretConstructor.class);
         Set<Attribute> attributes = c.describe();

--- a/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlSourceTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/yaml/YamlSourceTest.java
@@ -1,6 +1,6 @@
 package io.jenkins.plugins.casc.yaml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.jenkins.plugins.casc.MockHttpServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,12 +9,12 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class YamlSourceTest {
+class YamlSourceTest {
 
     @Test
-    public void shouldHaveInformativeToStringForUrlSource() {
+    void shouldHaveInformativeToStringForUrlSource() {
         // given
         String testUrl = "http://example.com/foo/bar";
         // and
@@ -24,7 +24,7 @@ public class YamlSourceTest {
     }
 
     @Test
-    public void shouldUseToStringOfSourceInToStringForInputStream() {
+    void shouldUseToStringOfSourceInToStringForInputStream() {
         // given
         InputStream testInputStream = new ByteArrayInputStream("IS content".getBytes(StandardCharsets.UTF_8));
         String testInputStreamToString = testInputStream.toString();
@@ -35,7 +35,7 @@ public class YamlSourceTest {
     }
 
     @Test
-    public void shouldHaveInformativeToStringForPathSource() {
+    void shouldHaveInformativeToStringForPathSource() {
         Path path = new File("./test").toPath();
         String testPathToString = path.toString();
         YamlSource<Path> yamlSource = YamlSource.of(path);
@@ -43,7 +43,7 @@ public class YamlSourceTest {
     }
 
     @Test
-    public void shouldHaveInformativeToStringForRequestSource() {
+    void shouldHaveInformativeToStringForRequestSource() {
         HttpServletRequest request = new MockHttpServletRequest("/configuration-as-code/check");
         YamlSource<HttpServletRequest> yamlSource = YamlSource.of(request);
         assertEquals("YamlSource: /configuration-as-code/check", yamlSource.toString());

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/Util.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/Util.java
@@ -37,6 +37,7 @@ import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
+import org.jvnet.hudson.test.LogRecorder;
 import org.jvnet.hudson.test.LoggerRule;
 import org.yaml.snakeyaml.nodes.Node;
 
@@ -208,12 +209,34 @@ public class Util {
     }
 
     /**
+     * Checks whether {@link LogRecorder} has not recorded the message.
+     * @param logging Logger rule
+     * @param unexpectedText Text to check
+     */
+    public static void assertNotInLog(LogRecorder logging, String unexpectedText) {
+        assertFalse(
+                "The log should not contain '" + unexpectedText + "'",
+                logging.getMessages().stream().anyMatch(m -> m.contains(unexpectedText)));
+    }
+
+    /**
      * Checks whether {@link LoggerRule} has recorded the message.
      * @param logging Logger rule
      * @param expectedText Text to check
      * @since 1.25
      */
     public static void assertLogContains(LoggerRule logging, String expectedText) {
+        assertTrue(
+                "The log should contain '" + expectedText + "'",
+                logging.getMessages().stream().anyMatch(m -> m.contains(expectedText)));
+    }
+
+    /**
+     * Checks whether {@link LogRecorder} has recorded the message.
+     * @param logging Logger rule
+     * @param expectedText Text to check
+     */
+    public static void assertLogContains(LogRecorder logging, String expectedText) {
         assertTrue(
                 "The log should contain '" + expectedText + "'",
                 logging.getMessages().stream().anyMatch(m -> m.contains(expectedText)));

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/BackwardCompatibilityTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/BackwardCompatibilityTest.java
@@ -1,29 +1,27 @@
 package io.jenkins.plugins.casc;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import hudson.model.Node;
 import hudson.util.VersionNumber;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.List;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class BackwardCompatibilityTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class BackwardCompatibilityTest {
 
     @Test
     @ConfiguredWithCode("BackwardCompatibilityTest.yml")
-    public void should_accept_legacy_symbols_on_descriptors() {
+    void should_accept_legacy_symbols_on_descriptors(JenkinsConfiguredWithCodeRule j) {
 
         final List<Node> nodes = j.jenkins.getNodes();
         System.out.println(nodes);

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import hudson.Functions;
 import java.io.IOException;
@@ -10,8 +10,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import jenkins.benchmark.jmh.BenchmarkFinder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
@@ -20,20 +20,20 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 /**
  * Runs sample benchmarks from JUnit tests.
  */
-public class CascJmhBenchmarkStateTest {
+class CascJmhBenchmarkStateTest {
     private static final String reportPath = "target/jmh-reports/jmh-benchmark-report.json";
 
-    @Before
-    public void createDirectoryForBenchmarkReport() throws IOException {
+    @BeforeEach
+    void createDirectoryForBenchmarkReport() throws IOException {
         Path directory = Paths.get("target/jmh-reports/");
         Files.createDirectories(directory);
     }
 
     @Test
-    public void testJmhBenchmarks() throws Exception {
+    void testJmhBenchmarks() throws Exception {
         assumeFalse(
-                "TODO Cannot run program C:\\openjdk-11\\bin\\java.exe: CreateProcess error=206, The filename or extension is too long",
-                Functions.isWindows() && System.getenv("CI") != null);
+                Functions.isWindows() && System.getenv("CI") != null,
+                "TODO Cannot run program C:\\openjdk-11\\bin\\java.exe: CreateProcess error=206, The filename or extension is too long");
         // number of iterations is kept to a minimum just to verify that the benchmarks work without spending extra
         // time during builds.
         ChainedOptionsBuilder optionsBuilder = new OptionsBuilder()

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/SampleBenchmark.java
@@ -1,6 +1,6 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.casc.misc.jmh.CascJmhBenchmarkState;

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationSanitisationTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationSanitisationTest.java
@@ -2,19 +2,17 @@ package io.jenkins.plugins.casc;
 
 import static io.jenkins.plugins.casc.SchemaGeneration.removeHtmlTags;
 import static io.jenkins.plugins.casc.SchemaGeneration.retrieveDocStringFromAttribute;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
 
-public class SchemaGenerationSanitisationTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class SchemaGenerationSanitisationTest {
 
     @Test
-    public void testRetrieveDocStringFromAttribute() {
+    void testRetrieveDocStringFromAttribute(JenkinsConfiguredWithCodeRule j) {
         String expectedDocString =
                 "If checked, this will allow users who are not authenticated to access Jenkins\n  in a read-only mode.";
         String actualDocString = retrieveDocStringFromAttribute(
@@ -23,7 +21,7 @@ public class SchemaGenerationSanitisationTest {
     }
 
     @Test
-    public void testRemoveHtmlTagRegex() {
+    void testRemoveHtmlTagRegex(JenkinsConfiguredWithCodeRule j) {
         String htmlTagString =
                 "<div> If checked, this will allow users who are not authenticated to access Jenkins in a read-only mode.</div>";
         String expectedString =

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationTest.java
@@ -7,50 +7,48 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
 
-public class SchemaGenerationTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class SchemaGenerationTest {
 
     @Test
-    public void validSchemaShouldSucceed() throws Exception {
+    void validSchemaShouldSucceed(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertThat(validateSchema(convertYamlFileToJson(this, "validSchemaConfig.yml")), empty());
     }
 
     @Test
-    public void invalidSchemaShouldNotSucceed() throws Exception {
+    void invalidSchemaShouldNotSucceed(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertThat(
                 validateSchema(convertYamlFileToJson(this, "invalidSchemaConfig.yml")),
                 contains("#/jenkins/numExecutors: expected type: Integer, found: String"));
     }
 
     @Test
-    public void rejectsInvalidBaseConfigurator() throws Exception {
+    void rejectsInvalidBaseConfigurator(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertThat(
                 validateSchema(convertYamlFileToJson(this, "invalidBaseConfig.yml")),
                 contains("#: extraneous key [invalidBaseConfigurator] is not permitted"));
     }
 
     @Test
-    public void validJenkinsBaseConfigurator() throws Exception {
+    void validJenkinsBaseConfigurator(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertThat(validateSchema(convertYamlFileToJson(this, "validJenkinsBaseConfig.yml")), empty());
     }
 
     @Test
-    public void symbolResolutionForJenkinsBaseConfigurator() throws Exception {
+    void symbolResolutionForJenkinsBaseConfigurator(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertThat(validateSchema(convertYamlFileToJson(this, "validJenkinsBaseConfigWithSymbol.yml")), empty());
     }
 
     @Test
-    public void validSelfConfigurator() throws Exception {
+    void validSelfConfigurator(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertThat(validateSchema(convertYamlFileToJson(this, "validSelfConfig.yml")), empty());
     }
 
     @Test
-    public void attributesNotFlattenedToTopLevel() throws Exception {
+    void attributesNotFlattenedToTopLevel(JenkinsConfiguredWithCodeRule j) throws Exception {
         assertThat(
                 validateSchema(convertYamlFileToJson(this, "attributesNotFlattenedToTop.yml")),
                 contains("#/tool: extraneous key [acceptLicense] is not permitted"));

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/Security1290Test.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/Security1290Test.java
@@ -1,26 +1,24 @@
 package io.jenkins.plugins.casc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import jenkins.model.Jenkins;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
-public class Security1290Test {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class Security1290Test {
 
     @Test
-    public void configurationAsCodePagesPermissions() throws Exception {
+    void configurationAsCodePagesPermissions(JenkinsConfiguredWithCodeRule j) throws Exception {
         final String ADMIN = "admin";
         final String USER = "user";
 
@@ -40,12 +38,16 @@ public class Security1290Test {
         JenkinsRule.WebClient userWc = j.createWebClient().withThrowExceptionOnFailingStatusCode(false);
         userWc.login(USER);
 
-        assertRightPermissionConfigurations("configuration-as-code/schema", adminWc, userWc);
-        assertRightPermissionConfigurations("configuration-as-code/reference", adminWc, userWc);
+        assertRightPermissionConfigurations(j, "configuration-as-code/schema", adminWc, userWc);
+        assertRightPermissionConfigurations(j, "configuration-as-code/reference", adminWc, userWc);
     }
 
     private void assertRightPermissionConfigurations(
-            String relativeUrl, JenkinsRule.WebClient adminWc, JenkinsRule.WebClient userWc) throws IOException {
+            JenkinsConfiguredWithCodeRule j,
+            String relativeUrl,
+            JenkinsRule.WebClient adminWc,
+            JenkinsRule.WebClient userWc)
+            throws IOException {
         WebRequest request = new WebRequest(new URL(j.getURL() + relativeUrl), HttpMethod.GET);
 
         assertEquals(

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/YamlReaderTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/YamlReaderTest.java
@@ -3,9 +3,11 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.htmlunit.HttpMethod.POST;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.yaml.YamlSource;
 import io.jenkins.plugins.casc.yaml.YamlUtils;
 import java.io.IOException;
@@ -16,21 +18,18 @@ import java.text.MessageFormat;
 import jenkins.model.Jenkins;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.WebRequest;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class YamlReaderTest {
+@WithJenkinsConfiguredWithCode
+class YamlReaderTest {
 
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
-
-    @Test(expected = IOException.class)
-    public void unknownReader() throws IOException {
-        YamlUtils.reader(new YamlSource<>(new StringBuilder()));
+    @Test
+    void unknownReader(JenkinsConfiguredWithCodeRule j) {
+        assertThrows(IOException.class, () -> YamlUtils.reader(new YamlSource<>(new StringBuilder())));
     }
 
     @Test
-    public void folder() throws Exception {
+    void folder(JenkinsConfiguredWithCodeRule j) throws Exception {
         String p =
                 Paths.get(getClass().getResource("./folder").toURI()).toFile().getAbsolutePath();
         ConfigurationAsCode.get().configure(p);
@@ -40,7 +39,7 @@ public class YamlReaderTest {
     }
 
     @Test
-    public void httpDoApply() throws Exception {
+    void httpDoApply(JenkinsConfiguredWithCodeRule j) throws Exception {
         j.jenkins.setCrumbIssuer(null);
 
         URL apiURL = new URL(MessageFormat.format(
@@ -58,7 +57,7 @@ public class YamlReaderTest {
     }
 
     @Test
-    public void httpDoCheck() throws Exception {
+    void httpDoCheck(JenkinsConfiguredWithCodeRule j) throws Exception {
         j.jenkins.setCrumbIssuer(null);
 
         URL apiURL = new URL(MessageFormat.format(
@@ -72,15 +71,15 @@ public class YamlReaderTest {
         assertThat(response, is(200));
     }
 
-    @Test(expected = FailingHttpStatusCodeException.class)
-    public void httpDoCheckFailure() throws Exception {
+    @Test
+    void httpDoCheckFailure(JenkinsConfiguredWithCodeRule j) throws Exception {
         j.jenkins.setCrumbIssuer(null);
-
         URL apiURL = new URL(MessageFormat.format(
                 "{0}configuration-as-code/check", j.getURL().toString()));
         WebRequest request = new WebRequest(apiURL, POST);
         request.setCharset(StandardCharsets.UTF_8);
         request.setRequestBody("jenkins:\n" + "  systemMessage: {}");
-        j.createWebClient().getPage(request);
+        assertThrows(
+                FailingHttpStatusCodeException.class, () -> j.createWebClient().getPage(request));
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorCloudSupportTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorCloudSupportTest.java
@@ -5,8 +5,8 @@ import static io.jenkins.plugins.casc.misc.Util.toYamlString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
@@ -20,25 +20,23 @@ import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import java.io.IOException;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.PretendSlave;
 
-public class JenkinsConfiguratorCloudSupportTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class JenkinsConfiguratorCloudSupportTest {
 
     @Test
     @ConfiguredWithCode("JenkinsConfiguratorCloudSupportTest.yml")
-    public void should_have_nodes_configured() {
-        assertEquals("Base nodes not found", 2, j.jenkins.getNodes().size());
+    void should_have_nodes_configured(JenkinsConfiguredWithCodeRule j) {
+        assertEquals(2, j.jenkins.getNodes().size(), "Base nodes not found");
     }
 
     @Test
-    public void should_remove_normal_nodes_configured_after_reload() throws Exception {
+    void should_remove_normal_nodes_configured_after_reload(JenkinsConfiguredWithCodeRule j) throws Exception {
         final Node slave = new StaticPretendSlave();
         j.jenkins.addNode(slave);
 
@@ -46,11 +44,12 @@ public class JenkinsConfiguratorCloudSupportTest {
                 .configure(this.getClass()
                         .getResource("JenkinsConfiguratorCloudSupportTest.yml")
                         .toString());
-        assertEquals("Base nodes not found", 2, j.jenkins.getNodes().size());
+        assertEquals(2, j.jenkins.getNodes().size(), "Base nodes not found");
     }
 
     @Test
-    public void should_keep_cloud_no_instantiable_nodes_configured_after_reload() throws Exception {
+    void should_keep_cloud_no_instantiable_nodes_configured_after_reload(JenkinsConfiguredWithCodeRule j)
+            throws Exception {
         final Node slave = new Cloud1PretendSlave();
         j.jenkins.addNode(slave);
 
@@ -58,14 +57,14 @@ public class JenkinsConfiguratorCloudSupportTest {
                 .configure(this.getClass()
                         .getResource("JenkinsConfiguratorCloudSupportTest.yml")
                         .toString());
-        assertEquals("Cloud nodes not found", 3, j.jenkins.getNodes().size());
-        assertNotNull("Slave 1", j.jenkins.getNode("agent1"));
-        assertNotNull("Slave 1", j.jenkins.getNode("agent2"));
-        assertNotNull("Slave cloud", j.jenkins.getNode("testCloud"));
+        assertEquals(3, j.jenkins.getNodes().size(), "Cloud nodes not found");
+        assertNotNull(j.jenkins.getNode("agent1"), "Slave 1");
+        assertNotNull(j.jenkins.getNode("agent2"), "Slave 1");
+        assertNotNull(j.jenkins.getNode("testCloud"), "Slave cloud");
     }
 
     @Test
-    public void should_keep_cloud_ephemeral_nodes_configured_after_reload() throws Exception {
+    void should_keep_cloud_ephemeral_nodes_configured_after_reload(JenkinsConfiguredWithCodeRule j) throws Exception {
         final Node slave = new Cloud2PretendSlave();
         j.jenkins.addNode(slave);
 
@@ -73,14 +72,15 @@ public class JenkinsConfiguratorCloudSupportTest {
                 .configure(this.getClass()
                         .getResource("JenkinsConfiguratorCloudSupportTest.yml")
                         .toString());
-        assertEquals("Cloud nodes not found", 3, j.jenkins.getNodes().size());
-        assertNotNull("Slave 1", j.jenkins.getNode("agent1"));
-        assertNotNull("Slave 1", j.jenkins.getNode("agent2"));
-        assertNotNull("Slave cloud", j.jenkins.getNode("testCloud"));
+        assertEquals(3, j.jenkins.getNodes().size(), "Cloud nodes not found");
+        assertNotNull(j.jenkins.getNode("agent1"), "Slave 1");
+        assertNotNull(j.jenkins.getNode("agent2"), "Slave 1");
+        assertNotNull(j.jenkins.getNode("testCloud"), "Slave cloud");
     }
 
     @Test
-    public void should_keep_cloud_abstractCloudSlave_nodes_configured_after_reload() throws Exception {
+    void should_keep_cloud_abstractCloudSlave_nodes_configured_after_reload(JenkinsConfiguredWithCodeRule j)
+            throws Exception {
         final Node slave = new Cloud3PretendSlave();
         j.jenkins.addNode(slave);
 
@@ -88,15 +88,15 @@ public class JenkinsConfiguratorCloudSupportTest {
                 .configure(this.getClass()
                         .getResource("JenkinsConfiguratorCloudSupportTest.yml")
                         .toString());
-        assertEquals("Cloud nodes not found", 3, j.jenkins.getNodes().size());
-        assertNotNull("Slave 1", j.jenkins.getNode("agent1"));
-        assertNotNull("Slave 1", j.jenkins.getNode("agent2"));
-        assertNotNull("Slave cloud", j.jenkins.getNode("testCloud"));
+        assertEquals(3, j.jenkins.getNodes().size(), "Cloud nodes not found");
+        assertNotNull(j.jenkins.getNode("agent1"), "Slave 1");
+        assertNotNull(j.jenkins.getNode("agent2"), "Slave 1");
+        assertNotNull(j.jenkins.getNode("testCloud"), "Slave cloud");
     }
 
     @Test
     @ConfiguredWithCode("JenkinsConfiguratorCloudSupportTest.yml")
-    public void should_export_only_static_nodes() throws Exception {
+    void should_export_only_static_nodes(JenkinsConfiguredWithCodeRule j) throws Exception {
         j.jenkins.addNode(new Cloud1PretendSlave());
 
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorTest.java
@@ -3,10 +3,10 @@ package io.jenkins.plugins.casc.core;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
@@ -22,14 +22,14 @@ import hudson.util.DescribableList;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Objects;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.Symbol;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -37,24 +37,22 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class JenkinsConfiguratorTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class JenkinsConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("Primitives.yml")
-    public void jenkins_primitive_attributes() {
+    void jenkins_primitive_attributes(JenkinsConfiguredWithCodeRule j) {
         final Jenkins jenkins = Jenkins.get();
         assertEquals(6666, jenkins.getSlaveAgentPort());
     }
 
     @Test
     @ConfiguredWithCode("HeteroDescribable.yml")
-    public void jenkins_abstract_describable_attributes() {
+    void jenkins_abstract_describable_attributes(JenkinsConfiguredWithCodeRule j) {
         final Jenkins jenkins = Jenkins.get();
-        assertTrue(jenkins.getSecurityRealm() instanceof HudsonPrivateSecurityRealm);
-        assertTrue(jenkins.getAuthorizationStrategy() instanceof FullControlOnceLoggedInAuthorizationStrategy);
+        assertInstanceOf(HudsonPrivateSecurityRealm.class, jenkins.getSecurityRealm());
+        assertInstanceOf(FullControlOnceLoggedInAuthorizationStrategy.class, jenkins.getAuthorizationStrategy());
         assertFalse(((FullControlOnceLoggedInAuthorizationStrategy) jenkins.getAuthorizationStrategy())
                 .isAllowAnonymousRead());
     }
@@ -62,7 +60,7 @@ public class JenkinsConfiguratorTest {
     @Test
     @Issue("Issue #173")
     @ConfiguredWithCode("SetEnvironmentVariable.yml")
-    public void shouldSetEnvironmentVariable() throws Exception {
+    void shouldSetEnvironmentVariable(JenkinsConfiguredWithCodeRule j) throws Exception {
         final DescribableList<NodeProperty<?>, NodePropertyDescriptor> properties =
                 Jenkins.get().getNodeProperties();
         EnvVars env = new EnvVars();
@@ -74,7 +72,7 @@ public class JenkinsConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("ConfigureLabels.yml")
-    public void shouldExportLabelAtoms() throws Exception {
+    void shouldExportLabelAtoms(JenkinsConfiguredWithCodeRule j) throws Exception {
         Objects.requireNonNull(Jenkins.get().getLabelAtom("label1"))
                 .getProperties()
                 .add(new TestProperty(1));
@@ -93,7 +91,7 @@ public class JenkinsConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("ConfigureLabels.yml")
-    public void shouldImportLabelAtoms() {
+    void shouldImportLabelAtoms(JenkinsConfiguredWithCodeRule j) {
         LabelAtom label1 = Jenkins.get().getLabelAtom("label1");
         assertNotNull(label1);
         assertThat(label1.getProperties(), hasSize(2));

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/MavenConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/MavenConfiguratorTest.java
@@ -1,37 +1,37 @@
 package io.jenkins.plugins.casc.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
 import hudson.tasks.Maven;
 import hudson.tools.InstallSourceProperty;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import jenkins.mvn.FilePathSettingsProvider;
 import jenkins.mvn.GlobalMavenConfig;
 import jenkins.mvn.SettingsProvider;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class MavenConfiguratorTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class MavenConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("MavenConfiguratorTest.yml")
-    public void should_configure_maven_tools_and_global_config() {
+    void should_configure_maven_tools_and_global_config(JenkinsConfiguredWithCodeRule j) {
         final Maven.DescriptorImpl descriptor = (Maven.DescriptorImpl) j.jenkins.getDescriptorOrDie(Maven.class);
-        Assert.assertEquals(1, descriptor.getInstallations().length);
-        Assert.assertEquals("/usr/share/maven", descriptor.getInstallations()[0].getHome());
+        assertEquals(1, descriptor.getInstallations().length);
+        assertEquals("/usr/share/maven", descriptor.getInstallations()[0].getHome());
 
         InstallSourceProperty installSourceProperty =
                 descriptor.getInstallations()[0].getProperties().get(InstallSourceProperty.class);
-        Assert.assertEquals("3.5.0", installSourceProperty.installers.get(Maven.MavenInstaller.class).id);
+        assertEquals("3.5.0", installSourceProperty.installers.get(Maven.MavenInstaller.class).id);
 
         final SettingsProvider provider = GlobalMavenConfig.get().getSettingsProvider();
-        Assert.assertTrue(provider instanceof FilePathSettingsProvider);
-        Assert.assertEquals("/usr/share/maven-settings.xml", ((FilePathSettingsProvider) provider).getPath());
+        assertInstanceOf(FilePathSettingsProvider.class, provider);
+        assertEquals("/usr/share/maven-settings.xml", ((FilePathSettingsProvider) provider).getPath());
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/UnsecuredAuthorizationStrategyConfiguratorTest.java
@@ -1,23 +1,22 @@
 package io.jenkins.plugins.casc.core;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import hudson.security.AuthorizationStrategy;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class UnsecuredAuthorizationStrategyConfiguratorTest {
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class UnsecuredAuthorizationStrategyConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("UnsecuredAuthorizationStrategyConfiguratorTest.yml")
-    public void unsecured() {
+    void unsecured(JenkinsConfiguredWithCodeRule j) {
         assertSame(AuthorizationStrategy.UNSECURED, j.jenkins.getAuthorizationStrategy());
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/UpdateCenterConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/UpdateCenterConfiguratorTest.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.casc.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import hudson.model.UpdateCenter;
 import hudson.model.UpdateSite;
@@ -10,20 +10,18 @@ import io.jenkins.plugins.casc.Configurator;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class UpdateCenterConfiguratorTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class UpdateCenterConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("UpdateCenter.yml")
-    public void shouldSetUpdateCenterSites() throws Exception {
+    void shouldSetUpdateCenterSites(JenkinsConfiguredWithCodeRule j) throws Exception {
         UpdateCenter updateCenter = j.jenkins.getUpdateCenter();
         List<UpdateSite> sites = updateCenter.getSites();
         assertEquals(2, sites.size());

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -5,13 +5,13 @@ import static io.jenkins.plugins.casc.misc.Util.assertNotInLog;
 import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.util.Secret;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
@@ -34,34 +34,34 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.annotation.PostConstruct;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.LogRecorder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class DataBoundConfiguratorTest {
+@WithJenkins
+class DataBoundConfiguratorTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @Rule
-    public LoggerRule logging = new LoggerRule();
+    private final LogRecorder logging = new LogRecorder();
 
-    @Before
-    public void tearUp() {
+    @BeforeEach
+    void tearUp(JenkinsRule j) {
+        this.j = j;
         logging.record(Logger.getLogger(DataBoundConfigurator.class.getName()), Level.FINEST)
                 .capture(2048);
     }
 
     @Test
-    public void configure_databound() throws Exception {
+    void configure_databound() throws Exception {
         Mapping config = new Mapping();
         config.put("foo", "foo");
         config.put("bar", "true");
@@ -78,7 +78,7 @@ public class DataBoundConfiguratorTest {
     }
 
     @Test
-    public void exportYaml() throws Exception {
+    void exportYaml() throws Exception {
         Foo foo = new Foo("foo", true, 42);
         foo.setZot("zot");
         foo.setDbl(12.34);
@@ -88,25 +88,25 @@ public class DataBoundConfiguratorTest {
         final ConfigurationContext context = new ConfigurationContext(registry);
         final CNode node = c.describe(foo, context);
         assertNotNull(node);
-        assertTrue(node instanceof Mapping);
+        assertInstanceOf(Mapping.class, node);
         Mapping map = (Mapping) node;
-        assertEquals(map.get("foo").toString(), "foo");
-        assertEquals(map.get("bar").toString(), "true");
-        assertEquals(map.get("qix").toString(), "42");
-        assertEquals(map.get("zot").toString(), "zot");
-        assertEquals(map.get("dbl").toString(), "12.34");
-        assertEquals(map.get("flt").toString(), "1.0");
-        assertEquals(Util.toYamlString(map.get("foo")).trim(), "\"foo\"");
-        assertEquals(Util.toYamlString(map.get("bar")).trim(), "true");
-        assertEquals(Util.toYamlString(map.get("qix")).trim(), "42");
-        assertEquals(Util.toYamlString(map.get("zot")).trim(), "\"zot\"");
-        assertEquals(Util.toYamlString(map.get("dbl")).trim(), "\"12.34\"");
-        assertEquals(Util.toYamlString(map.get("flt")).trim(), "\"1.0\"");
+        assertEquals("foo", map.get("foo").toString());
+        assertEquals("true", map.get("bar").toString());
+        assertEquals("42", map.get("qix").toString());
+        assertEquals("zot", map.get("zot").toString());
+        assertEquals("12.34", map.get("dbl").toString());
+        assertEquals("1.0", map.get("flt").toString());
+        assertEquals("\"foo\"", Util.toYamlString(map.get("foo")).trim());
+        assertEquals("true", Util.toYamlString(map.get("bar")).trim());
+        assertEquals("42", Util.toYamlString(map.get("qix")).trim());
+        assertEquals("\"zot\"", Util.toYamlString(map.get("zot")).trim());
+        assertEquals("\"12.34\"", Util.toYamlString(map.get("dbl")).trim());
+        assertEquals("\"1.0\"", Util.toYamlString(map.get("flt")).trim());
         assertFalse(map.containsKey("other"));
     }
 
     @Test
-    public void configureWithSets() throws Exception {
+    void configureWithSets() throws Exception {
         Mapping config = new Mapping();
         Sequence sequence = new Sequence();
         sequence.add(new Scalar("bar"));
@@ -122,7 +122,7 @@ public class DataBoundConfiguratorTest {
     }
 
     @Test
-    public void configureWithEmptySet() throws Exception {
+    void configureWithEmptySet() throws Exception {
         Mapping config = new Mapping();
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         final Bar configured =
@@ -132,7 +132,7 @@ public class DataBoundConfiguratorTest {
     }
 
     @Test
-    public void nonnullConstructorParameter() throws Exception {
+    void nonnullConstructorParameter() throws Exception {
         Mapping config = new Mapping();
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         final NonnullParameterConstructor configured =
@@ -142,7 +142,7 @@ public class DataBoundConfiguratorTest {
     }
 
     @Test
-    public void classParametersAreNonnullByDefault() throws Exception {
+    void classParametersAreNonnullByDefault() throws Exception {
         Mapping config = new Mapping();
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         final ClassParametersAreNonnullByDefault configured =
@@ -152,7 +152,7 @@ public class DataBoundConfiguratorTest {
     }
 
     @Test
-    public void packageParametersAreNonnullByDefault() {
+    void packageParametersAreNonnullByDefault() {
         Mapping config = new Mapping();
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
 
@@ -168,7 +168,7 @@ public class DataBoundConfiguratorTest {
 
     @Test
     @Issue("#1025")
-    public void packageParametersAreNonnullByDefaultButCanBeNullable() throws Exception {
+    void packageParametersAreNonnullByDefaultButCanBeNullable() throws Exception {
         Mapping config = new Mapping();
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         final PackageParametersNonNullCheckForNull configured =
@@ -179,7 +179,7 @@ public class DataBoundConfiguratorTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void exportWithSets() throws Exception {
+    void exportWithSets() throws Exception {
         HashSet<String> set = new HashSet<>();
         set.add("foo");
 
@@ -189,25 +189,26 @@ public class DataBoundConfiguratorTest {
         final ConfigurationContext context = new ConfigurationContext(registry);
         CNode node = c.describe(bar, context);
         assertNotNull(node);
-        assertTrue(node instanceof Mapping);
+        assertInstanceOf(Mapping.class, node);
         Mapping map = (Mapping) node;
-        assertEquals(map.get("strings").toString(), "[foo]");
-        assertEquals(Util.toYamlString(map.get("strings")).trim(), "- \"foo\"");
+        assertEquals("[foo]", map.get("strings").toString());
+        assertEquals("- \"foo\"", Util.toYamlString(map.get("strings")).trim());
         assertFalse(map.containsKey("other"));
 
         // now with two elements
         set.add("bar");
         node = c.describe(bar, context);
         assertNotNull(node);
-        assertTrue(node instanceof Mapping);
+        assertInstanceOf(Mapping.class, node);
         map = (Mapping) node;
-        assertEquals(map.get("strings").toString(), "[bar, foo]");
-        assertEquals(Util.toYamlString(map.get("strings")).trim(), "- \"bar\"\n- \"foo\"");
+        assertEquals("[bar, foo]", map.get("strings").toString());
+        assertEquals(
+                "- \"bar\"\n- \"foo\"", Util.toYamlString(map.get("strings")).trim());
     }
 
     @Test
     @Issue("PR #838, Issue #222")
-    public void export_mapping_should_not_be_null() throws Exception {
+    void export_mapping_should_not_be_null() throws Exception {
         j.createFreeStyleProject("testJob1");
         ConfigurationAsCode casc = ConfigurationAsCode.get();
         casc.configure(
@@ -231,28 +232,27 @@ public class DataBoundConfiguratorTest {
     }
 
     @Test
-    public void shouldThrowConfiguratorException() {
+    void shouldThrowConfiguratorException() {
         Mapping config = new Mapping();
         config.put("foo", "foo");
         config.put("bar", "abcd");
         config.put("qix", "99");
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
-        try {
-            registry.lookupOrFail(Foo.class).configure(config, new ConfigurationContext(registry));
-            fail("above action is excepted to throw ConfiguratorException!");
-        } catch (ConfiguratorException e) {
-            assertThat(
-                    e.getMessage(),
-                    is(
-                            "foo: Failed to construct instance of class io.jenkins.plugins.casc.impl.configurators.DataBoundConfiguratorTest$Foo.\n"
-                                    + " Constructor: public io.jenkins.plugins.casc.impl.configurators.DataBoundConfiguratorTest$Foo(java.lang.String,boolean,int).\n"
-                                    + " Arguments: [java.lang.String, java.lang.Boolean, java.lang.Integer].\n"
-                                    + " Expected Parameters: foo java.lang.String, bar boolean, qix int"));
-        }
+        ConfiguratorException e = assertThrows(
+                ConfiguratorException.class,
+                () -> registry.lookupOrFail(Foo.class).configure(config, new ConfigurationContext(registry)),
+                "action is excepted to throw ConfiguratorException!");
+        assertThat(
+                e.getMessage(),
+                is(
+                        "foo: Failed to construct instance of class io.jenkins.plugins.casc.impl.configurators.DataBoundConfiguratorTest$Foo.\n"
+                                + " Constructor: public io.jenkins.plugins.casc.impl.configurators.DataBoundConfiguratorTest$Foo(java.lang.String,boolean,int).\n"
+                                + " Arguments: [java.lang.String, java.lang.Boolean, java.lang.Integer].\n"
+                                + " Expected Parameters: foo java.lang.String, bar boolean, qix int"));
     }
 
     @Test
-    public void shouldNotLogSecrets() throws Exception {
+    void shouldNotLogSecrets() throws Exception {
         Mapping config = new Mapping();
         config.put("secret", "mySecretValue");
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
@@ -263,7 +263,7 @@ public class DataBoundConfiguratorTest {
 
     @Test
     @Issue("SECURITY-1497")
-    public void shouldNotLogSecretsForUndefinedConstructors() throws Exception {
+    void shouldNotLogSecretsForUndefinedConstructors() throws Exception {
         Mapping config = new Mapping();
         config.put("secret", "mySecretValue");
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
@@ -273,7 +273,7 @@ public class DataBoundConfiguratorTest {
     }
 
     @Test
-    public void shouldExportArray() throws Exception {
+    void shouldExportArray() throws Exception {
         ArrayConstructor obj = new ArrayConstructor(new Foo[] {new Foo("", false, 0)});
 
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
@@ -283,9 +283,9 @@ public class DataBoundConfiguratorTest {
         CNode node = c.describe(obj, context);
 
         assertNotNull(node);
-        assertTrue(node instanceof Mapping);
+        assertInstanceOf(Mapping.class, node);
         Mapping map = (Mapping) node;
-        assertEquals(map.get("anArray").toString(), "[{qix=0, bar=false, foo=}]");
+        assertEquals("[{qix=0, bar=false, foo=}]", map.get("anArray").toString());
     }
 
     public static class Foo {

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
@@ -7,23 +7,21 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import jenkins.model.GlobalConfiguration;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class DescriptorConfiguratorTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class DescriptorConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("DescriptorConfiguratorTest_camelCase.yml")
-    public void configurator_shouldConfigureItselfWhenUsingCamelCase() {
+    void configurator_shouldConfigureItselfWhenUsingCamelCase(JenkinsConfiguredWithCodeRule j) {
         FooBar descriptor = (FooBar) j.jenkins.getDescriptorOrDie(FooBar.class);
         assertThat(descriptor.getFoo(), equalTo("foo"));
         assertThat(descriptor.getBar(), equalTo("bar"));
@@ -31,7 +29,7 @@ public class DescriptorConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("DescriptorConfiguratorTest_lowerCase.yml")
-    public void configurator_shouldConfigureItselfWhenUsingLoweCase() {
+    void configurator_shouldConfigureItselfWhenUsingLoweCase(JenkinsConfiguredWithCodeRule j) {
         FooBar descriptor = (FooBar) j.jenkins.getDescriptorOrDie(FooBar.class);
         assertThat(descriptor.getFoo(), equalTo("foo"));
         assertThat(descriptor.getBar(), equalTo("bar"));
@@ -39,7 +37,7 @@ public class DescriptorConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("DescriptorConfiguratorTest_camelCase.yml")
-    public void configurator_shouldResolveFloatAndDoubleValues() {
+    void configurator_shouldResolveFloatAndDoubleValues(JenkinsConfiguredWithCodeRule j) {
         FooBar descriptor = (FooBar) j.jenkins.getDescriptorOrDie(FooBar.class);
         assertThat(descriptor.getBaz(), equalTo(1.0));
         assertThat(descriptor.getFlt(), equalTo(1000f));

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DuplicateKeyDescribableConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DuplicateKeyDescribableConfiguratorTest.java
@@ -9,20 +9,19 @@ import hudson.model.Descriptor;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.Objects;
 import jenkins.model.GlobalConfiguration;
 import org.jenkinsci.Symbol;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-public class DuplicateKeyDescribableConfiguratorTest {
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class DuplicateKeyDescribableConfiguratorTest {
 
     @Test
-    public void implementors_shouldNotThrowException() {
+    void implementors_shouldNotThrowException(JenkinsConfiguredWithCodeRule j) {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         HeteroDescribableConfigurator configurator =
                 Objects.requireNonNull((HeteroDescribableConfigurator) registry.lookup(FooBar.class));
@@ -32,7 +31,7 @@ public class DuplicateKeyDescribableConfiguratorTest {
 
     @Test
     @ConfiguredWithCode("DuplicateKeyDescribableConfigure.yml")
-    public void configure_shouldNotThrowException() {
+    void configure_shouldNotThrowException(JenkinsConfiguredWithCodeRule j) {
         FooBarGlobalConfiguration descriptor =
                 (FooBarGlobalConfiguration) j.jenkins.getDescriptor(FooBarGlobalConfiguration.class);
         FooBarOne instance = (FooBarOne) Objects.requireNonNull(descriptor).fooBar;

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/MissingConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/MissingConfiguratorTest.java
@@ -9,20 +9,18 @@ import hudson.model.User;
 import io.jenkins.plugins.casc.UnknownAttributesException;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
 
-public class MissingConfiguratorTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class MissingConfiguratorTest {
 
     @ConfiguredWithCode(
             value = "MissingConfiguratorTest.yml",
             expected = UnknownAttributesException.class,
             message = "No hudson.security.AuthorizationStrategy implementation found for globalMatrix")
     @Test
-    public void testThrowsSuggestion() {
+    void testThrowsSuggestion(JenkinsConfiguredWithCodeRule j) {
         // The conditions for this test can be false in PCT runs
         assumeThat(j.jenkins.getPlugin("matrix-auth"), nullValue());
         // No config check needed, should fail with IllegalArgumentException

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/SelfConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/SelfConfiguratorTest.java
@@ -7,26 +7,24 @@ import static org.hamcrest.Matchers.not;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class SelfConfiguratorTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class SelfConfiguratorTest {
 
     @Test
     @ConfiguredWithCode(value = "SelfConfiguratorTest.yml")
-    public void self_configure() {
+    void self_configure(JenkinsConfiguredWithCodeRule j) {
         assertThat(j.jenkins.getRawBuildsDir(), is("/tmp"));
     }
 
     @Test
     @ConfiguredWithCode(value = "SelfConfiguratorRestrictedTest.yml", expected = ConfiguratorException.class)
-    public void self_configure_restricted() {
+    void self_configure_restricted(JenkinsConfiguredWithCodeRule j) {
         // expected to throw Configurator Exception
         assertThat(j.jenkins.getRawBuildsDir(), is(not("/tmp")));
     }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/junit/jupiter/JenkinsConfiguredWithCodeMethodRuleTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/junit/jupiter/JenkinsConfiguredWithCodeMethodRuleTest.java
@@ -9,12 +9,12 @@ import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class JenkinsConfiguredWithCodeMethodRuleTest {
+class JenkinsConfiguredWithCodeMethodRuleTest {
 
     @Test
     @WithJenkinsConfiguredWithCode
     @ConfiguredWithCode("admin.yml")
-    public void user_created(JenkinsConfiguredWithCodeRule rule) {
+    void user_created(JenkinsConfiguredWithCodeRule rule) {
         assertNotNull(rule);
         User admin = User.get("admin", false, Collections.emptyMap());
         assertNotNull(admin);

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/junit/jupiter/JenkinsConfiguredWithCodeRuleClassRuleTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/junit/jupiter/JenkinsConfiguredWithCodeRuleClassRuleTest.java
@@ -11,17 +11,17 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @WithJenkinsConfiguredWithCode
-public class JenkinsConfiguredWithCodeRuleClassRuleTest {
+class JenkinsConfiguredWithCodeRuleClassRuleTest {
     @ConfiguredWithCode("admin.yml")
     public static JenkinsConfiguredWithCodeRule j;
 
     @BeforeAll
-    public static void beforeAll() {
+    static void beforeAll() {
         assertNotNull(j);
     }
 
     @Test
-    public void user_created() {
+    void user_created() {
         User admin = User.get("admin", false, Collections.emptyMap());
         assertNotNull(admin);
     }


### PR DESCRIPTION
This PR aims to migrate tests to JUnit5. Changes include:

* Migrate annotations
* Migrate assertions
* Cleanup assertions
* Remove public visibility of test classes and methods

I did not migrate tests that explicitly test behavior of the JUnit4 rules provided by the plugin.

There are no changes to the public classes and utilities delivered by this plugin (besides https://github.com/strangelookingnerd/configuration-as-code-plugin/blob/c0e1e348f7d955560eb2219840a5cbb920245ff0/test-harness/src/main/java/io/jenkins/plugins/casc/misc/Util.java#L205-L243). 

Some tests can not (yet) be migrated. Most of which use `JenkinsConfiguredWithReadmeRule`. While that could also be migrated to a JUnit5 Extension like `JenkinsConfiguredWithCodeExtension`, it seems like [no other project is using that rule](https://github.com/search?q=org%3Ajenkinsci%20JenkinsConfiguredWithReadmeRule&type=code). Therefore I'm honestly not sure if it is worth the effort.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
