### PR TITLE
Update ConfigurationAsCode category and exception handling

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -143,12 +143,10 @@ public class ConfigurationAsCode extends ManagementLink {
         return "Reload your configuration or update configuration source.";
     }
 
-    /**
-     * Name of the category for this management link.
-     * TODO: Use getCategory when core requirement is greater or equal to 2.226
-     */
-    public @NonNull String getCategoryName() {
-        return "CONFIGURATION";
+    @NonNull
+    @Override
+    public Category getCategory() {
+        return Category.CONFIGURATION;
     }
 
     @NonNull
@@ -228,7 +226,7 @@ public class ConfigurationAsCode extends ManagementLink {
                     candidateSources.add(candidateSource);
                 } else {
                     LOGGER.log(Level.WARNING, "Source {0} could not be applied", candidateSource);
-                    // todo: show message in UI
+                    throw new ConfiguratorException("Source " + candidateSource + " could not be applied or does not exist.");
                 }
             }
             if (!candidateSources.isEmpty()) {
@@ -244,7 +242,7 @@ public class ConfigurationAsCode extends ManagementLink {
                     LOGGER.log(Level.FINE, "Replace configuration with: " + normalizedSource);
                 } else {
                     LOGGER.log(Level.WARNING, "Provided sources could not be applied");
-                    // todo: show message in UI
+                    throw new ConfiguratorException("Provided sources could not be applied. Please check the syntax and validity of the provided configuration.");
                 }
             } else {
                 LOGGER.log(Level.FINE, "No such source exists, applying default");
@@ -453,7 +451,9 @@ public class ConfigurationAsCode extends ManagementLink {
                     URL bundled = servletContext.getResource(cascItem);
                     if (bundled != null && matcher.matches(new File(bundled.getPath()).toPath())) {
                         res.add(bundled.toString());
-                    } // TODO: else do some handling?
+                    } else if (bundled != null) {
+                        LOGGER.log(Level.FINE, "Skipped bundled resource {0} as it does not match the YAML pattern.", bundled.getPath());
+                    }
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, "Failed to execute " + res, e);
                 }
