### PR TITLE
Use parent pom 5.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.14</version>
+    <version>5.16</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Use parent pom 5.16

The plugin bill of materials fails to run tests with parent pom versions 5.13 through 5.15.  Details are available in https://github.com/jenkinsci/bom/pull/5000#issuecomment-2852005108 and in the related pull requests:

* https://github.com/jenkinsci/maven-hpi-plugin/pull/741
* https://github.com/jenkinsci/plugin-pom/pull/1138

Tests fails with the most recent release of the configuration as code plugin in plugin BOM when I run the command (in the BOM repository):

```
gh pr checkout 5009 # JCasC upgrade PR
PLUGINS=configuration-as-code LINE=2.492.x bash ./local-test.sh
```

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
