### PR TITLE
Fix collection-to-set conversion causing type mismatch in JCasC setters

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -29,9 +29,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -169,14 +172,23 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
             rawAttribute.setter((targetInstance, value) -> {
                 Object finalValue = value;
 
-                if (value instanceof Collection<?> collection && finalType.rawType.isArray()) {
-                    Object array = newInstance(rawAttribute.getType(), collection.size());
-                    int i = 0;
-                    for (Object item : collection) {
-                        set(array, i++, item);
+                if (value instanceof Collection<?> collection) {
+                    if (finalType.rawType.isArray()) {
+                        Object array = newInstance(rawAttribute.getType(), collection.size());
+                        int i = 0;
+                        for (Object item : collection) {
+                            set(array, i++, item);
+                        }
+                        finalValue = array;
+
+                    } else if (SortedSet.class.isAssignableFrom(finalType.rawType)) {
+                        finalValue = new TreeSet<>(collection);
+
+                    } else if (Set.class.isAssignableFrom(finalType.rawType)) {
+                        finalValue = new LinkedHashSet<>(collection);
                     }
-                    finalValue = array;
                 }
+
                 bestMethod.invoke(targetInstance, finalValue);
             });
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/BaseConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/BaseConfiguratorTest.java
@@ -11,9 +11,12 @@ import hudson.util.PersistedList;
 import io.jenkins.plugins.casc.model.Mapping;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.kohsuke.accmod.Restricted;
@@ -58,6 +61,8 @@ public class BaseConfiguratorTest {
     public static class DummyTarget {
 
         private String[] items;
+        private Set<String> stringSet;
+        private SortedSet<String> sortedStringSet;
 
         public String getStandard() {
             return null;
@@ -107,6 +112,22 @@ public class BaseConfiguratorTest {
 
         public void setItems(String[] items) {
             this.items = items;
+        }
+
+        public Set<String> getStringSet() {
+            return stringSet;
+        }
+
+        public void setStringSet(Set<String> stringSet) {
+            this.stringSet = stringSet;
+        }
+
+        public SortedSet<String> getSortedStringSet() {
+            return sortedStringSet;
+        }
+
+        public void setSortedStringSet(SortedSet<String> sortedStringSet) {
+            this.sortedStringSet = sortedStringSet;
         }
 
         public List<String> getArrayFallback() {
@@ -269,7 +290,7 @@ public class BaseConfiguratorTest {
         Map<String, Class<?>> resolvedAttributes =
                 attributes.stream().collect(Collectors.toMap(Attribute::getName, attr -> (Class<?>) attr.getType()));
 
-        assertEquals("Should discover exactly 22 configurable properties", 22, resolvedAttributes.size());
+        assertEquals("Should discover exactly 24 configurable properties", 24, resolvedAttributes.size());
 
         assertEquals("Standard setter should resolve to String", String.class, resolvedAttributes.get("standard"));
 
@@ -363,6 +384,8 @@ public class BaseConfiguratorTest {
                         "ambiguous",
                         "mismatchedToken",
                         "items",
+                        "stringSet",
+                        "sortedStringSet",
                         "arrayFallback",
                         "shapeSubtype",
                         "concreteWins",
@@ -403,6 +426,40 @@ public class BaseConfiguratorTest {
         assertNotNull("Array should have been set", result);
         assertEquals("Array should have the same size as the collection", 3, result.length);
         assertArrayEquals(new String[] {"foo", "bar", "baz"}, result);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testCollectionToSetConversions() throws Exception {
+        DummyConfigurator configurator = new DummyConfigurator();
+        Set<Attribute<DummyTarget, ?>> attributes = configurator.describe();
+
+        Attribute<DummyTarget, ?> setAttr = attributes.stream()
+                .filter(a -> a.getName().equals("stringSet"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("stringSet attribute not found"));
+
+        Attribute<DummyTarget, ?> sortedSetAttr = attributes.stream()
+                .filter(a -> a.getName().equals("sortedStringSet"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("sortedStringSet attribute not found"));
+
+        DummyTarget target = new DummyTarget();
+
+        List<String> inputCollection = Arrays.asList("foo", "bar", "baz");
+
+        ((Attribute) setAttr).setValue(target, inputCollection);
+        ((Attribute) sortedSetAttr).setValue(target, inputCollection);
+
+        Set<String> setResult = target.getStringSet();
+        assertNotNull("Set should have been populated", setResult);
+        assertEquals("Set should be converted to LinkedHashSet", LinkedHashSet.class, setResult.getClass());
+        assertEquals("Set should have 3 items", 3, setResult.size());
+
+        SortedSet<String> sortedSetResult = target.getSortedStringSet();
+        assertNotNull("SortedSet should have been populated", sortedSetResult);
+        assertEquals("SortedSet should be converted to TreeSet", TreeSet.class, sortedSetResult.getClass());
+        assertEquals("SortedSet should have 3 items", 3, sortedSetResult.size());
     }
 
     @Test


### PR DESCRIPTION
Fixes #2828 

Fixes IllegalArgumentException when configuring collection-based attributes like disabledAdministrativeMonitors. Previously, it passed a List to setters expecting Set/SortedSet, causing a runtime type mismatch. This change converts collections to the appropriate type (LinkedHashSet or TreeSet) before invoking the setter.

Verified manually using mvn hpi:run with a configuration including disabledAdministrativeMonitors. Jenkins starts successfully, and the configuration is correctly applied and exported.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test case? That demonstrates a feature that works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
