### PR TITLE
Produce an empty map if so directed

### DIFF
--- a/integrations/src/test/resources/io/jenkins/plugins/casc/LDAPSecurityRealmTestNoSecretExpected.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/LDAPSecurityRealmTestNoSecretExpected.yml
@@ -2,7 +2,10 @@ cache:
   size: 100
   ttl: 30
 configurations:
-- inhibitInferRootDN: false
+- groupMembershipStrategy:
+    fromGroupSearch: {
+      }
+  inhibitInferRootDN: false
   rootDN: "dc=acme,dc=fr"
   server: "ldap.acme.com"
 disableMailAddressResolver: false

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -632,9 +632,6 @@ public class ConfigurationAsCode extends ManagementLink {
                     }
                     tuples.add(new NodeTuple(new ScalarNode(Tag.STR, entry.getKey(), null, null, PLAIN), valueNode));
                 }
-                if (tuples.isEmpty()) {
-                    return null;
-                }
 
                 return new MappingNode(Tag.MAP, tuples, BLOCK);
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
@@ -16,6 +16,7 @@ import io.jenkins.plugins.casc.RootElementConfigurator;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.jenkins.plugins.casc.model.Scalar;
+import io.jenkins.plugins.casc.model.Sequence;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -109,6 +110,11 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
         Jenkins.get().getExtensionList(Descriptor.class).stream()
                 .filter(this::filterDescriptors)
                 .forEach(d -> describe(d, mapping, context));
+        mapping.entrySet()
+                .removeIf(e -> e.getValue() instanceof Mapping m
+                        && m.keySet().equals(Set.of("installations"))
+                        && m.get("installations") instanceof Sequence s
+                        && s.isEmpty());
         return mapping;
     }
 


### PR DESCRIPTION
An `f:optionalProperty` that is set to a value which happens to not override any of its own fields is legal; preserve it in export unless there is a specific reason to determine that it can be safely omitted.