### PR TITLE
Ensure ConfiguratorException can be reported

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfiguratorException.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfiguratorException.java
@@ -25,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import io.jenkins.plugins.casc.model.CNode;
 import java.util.Collections;
 import java.util.List;
+import jenkins.model.Jenkins;
 
 /**
  * Exception type for {@link Configurator} issues.
@@ -100,7 +101,10 @@ public class ConfiguratorException extends RuntimeException {
     @Override
     public String getMessage() {
         if (configurator != null) {
-            return String.format("%s: %s", configurator.getName(), super.getMessage());
+            return String.format(
+                    "%s: %s",
+                    Jenkins.getInstanceOrNull() == null ? configurator.getClass() : configurator.getName(),
+                    super.getMessage());
         }
         return super.getMessage();
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #2729

Making sure `ConfiguratorException` can be reported once Jenkins is shutdown 

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
