### PR TITLE
Refactor SecretSourceResolver map initialization and clarify UpdateCenterConfigurator intent

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -10,8 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -38,18 +36,25 @@ public class SecretSourceResolver {
     private final StringSubstitutor substitutor;
 
     public SecretSourceResolver(ConfigurationContext configurationContext) {
-        // TODO update to use Map.of in JDK11+
-        Map<String, org.apache.commons.text.lookup.StringLookup> map = new HashMap<>(16);
-        map.put("base64", Base64Lookup.INSTANCE);
-        map.put("fileBase64", FileBase64Lookup.INSTANCE);
-        map.put("readFileBase64", FileBase64Lookup.INSTANCE);
-        map.put("file", FileStringLookup.INSTANCE);
-        map.put("readFile", FileStringLookup.INSTANCE);
-        map.put("sysProp", SystemPropertyLookup.INSTANCE);
-        map.put("decodeBase64", DecodeBase64Lookup.INSTANCE);
-        map.put("json", JsonLookup.INSTANCE);
-        map.put("trim", TrimLookup.INSTANCE);
-        map = Collections.unmodifiableMap(map);
+        Map<String, StringLookup> map = Map.of(
+                "base64",
+                Base64Lookup.INSTANCE,
+                "fileBase64",
+                FileBase64Lookup.INSTANCE,
+                "readFileBase64",
+                FileBase64Lookup.INSTANCE,
+                "file",
+                FileStringLookup.INSTANCE,
+                "readFile",
+                FileStringLookup.INSTANCE,
+                "sysProp",
+                SystemPropertyLookup.INSTANCE,
+                "decodeBase64",
+                DecodeBase64Lookup.INSTANCE,
+                "json",
+                JsonLookup.INSTANCE,
+                "trim",
+                TrimLookup.INSTANCE);
 
         substitutor = new StringSubstitutor(new FixedInterpolatorStringLookup(
                         map, new ConfigurationContextStringLookup(configurationContext)))

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/UpdateCenterConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/UpdateCenterConfigurator.java
@@ -17,9 +17,6 @@ import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-/**
- * TODO would  not be required if UpdateCenter had a DataBoundConstructor
- */
 @Extension
 @Restricted(NoExternalUse.class)
 public class UpdateCenterConfigurator extends BaseConfigurator<UpdateCenter> {


### PR DESCRIPTION
Refactor map initialization in SecretSourceResolver by replacing the manual map.put usage with Map.of and removed outdated TODO in UpdateCenterConfigurator and clarified intent, since UpdateCenter is a Jenkins singleton and not a DataBound bean.

<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test case? That demonstrates a feature that works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
