### PR TITLE
Allowing empty valued global variables in config file

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
@@ -15,7 +15,9 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import jenkins.model.Jenkins;
 import org.junit.jupiter.api.Test;
@@ -33,11 +35,20 @@ class GlobalNodePropertiesTest {
         Set<Map.Entry<String, String>> entries = ((EnvironmentVariablesNodeProperty) nodeProperties.get(0))
                 .getEnvVars()
                 .entrySet();
-        assertEquals(1, entries.size());
+        assertEquals(3, entries.size());
 
-        Map.Entry<String, String> envVar = entries.iterator().next();
+        Iterator<Entry<String, String>> iterator = entries.iterator();
+        Map.Entry<String, String> envVar = iterator.next();
         assertEquals("FOO", envVar.getKey());
         assertEquals("BAR", envVar.getValue());
+
+        envVar = iterator.next();
+        assertEquals("FOO2", envVar.getKey());
+        assertEquals("", envVar.getValue());
+
+        envVar = iterator.next();
+        assertEquals("FOO3", envVar.getKey());
+        assertEquals("", envVar.getValue());
     }
 
     @Test

--- a/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/GlobalNodePropertiesTest.java
@@ -7,9 +7,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import hudson.node_monitors.DiskSpaceMonitorNodeProperty;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
+import hudson.tools.ToolLocationNodeProperty;
 import hudson.util.DescribableList;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
