### PR TITLE
Raise default permissions of `JUnit5JenkinsConfiguredWithCodeRule`

### DIFF
--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/junit/jupiter/JUnit5JenkinsConfiguredWithCodeRule.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/junit/jupiter/JUnit5JenkinsConfiguredWithCodeRule.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc.misc.junit.jupiter;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.security.ACL;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -22,6 +23,9 @@ class JUnit5JenkinsConfiguredWithCodeRule extends JenkinsConfiguredWithCodeRule 
 
     @Override
     public void recipe() throws Exception {
+        // so that test code has all the access to the system
+        ACL.as2(ACL.SYSTEM2);
+
         final JenkinsRecipe recipe = this.testDescription.getAnnotation(JenkinsRecipe.class);
         if (recipe == null) {
             return;

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/junit/jupiter/JenkinsConfiguredWithCodeRulePermissionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/junit/jupiter/JenkinsConfiguredWithCodeRulePermissionTest.java
@@ -1,0 +1,56 @@
+package io.jenkins.plugins.casc.junit.jupiter;
+
+import hudson.security.Permission;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+
+/**
+ * Validates that JUnit4 and JUnit5 based {@link JenkinsConfiguredWithCodeRule} implementations have the same default authorization and permissions.
+ */
+@SuppressWarnings("deprecation")
+public class JenkinsConfiguredWithCodeRulePermissionTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule junit4rule = new JenkinsConfiguredWithCodeRule();
+
+    @org.junit.Test
+    public void junit4() {
+        MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
+        junit4rule.getInstance().setAuthorizationStrategy(strategy);
+
+        // basic permissions
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.READ));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.WRITE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.CREATE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.UPDATE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.DELETE));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.CONFIGURE));
+
+        // admin permissions
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.FULL_CONTROL));
+        Assert.assertTrue(junit4rule.getInstance().getACL().hasPermission(Permission.HUDSON_ADMINISTER));
+    }
+
+    @org.junit.jupiter.api.Test
+    @WithJenkinsConfiguredWithCode
+    void junit5(JenkinsConfiguredWithCodeRule junit5rule) {
+        MockAuthorizationStrategy strategy = new MockAuthorizationStrategy();
+        junit5rule.getInstance().setAuthorizationStrategy(strategy);
+
+        // basic permissions
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.READ));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.WRITE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.CREATE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.UPDATE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.DELETE));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.CONFIGURE));
+
+        // admin permissions
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.FULL_CONTROL));
+        Assertions.assertTrue(junit5rule.getInstance().getACL().hasPermission(Permission.HUDSON_ADMINISTER));
+    }
+}


### PR DESCRIPTION
Same issue / solution as in https://github.com/jenkinsci/jenkins-test-harness/issues/901 / https://github.com/jenkinsci/jenkins-test-harness/pull/910

This PR raises the default permissions of `JUnit5JenkinsConfiguredWithCodeRule` to align with their JUnit4 counterparts.
Added `io.jenkins.plugins.casc.junit.jupiter.JenkinsConfiguredWithCodeRulePermissionTest` to validate the behavior.

Required for https://github.com/jenkinsci/role-strategy-plugin/pull/389 and https://github.com/jenkinsci/configuration-as-code-plugin/pull/2634

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
