### PR TITLE
Add demo for locale plugin configuration

### DIFF
--- a/demos/locale/README.md
+++ b/demos/locale/README.md
@@ -1,0 +1,40 @@
+# Configure Locale Plugin
+
+## Sample Configuration
+
+Sample configuration for the [Locale plugin](https://plugins.jenkins.io/locale).
+
+This plugin allows you to set Jenkins UI language and ignore browser language preferences.
+
+### Minimal Configuration
+
+Set Jenkins UI to English:
+
+```yaml
+appearance:
+  locale:
+    systemLocale: "en"
+```
+
+### Full Configuration
+
+Set Jenkins UI to English and ignore browser Accept-Language header:
+
+```yaml
+appearance:
+  locale:
+    systemLocale: "en"
+    ignoreAcceptLanguage: true
+```
+
+## Options
+
+- `systemLocale`: The locale to use (e.g., "en", "en_US", "de", "fr", "ja", "zh_CN")
+- `ignoreAcceptLanguage`: If true, ignore browser's Accept-Language header and always use systemLocale
+
+## Notes
+
+- Without `ignoreAcceptLanguage: true`, Jenkins will still respect user's browser language settings
+- This is useful for teams that want consistent UI language regardless of browser settings
+- Supported locales depend on installed language packs
+

--- a/demos/locale/locale.yaml
+++ b/demos/locale/locale.yaml
@@ -1,0 +1,9 @@
+---
+# Locale Plugin Configuration
+# Forces Jenkins UI to English and ignores browser language preferences
+
+appearance:
+  locale:
+    systemLocale: "en"
+    ignoreAcceptLanguage: true
+


### PR DESCRIPTION
This PR adds a missing demo for Locale plugin configuration.


- Add README with locale plugin examples
- Add locale.yaml with minimal configuration
- Demonstrates systemLocale and ignoreAcceptLanguage settings

The Locale plugin is commonly used to force Jenkins UI language (e.g., always use English regardless of browser settings), but there was no demo in the `demos/` folder. This addition provides examples for the `appearance:locale` configuration.
[issue 2748](https://github.com/jenkinsci/configuration-as-code-plugin/issues/2748)

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.