@@ -32,12 +34,15 @@ class GlobalNodePropertiesTest {
 
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties = jenkins.getGlobalNodeProperties();
 
-        Set<Map.Entry<String, String>> entries = ((EnvironmentVariablesNodeProperty) nodeProperties.get(0))
+        assertEquals(3, nodeProperties.size());
+
+        Set<Map.Entry<String, String>> envVars = ((EnvironmentVariablesNodeProperty)
+                        nodeProperties.get(EnvironmentVariablesNodeProperty.class))
                 .getEnvVars()
                 .entrySet();
-        assertEquals(3, entries.size());
+        assertEquals(3, envVars.size());
 
-        Iterator<Entry<String, String>> iterator = entries.iterator();
+        Iterator<Entry<String, String>> iterator = envVars.iterator();
         Map.Entry<String, String> envVar = iterator.next();
         assertEquals("FOO", envVar.getKey());
         assertEquals("BAR", envVar.getValue());
@@ -49,6 +54,17 @@ class GlobalNodePropertiesTest {
         envVar = iterator.next();
         assertEquals("FOO3", envVar.getKey());
         assertEquals("", envVar.getValue());
+
+        DiskSpaceMonitorNodeProperty diskSpace = nodeProperties.get(DiskSpaceMonitorNodeProperty.class);
+        assertEquals("1GiB", diskSpace.getFreeDiskSpaceThreshold());
+        assertEquals("2GiB", diskSpace.getFreeDiskSpaceWarningThreshold());
+        assertEquals("1GiB", diskSpace.getFreeTempSpaceThreshold());
+        assertEquals("2GiB", diskSpace.getFreeTempSpaceWarningThreshold());
+
+        ToolLocationNodeProperty toolLocations = nodeProperties.get(ToolLocationNodeProperty.class);
+        assertEquals(1, toolLocations.getLocations().size());
+        assertEquals("Default", toolLocations.getLocations().get(0).getName());
+        assertEquals("/home/user/bin/git", toolLocations.getLocations().get(0).getHome());
     }
 
     @Test

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTest.yml
@@ -1,5 +1,10 @@
 jenkins:
   globalNodeProperties:
+    - diskSpaceMonitor:
+        freeDiskSpaceThreshold: "1GiB"
+        freeDiskSpaceWarningThreshold: "2GiB"
+        freeTempSpaceThreshold: "1GiB"
+        freeTempSpaceWarningThreshold: "2GiB"
     - envVars:
         env:
           - key: FOO
@@ -7,3 +12,7 @@ jenkins:
           - key: FOO2
             value: ""
           - key: FOO3
+    - toolLocation:
+        locations:
+          - home: "/home/user/bin/git"
+            key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTest.yml
@@ -4,3 +4,5 @@ jenkins:
         env:
           - key: FOO
             value: BAR
+          - key: FOO2
+            value: ""

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTest.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTest.yml
@@ -6,3 +6,4 @@ jenkins:
             value: BAR
           - key: FOO2
             value: ""
+          - key: FOO3

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTestExpected.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTestExpected.yml
@@ -1,6 +1,15 @@
+- diskSpaceMonitor:
+    freeDiskSpaceThreshold: "1GiB"
+    freeDiskSpaceWarningThreshold: "2GiB"
+    freeTempSpaceThreshold: "1GiB"
+    freeTempSpaceWarningThreshold: "2GiB"
 - envVars:
     env:
     - key: "FOO"
       value: "BAR"
     - key: "FOO2"
     - key: "FOO3"
+- toolLocation:
+    locations:
+    - home: "/home/user/bin/git"
+      key: "hudson.plugins.git.GitTool$DescriptorImpl@Default"

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTestExpected.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/GlobalNodePropertiesTestExpected.yml
@@ -2,3 +2,5 @@
     env:
     - key: "FOO"
       value: "BAR"
+    - key: "FOO2"
+    - key: "FOO3"

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
@@ -4,45 +4,29 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
-import io.jenkins.plugins.casc.Attribute;
-import io.jenkins.plugins.casc.BaseConfigurator;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorException;
-import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Extension
-public class GlobalNodePropertiesConfigurator extends BaseConfigurator<EnvironmentVariablesNodeProperty> {
+public class GlobalNodePropertiesConfigurator extends DataBoundConfigurator<EnvironmentVariablesNodeProperty> {
+
+    public GlobalNodePropertiesConfigurator() {
+        this(EnvironmentVariablesNodeProperty.class);
+    }
+
+    public GlobalNodePropertiesConfigurator(Class<?> clazz) {
+        super(EnvironmentVariablesNodeProperty.class);
+    }
 
     @NonNull
     @Override
     public String getName() {
         return "globalNodeProperties";
-    }
-
-    @Override
-    protected EnvironmentVariablesNodeProperty instance(Mapping mapping, ConfigurationContext context)
-            throws ConfiguratorException {
-        List<Entry> vars = getVarsAsList(mapping);
-        return new EnvironmentVariablesNodeProperty(vars);
-    }
-
-    @Override
-    public Class<EnvironmentVariablesNodeProperty> getTarget() {
-        return EnvironmentVariablesNodeProperty.class;
-    }
-
-    @NonNull
-    @Override
-    public Set<Attribute<EnvironmentVariablesNodeProperty, ?>> describe() {
-        Set<Attribute<EnvironmentVariablesNodeProperty, ?>> attrs = super.describe();
-        attrs.add(new MultivaluedAttribute<EnvironmentVariablesNodeProperty, EnvironmentVariablesNodeProperty.Entry>(
-                "env", Entry.class));
-        return attrs;
     }
 
     @NonNull

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
@@ -2,14 +2,9 @@ package io.jenkins.plugins.casc.core;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-//import hudson.EnvVars;
-import hudson.EnvVars;
 import hudson.Extension;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
-import hudson.slaves.EnvironmentVariablesNodeProperty.DescriptorImpl;
 import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
-import hudson.util.DescribableList;
-import hudson.util.PersistedList;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.BaseConfigurator;
 import io.jenkins.plugins.casc.ConfigurationContext;
@@ -19,12 +14,8 @@ import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.jenkins.plugins.casc.model.Sequence;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
 
 @Extension
 public class GlobalNodePropertiesConfigurator extends BaseConfigurator<EnvironmentVariablesNodeProperty> {
@@ -36,8 +27,8 @@ public class GlobalNodePropertiesConfigurator extends BaseConfigurator<Environme
     }
 
     @Override
-    protected EnvironmentVariablesNodeProperty instance(Mapping mapping,
-        ConfigurationContext context) throws ConfiguratorException {
+    protected EnvironmentVariablesNodeProperty instance(Mapping mapping, ConfigurationContext context)
+            throws ConfiguratorException {
         List<Entry> vars = getVarsAsList(mapping);
         return new EnvironmentVariablesNodeProperty(vars);
     }
@@ -51,13 +42,15 @@ public class GlobalNodePropertiesConfigurator extends BaseConfigurator<Environme
     @Override
     public Set<Attribute<EnvironmentVariablesNodeProperty, ?>> describe() {
         Set<Attribute<EnvironmentVariablesNodeProperty, ?>> attrs = super.describe();
-        attrs.add(new MultivaluedAttribute<EnvironmentVariablesNodeProperty, EnvironmentVariablesNodeProperty.Entry>("env", Entry.class));
+        attrs.add(new MultivaluedAttribute<EnvironmentVariablesNodeProperty, EnvironmentVariablesNodeProperty.Entry>(
+                "env", Entry.class));
         return attrs;
     }
 
     @NonNull
     @Override
-    public EnvironmentVariablesNodeProperty configure(CNode c, ConfigurationContext context) throws ConfiguratorException {
+    public EnvironmentVariablesNodeProperty configure(CNode c, ConfigurationContext context)
+            throws ConfiguratorException {
         Mapping mapping = c.asMapping();
         List<Entry> variables = getVarsAsList(mapping);
         return new EnvironmentVariablesNodeProperty(variables);
@@ -68,25 +61,32 @@ public class GlobalNodePropertiesConfigurator extends BaseConfigurator<Environme
         Mapping mapping = new Mapping();
         for (Attribute attribute : getAttributes()) {
             CNode value = attribute.describe(instance, context);
-            // Clean empty vars
-            Sequence values = new Sequence();
-            value.asSequence().stream().filter(entry -> StringUtils.isNotBlank(entry.asMapping().get("value").toString()))
-                .forEach(values::add);
             if (value != null) {
+                Sequence values = new Sequence();
+                value.asSequence().stream().forEach(values::add);
                 mapping.put(attribute.getName(), values);
             }
         }
         return mapping;
     }
 
-
     private List<Entry> getVarsAsList(Mapping m) {
         List<Entry> result = new ArrayList<>();
-        if (m.get("env") != null){
+        if (m.get("env") != null) {
             result = m.get("env").asSequence().stream()
-                .map(pair -> new Entry(pair.asMapping().get("key").asScalar().getValue(),
-                                              pair.asMapping().get("value").asScalar().getValue()))
-                .toList();
+                    .map(pair -> {
+                        if (pair.asMapping().get("key") == null) {
+                            return null;
+                        }
+                        final String key =
+                                pair.asMapping().get("key").asScalar().getValue();
+                        final String value = pair.asMapping().get("value") == null
+                                ? ""
+                                : pair.asMapping().get("value").asScalar().getValue();
+
+                        return new Entry(key, value);
+                    })
+                    .toList();
         }
         return result;
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
@@ -1,0 +1,93 @@
+package io.jenkins.plugins.casc.core;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+//import hudson.EnvVars;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.slaves.EnvironmentVariablesNodeProperty.DescriptorImpl;
+import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
+import hudson.util.DescribableList;
+import hudson.util.PersistedList;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang.StringUtils;
+
+@Extension
+public class GlobalNodePropertiesConfigurator extends BaseConfigurator<EnvironmentVariablesNodeProperty> {
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "globalNodeProperties";
+    }
+
+    @Override
+    protected EnvironmentVariablesNodeProperty instance(Mapping mapping,
+        ConfigurationContext context) throws ConfiguratorException {
+        List<Entry> vars = getVarsAsList(mapping);
+        return new EnvironmentVariablesNodeProperty(vars);
+    }
+
+    @Override
+    public Class<EnvironmentVariablesNodeProperty> getTarget() {
+        return EnvironmentVariablesNodeProperty.class;
+    }
+
+    @NonNull
+    @Override
+    public Set<Attribute<EnvironmentVariablesNodeProperty, ?>> describe() {
+        Set<Attribute<EnvironmentVariablesNodeProperty, ?>> attrs = super.describe();
+        attrs.add(new MultivaluedAttribute<EnvironmentVariablesNodeProperty, EnvironmentVariablesNodeProperty.Entry>("env", Entry.class));
+        return attrs;
+    }
+
+    @NonNull
+    @Override
+    public EnvironmentVariablesNodeProperty configure(CNode c, ConfigurationContext context) throws ConfiguratorException {
+        Mapping mapping = c.asMapping();
+        List<Entry> variables = getVarsAsList(mapping);
+        return new EnvironmentVariablesNodeProperty(variables);
+    }
+
+    @CheckForNull
+    public CNode describe(EnvironmentVariablesNodeProperty instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        for (Attribute attribute : getAttributes()) {
+            CNode value = attribute.describe(instance, context);
+            // Clean empty vars
+            Sequence values = new Sequence();
+            value.asSequence().stream().filter(entry -> StringUtils.isNotBlank(entry.asMapping().get("value").toString()))
+                .forEach(values::add);
+            if (value != null) {
+                mapping.put(attribute.getName(), values);
+            }
+        }
+        return mapping;
+    }
+
+
+    private List<Entry> getVarsAsList(Mapping m) {
+        List<Entry> result = new ArrayList<>();
+        if (m.get("env") != null){
+            result = m.get("env").asSequence().stream()
+                .map(pair -> new Entry(pair.asMapping().get("key").asScalar().getValue(),
+                                              pair.asMapping().get("value").asScalar().getValue()))
+                .toList();
+        }
+        return result;
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/GlobalNodePropertiesConfigurator.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.casc.core;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
@@ -12,7 +11,6 @@ import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
-import io.jenkins.plugins.casc.model.Sequence;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -54,20 +52,6 @@ public class GlobalNodePropertiesConfigurator extends BaseConfigurator<Environme
         Mapping mapping = c.asMapping();
         List<Entry> variables = getVarsAsList(mapping);
         return new EnvironmentVariablesNodeProperty(variables);
-    }
-
-    @CheckForNull
-    public CNode describe(EnvironmentVariablesNodeProperty instance, ConfigurationContext context) throws Exception {
-        Mapping mapping = new Mapping();
-        for (Attribute attribute : getAttributes()) {
-            CNode value = attribute.describe(instance, context);
-            if (value != null) {
-                Sequence values = new Sequence();
-                value.asSequence().stream().forEach(values::add);
-                mapping.put(attribute.getName(), values);
-            }
-        }
-        return mapping;
     }
 
     private List<Entry> getVarsAsList(Mapping m) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes: https://github.com/jenkinsci/configuration-as-code-plugin/issues/2658

Exporting empty variables as an empty string seems not possible. There's a explicit [check](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java#L660-L662) to avoid it and removing it would result in lots of empty configurations being exported, which is not desired.

Also, export works recursively, so any line being exported is not aware of the existence of any sibling, meaning in
```
- key: "FOO"
  value: ""
``` 
`key` and `value` lines are not aware of each other.

Having these, this PR will allow reading a config file that contains variables without a value (as they are exported)
```
jenkins:
  globalNodeProperties:
  - envVars:
      env:
      - key: VARIABLE1
        value: foo
      - key: EMPTY_VAR
```
will be accepted, Jenkins will start normally and variable will be visible
![image](https://github.com/user-attachments/assets/a60033f0-a844-458d-9244-6b7bc09abfd0)

Modified integration tests accordingly.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