@@ -569,23 +569,7 @@ public class ConfigurationAsCode extends ManagementLink {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         export(out);
 
-        req.setAttribute("viewExport", new ManagementLink() {
-            @Override
-            public String getIconFileName() {
-                return "";
-            }
-
-            // TODO - FIX - EXTREMELY HACKY - couldn't expose a public method for some reason
-            @Override
-            public String getUrlName() {
-                return out.toString(StandardCharsets.UTF_8);
-            }
-
-            @Override
-            public String getDisplayName() {
-                return "Export configuration";
-            }
-        });
+        req.setAttribute("exportedYaml", out.toString(StandardCharsets.UTF_8));
         req.getView(this, "viewExport.jelly").forward(req, res);
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -226,7 +226,8 @@ public class ConfigurationAsCode extends ManagementLink {
                     candidateSources.add(candidateSource);
                 } else {
                     LOGGER.log(Level.WARNING, "Source {0} could not be applied", candidateSource);
-                    throw new ConfiguratorException("Source " + candidateSource + " could not be applied or does not exist.");
+                    throw new ConfiguratorException(
+                            "Source " + candidateSource + " could not be applied or does not exist.");
                 }
             }
             if (!candidateSources.isEmpty()) {
@@ -242,7 +243,8 @@ public class ConfigurationAsCode extends ManagementLink {
                     LOGGER.log(Level.FINE, "Replace configuration with: " + normalizedSource);
                 } else {
                     LOGGER.log(Level.WARNING, "Provided sources could not be applied");
-                    throw new ConfiguratorException("Provided sources could not be applied. Please check the syntax and validity of the provided configuration.");
+                    throw new ConfiguratorException(
+                            "Provided sources could not be applied. Please check the syntax and validity of the provided configuration.");
                 }
             } else {
                 LOGGER.log(Level.FINE, "No such source exists, applying default");
@@ -452,7 +454,10 @@ public class ConfigurationAsCode extends ManagementLink {
                     if (bundled != null && matcher.matches(new File(bundled.getPath()).toPath())) {
                         res.add(bundled.toString());
                     } else if (bundled != null) {
-                        LOGGER.log(Level.FINE, "Skipped bundled resource {0} as it does not match the YAML pattern.", bundled.getPath());
+                        LOGGER.log(
+                                Level.FINE,
+                                "Skipped bundled resource {0} as it does not match the YAML pattern.",
+                                bundled.getPath());
                     }
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, "Failed to execute " + res, e);

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/viewExport.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/viewExport.jelly
@@ -11,7 +11,7 @@
     </l:view>
   </j:set>
 
-  <l:settings-subpage includeBreadcrumb="true" header="${header}">
+  <l:settings-subpage includeBreadcrumb="true" header="${header}" title="${%Export configuration}">
     <st:adjunct includes="io.jenkins.plugins.casc.assets.viewExport" />
 
     <div class="jenkins-alert jenkins-alert-info">

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/viewExport.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/ConfigurationAsCode/viewExport.jelly
@@ -3,7 +3,7 @@
   xmlns:f="/lib/form">
   <j:set var="header">
     <l:view>
-      <l:app-bar title="${viewExport.displayName}">
+      <l:app-bar title="${%Export configuration}">
         <f:form method="post" action="export" name="export">
           <f:submit icon="symbol-download" primary="false" name="export" value="${%Download}"/>
         </f:form>
@@ -11,7 +11,7 @@
     </l:view>
   </j:set>
 
-  <l:settings-subpage includeBreadcrumb="true" header="${header}" managementLink="${viewExport}" noDefer="true">
+  <l:settings-subpage includeBreadcrumb="true" header="${header}">
     <st:adjunct includes="io.jenkins.plugins.casc.assets.viewExport" />
 
     <div class="jenkins-alert jenkins-alert-info">
@@ -20,7 +20,7 @@
 
     <p:prism configuration="${it.prismConfiguration}" />
     <pre>
-      <code class="language-yaml">${viewExport.urlName}</code>
+      <code class="language-yaml">${exportedYaml}</code>
     </pre>
   </l:settings-subpage>
 </j:jelly>

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
@@ -5,10 +5,14 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import jenkins.model.Jenkins;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
 import org.htmlunit.WebResponse;
+import org.htmlunit.util.NameValuePair;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -157,6 +161,28 @@ public class ConfigurationAsCodeApiTest {
                     .getWebResponse();
             assertThat(response2.getStatusCode(), is(200));
             assertThat(j.jenkins.getSystemMessage(), is("Idempotency Test"));
+        }
+    }
+
+    @Test
+    public void testDoReplace_ValidSource() throws Exception {
+        configureAdminSecurity();
+
+        Path configFile = Files.createTempFile("valid", ".yaml");
+        Files.writeString(configFile, "jenkins:\n  systemMessage: 'Hello Replace'");
+
+        try (JenkinsRule.WebClient wc = j.createWebClient().withBasicApiToken(ADMIN)) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+
+            WebRequest request =
+                    new WebRequest(new URL(j.getURL(), "manage/configuration-as-code/replace"), HttpMethod.POST);
+
+            request.setRequestParameters(List.of(new NameValuePair("_.newSource", configFile.toString())));
+
+            WebResponse response = wc.getPage(request).getWebResponse();
+
+            assertThat(response.getStatusCode(), is(200));
+            assertThat(j.jenkins.getSystemMessage(), is("Hello Replace"));
         }
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
@@ -1,7 +1,10 @@
 package io.jenkins.plugins.casc;
 
