### PR TITLE
Add SonarQube Scanner tool installation demo

### DIFF
--- a/demos/sonarqube/README.md
+++ b/demos/sonarqube/README.md
@@ -17,6 +17,16 @@ credentials:
             secret: "secret value"
             description: "Sonar token"
 
+tool:
+  sonarRunnerInstallation:
+    installations:
+      - name: "SonarQube Scanner"
+        properties:
+          - installSource:
+              installers:
+                - sonarRunnerInstaller:
+                    id: "7.3.0.5189"
+
 unclassified:
   sonarglobalconfiguration:                  # mandatory
     buildWrapperEnabled: true
@@ -36,4 +46,6 @@ unclassified:
 
 ## notes
 
-You can add multiple installations.
+- You can add multiple SonarQube server installations
+- `tool:sonarRunnerInstallation` installs the SonarQube Scanner tool
+- The `id` in sonarRunnerInstaller refers to the scanner version to install

--- a/demos/sonarqube/sonar-with-scanner.yaml
+++ b/demos/sonarqube/sonar-with-scanner.yaml
@@ -1,0 +1,31 @@
+---
+# SonarQube Plugin Configuration with Scanner Tool Installation
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+        - string:
+            scope: GLOBAL
+            id: "sonarqube-token"
+            secret: "${SONAR_TOKEN}"
+            description: "SonarQube Access Token"
+
+tool:
+  sonarRunnerInstallation:
+    installations:
+      - name: "SonarQube Scanner"
+        properties:
+          - installSource:
+              installers:
+                - sonarRunnerInstaller:
+                    id: "7.3.0.5189"
+
+unclassified:
+  sonarglobalconfiguration:
+    buildWrapperEnabled: true
+    installations:
+      - name: "sq1"
+        serverUrl: "http://sonarqube:9000"
+        credentialsId: "sonarqube-token"
+

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SonarQubeTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SonarQubeTest.java
@@ -5,11 +5,14 @@ import static io.jenkins.plugins.casc.misc.Util.validateSchema;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import hudson.plugins.sonar.SonarGlobalConfiguration;
 import hudson.plugins.sonar.SonarInstallation;
+import hudson.plugins.sonar.SonarRunnerInstallation;
 import hudson.plugins.sonar.model.TriggersConfig;
+import hudson.tools.InstallSourceProperty;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import jenkins.model.GlobalConfiguration;
@@ -41,6 +44,20 @@ public class SonarQubeTest {
         assertTrue(triggers.isSkipScmCause());
         assertTrue(triggers.isSkipUpstreamCause());
         assertEquals("envVar", triggers.getEnvVar());
+        
+        // Test SonarQube Scanner tool installation
+        final SonarRunnerInstallation.DescriptorImpl descriptor = 
+            j.jenkins.getDescriptorByType(SonarRunnerInstallation.DescriptorImpl.class);
+        assertNotNull("SonarRunnerInstallation descriptor should not be null", descriptor);
+        final SonarRunnerInstallation[] installations = descriptor.getInstallations();
+        assertEquals("Should have one SonarQube Scanner installation", 1, installations.length);
+        assertEquals("SonarQube Scanner", installations[0].getName());
+        
+        // Verify installer is configured
+        final InstallSourceProperty installSourceProperty = installations[0].getProperties()
+            .get(InstallSourceProperty.class);
+        assertNotNull("InstallSourceProperty should be configured", installSourceProperty);
+        assertEquals("Should have one installer configured", 1, installSourceProperty.installers.size());
     }
 
     @Test


### PR DESCRIPTION
This PR adds a missing demo for SonarQube Scanner tool installation configuration.


- Update README with sonarRunnerInstallation example
- Add sonar-with-scanner.yaml demonstrating tool configuration
- Shows how to auto-install SonarQube Scanner

[issue 2746](https://github.com/jenkinsci/configuration-as-code-plugin/issues/2746)
The existing SonarQube demo only covered server configuration (`unclassified:sonarglobalconfiguration`) but was missing the tool installation part (`tool:sonarRunnerInstallation`). This addition completes the SonarQube plugin configuration examples.




- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.