+import static hudson.model.ManagementLink.Category.CONFIGURATION;
+import static jenkins.model.Jenkins.ADMINISTER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
@@ -86,5 +90,46 @@ class ErrorPageTest {
         assertThat(pageContent, containsString("securityRealm"));
         assertThat(pageContent, containsString("Attribute was:"));
         assertThat(pageContent, containsString("unknown"));
+    }
+
+    @Test
+    void replaceWithInvalidSource() throws Exception {
+        String pageContent = replaceConfiguration();
+
+        assertThat(
+                pageContent, containsString("Source non-existent-file.yaml could not be applied or does not exist."));
+    }
+
+    private String replaceConfiguration() throws Exception {
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        r.jenkins.setAuthorizationStrategy(
+                new MockAuthorizationStrategy().grant(ADMINISTER).everywhere().to("admin"));
+
+        try (WebClient webClient = r.createWebClient().withThrowExceptionOnFailingStatusCode(false)) {
+            webClient.login("admin", "admin");
+
+            HtmlPage htmlPage = webClient.goTo("manage/configuration-as-code/");
+
+            HtmlButton button = (HtmlButton) htmlPage.getElementById("btn-open-apply-configuration");
+            HtmlElementUtil.click(button);
+
+            HtmlForm replaceForm = htmlPage.getFormByName("replace");
+            replaceForm.getInputByName("_.newSource").setValue("non-existent-file.yaml");
+
+            HtmlPage submit = r.submit(replaceForm);
+
+            return submit.asNormalizedText();
+        }
+    }
+
+    @Test
+    void verifyManagementLinkProperties() {
+        ConfigurationAsCode casc = ConfigurationAsCode.get();
+
+        assertEquals(CONFIGURATION, casc.getCategory());
+
+        assertEquals("configuration-as-code", casc.getUrlName());
+        assertEquals("Configuration as Code", casc.getDisplayName());
+        assertEquals("symbol-logo plugin-configuration-as-code", casc.getIconFileName());
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
@@ -1,10 +1,8 @@
 package io.jenkins.plugins.casc;
 
-import static hudson.model.ManagementLink.Category.CONFIGURATION;
 import static jenkins.model.Jenkins.ADMINISTER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,16 +118,5 @@ class ErrorPageTest {
 
             return submit.asNormalizedText();
         }
-    }
-
-    @Test
-    void verifyManagementLinkProperties() {
-        ConfigurationAsCode casc = ConfigurationAsCode.get();
-
-        assertEquals(CONFIGURATION, casc.getCategory());
-
-        assertEquals("configuration-as-code", casc.getUrlName());
-        assertEquals("Configuration as Code", casc.getDisplayName());
-        assertEquals("symbol-logo plugin-configuration-as-code", casc.getIconFileName());
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.casc;
 
-import static hudson.model.ManagementLink.Category.CONFIGURATION;
 import static io.jenkins.plugins.casc.ConfigurationAsCode.CASC_JENKINS_CONFIG_PROPERTY;
 import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
@@ -339,12 +338,6 @@ class ConfigurationAsCodeTest {
         String actualDocString = ConfigurationAsCode.get()
                 .getHtmlHelp(hudson.security.FullControlOnceLoggedInAuthorizationStrategy.class, "allowAnonymousRead");
         assertEquals(expectedDocString, actualDocString);
-    }
-
-    @Test
-    void configurationCategory(JenkinsConfiguredWithCodeRule j) {
-        ConfigurationAsCode configurationAsCode = ConfigurationAsCode.get();
-        assertThat(configurationAsCode.getCategory(), is(CONFIGURATION));
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.casc;
 
+import static hudson.model.ManagementLink.Category.CONFIGURATION;
 import static io.jenkins.plugins.casc.ConfigurationAsCode.CASC_JENKINS_CONFIG_PROPERTY;
 import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
@@ -343,7 +344,7 @@ class ConfigurationAsCodeTest {
     @Test
     void configurationCategory(JenkinsConfiguredWithCodeRule j) {
         ConfigurationAsCode configurationAsCode = ConfigurationAsCode.get();
-        assertThat(configurationAsCode.getCategory(), is("CONFIGURATION"));
+        assertThat(configurationAsCode.getCategory(), is(CONFIGURATION));
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeTest.java
@@ -343,7 +343,7 @@ class ConfigurationAsCodeTest {
     @Test
     void configurationCategory(JenkinsConfiguredWithCodeRule j) {
         ConfigurationAsCode configurationAsCode = ConfigurationAsCode.get();
-        assertThat(configurationAsCode.getCategoryName(), is("CONFIGURATION"));
+        assertThat(configurationAsCode.getCategory(), is("CONFIGURATION"));
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {


### PR DESCRIPTION
This PR updates the Configuration as Code management link and improves related error handling

Changes included:

- Category Update: Replaced the legacy getCategoryName() string method with the modern getCategory() API
- Exception Handling: Replaced generic TODO comments in doReplace() with thrown ConfiguratorExceptions.
- Cleaned up View Export: Removed the hacky dummy ManagementLink object in doViewExport(). The exported YAML is now passed securely as a standard request attribute to viewExport.jelly.
- Added Debug Logging: Added FINE level logging when skipping non-YAML bundled resources.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature that works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
