### PR TITLE
Resolve Descriptor generic type to derive natural names in DescriptorConfigurator

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
@@ -94,19 +94,18 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor>
                     && Descriptor.class.isAssignableFrom(rawClass)) {
 
                 Type[] args = pt.getActualTypeArguments();
-                if (args.length == 0) {
-                    return null;
-                }
 
-                Type typeArg = args[0];
+                if (args.length > 0) {
+                    Type typeArg = args[0];
 
-                if (typeArg instanceof Class<?> clazzArg) {
-                    return clazzArg;
-                }
+                    if (typeArg instanceof Class<?> clazzArg) {
+                        return clazzArg;
+                    }
 
-                if (typeArg instanceof ParameterizedType nestedPt
-                        && nestedPt.getRawType() instanceof Class<?> nestedClass) {
-                    return nestedClass;
+                    if (typeArg instanceof ParameterizedType nestedPt
+                            && nestedPt.getRawType() instanceof Class<?> nestedClass) {
+                        return nestedClass;
+                    }
                 }
             }
             clazz = clazz.getSuperclass();
@@ -115,9 +114,6 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor>
     }
 
     private static String fromPascalCaseToCamelCase(String s) {
-        if (s == null || s.isEmpty()) {
-            throw new IllegalStateException("Cannot derive configurator name from an empty class name");
-        }
         StringBuilder sb = new StringBuilder(s);
         sb.setCharAt(0, Character.toLowerCase(s.charAt(0)));
         return sb.toString();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
@@ -8,6 +8,8 @@ import io.jenkins.plugins.casc.BaseConfigurator;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.RootElementConfigurator;
 import io.jenkins.plugins.casc.model.Mapping;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -64,15 +66,53 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor>
         return Optional.ofNullable(descriptor.getClass().getAnnotation(Symbol.class))
                 .map(s -> Arrays.asList(s.value()))
                 .orElseGet(() -> {
-                    /* TODO: extract Descriptor parameter type such that DescriptorImpl extends Descriptor<XX> returns XX.
-                     * Then, if `baseClass == fooXX` we get natural name `foo`.
-                     */
-                    return singletonList(fromPascalCaseToCamelCase(
-                            descriptor.getKlass().toJavaClass().getSimpleName()));
+                    Class<?> typeParam = extractDescriptorTypeParameter(descriptor.getClass());
+
+                    Class<?> targetClass = typeParam != null
+                            ? typeParam
+                            : descriptor.getKlass().toJavaClass();
+
+                    while (targetClass.isAnonymousClass()) {
+                        targetClass = targetClass.getSuperclass();
+                    }
+
+                    return singletonList(fromPascalCaseToCamelCase(targetClass.getSimpleName()));
                 });
     }
 
+    private Class<?> extractDescriptorTypeParameter(Class<?> clazz) {
+        while (clazz != null && clazz != Object.class) {
+            Type genericSuperclass = clazz.getGenericSuperclass();
+
+            if (genericSuperclass instanceof ParameterizedType pt) {
+                Type rawType = pt.getRawType();
+
+                if (rawType instanceof Class && Descriptor.class.isAssignableFrom((Class<?>) rawType)) {
+                    Type[] args = pt.getActualTypeArguments();
+
+                    if (args.length > 0) {
+                        Type typeArg = args[0];
+
+                        if (typeArg instanceof Class) {
+                            return (Class<?>) typeArg;
+                        } else if (typeArg instanceof ParameterizedType) {
+                            Type nestedRawType = ((ParameterizedType) typeArg).getRawType();
+                            if (nestedRawType instanceof Class) {
+                                return (Class<?>) nestedRawType;
+                            }
+                        }
+                    }
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return null;
+    }
+
     private static String fromPascalCaseToCamelCase(String s) {
+        if (s == null || s.isEmpty()) {
+            return s != null ? s : "";
+        }
         StringBuilder sb = new StringBuilder(s);
         sb.setCharAt(0, Character.toLowerCase(s.charAt(0)));
         return sb.toString();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
@@ -84,24 +84,24 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor>
         while (clazz != null && clazz != Object.class) {
             Type genericSuperclass = clazz.getGenericSuperclass();
 
-            if (genericSuperclass instanceof ParameterizedType pt) {
-                Type rawType = pt.getRawType();
+            if (genericSuperclass instanceof ParameterizedType pt
+                    && pt.getRawType() instanceof Class<?> rawClass
+                    && Descriptor.class.isAssignableFrom(rawClass)) {
 
-                if (rawType instanceof Class && Descriptor.class.isAssignableFrom((Class<?>) rawType)) {
-                    Type[] args = pt.getActualTypeArguments();
+                Type[] args = pt.getActualTypeArguments();
+                if (args.length == 0) {
+                    return null;
+                }
 
-                    if (args.length > 0) {
-                        Type typeArg = args[0];
+                Type typeArg = args[0];
 
-                        if (typeArg instanceof Class) {
-                            return (Class<?>) typeArg;
-                        } else if (typeArg instanceof ParameterizedType) {
-                            Type nestedRawType = ((ParameterizedType) typeArg).getRawType();
-                            if (nestedRawType instanceof Class) {
-                                return (Class<?>) nestedRawType;
-                            }
-                        }
-                    }
+                if (typeArg instanceof Class<?> clazzArg) {
+                    return clazzArg;
+                }
+
+                if (typeArg instanceof ParameterizedType nestedPt
+                        && nestedPt.getRawType() instanceof Class<?> nestedClass) {
+                    return nestedClass;
                 }
             }
             clazz = clazz.getSuperclass();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfigurator.java
@@ -66,17 +66,22 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor>
         return Optional.ofNullable(descriptor.getClass().getAnnotation(Symbol.class))
                 .map(s -> Arrays.asList(s.value()))
                 .orElseGet(() -> {
+                    String fallbackName = fromPascalCaseToCamelCase(
+                            unwrapAnonymous(descriptor.getKlass().toJavaClass()).getSimpleName());
+
                     Class<?> typeParam = extractDescriptorTypeParameter(descriptor.getClass());
+                    String derivedName = null;
 
-                    Class<?> targetClass = typeParam != null
-                            ? typeParam
-                            : descriptor.getKlass().toJavaClass();
-
-                    while (targetClass.isAnonymousClass()) {
-                        targetClass = targetClass.getSuperclass();
+                    if (typeParam != null) {
+                        Class<?> targetClass = unwrapAnonymous(typeParam);
+                        derivedName = fromPascalCaseToCamelCase(targetClass.getSimpleName());
                     }
 
-                    return singletonList(fromPascalCaseToCamelCase(targetClass.getSimpleName()));
+                    if (derivedName != null && !derivedName.equals(fallbackName)) {
+                        return Arrays.asList(fallbackName, derivedName);
+                    }
+
+                    return singletonList(fallbackName);
                 });
     }
 
@@ -111,10 +116,17 @@ public class DescriptorConfigurator extends BaseConfigurator<Descriptor>
 
     private static String fromPascalCaseToCamelCase(String s) {
         if (s == null || s.isEmpty()) {
-            return s != null ? s : "";
+            throw new IllegalStateException("Cannot derive configurator name from an empty class name");
         }
         StringBuilder sb = new StringBuilder(s);
         sb.setCharAt(0, Character.toLowerCase(s.charAt(0)));
         return sb.toString();
+    }
+
+    private Class<?> unwrapAnonymous(Class<?> clazz) {
+        while (clazz.isAnonymousClass()) {
+            clazz = clazz.getSuperclass();
+        }
+        return clazz;
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/DescriptorConfiguratorTest.java
@@ -1,0 +1,114 @@
+package io.jenkins.plugins.casc.impl.configurators;
+
+import static org.junit.Assert.assertEquals;
+
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import java.util.Arrays;
+import java.util.Collections;
+import org.jenkinsci.Symbol;
+import org.junit.Test;
+
+public class DescriptorConfiguratorTest {
+
+    public static class DummyTask implements Describable<DummyTask> {
+        @Override
+        public Descriptor<DummyTask> getDescriptor() {
+            throw new UnsupportedOperationException("Not required for name extraction tests");
+        }
+    }
+
+    public static class ParameterizedTask<T> implements Describable<ParameterizedTask<T>> {
+        @Override
+        public Descriptor<ParameterizedTask<T>> getDescriptor() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static class DummyTaskDescriptor extends Descriptor<DummyTask> {
+        public DummyTaskDescriptor() {
+            super(DummyTask.class);
+        }
+    }
+
+    @Symbol({"primary", "alias"})
+    public static class MultiSymbolDescriptor extends Descriptor<DummyTask> {
+        public MultiSymbolDescriptor() {
+            super(DummyTask.class);
+        }
+    }
+
+    public abstract static class SimulatedBuildStepDescriptor<T extends Describable<T>> extends Descriptor<T> {
+        protected SimulatedBuildStepDescriptor(Class<? extends T> clazz) {
+            super(clazz);
+        }
+    }
+
+    public static class DeepTaskDescriptor extends SimulatedBuildStepDescriptor<DummyTask> {
+        public DeepTaskDescriptor() {
+            super(DummyTask.class);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static class ParameterizedDescriptor extends Descriptor<ParameterizedTask<String>> {
+        public ParameterizedDescriptor() {
+            super((Class) ParameterizedTask.class);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static class RawDescriptor extends Descriptor {
+        @SuppressWarnings("unchecked")
+        public RawDescriptor(Class clazz) {
+            super(clazz);
+        }
+    }
+
+    @Test
+    public void testMultipleSymbols() {
+        DescriptorConfigurator configurator = new DescriptorConfigurator(new MultiSymbolDescriptor());
+
+        assertEquals("Should use the first symbol as primary name", "primary", configurator.getName());
+        assertEquals(
+                "Should return all symbols as aliases", Arrays.asList("primary", "alias"), configurator.getNames());
+    }
+
+    @Test
+    public void testNameResolvedFromGenericExtraction() {
+        DescriptorConfigurator configurator = new DescriptorConfigurator(new DummyTaskDescriptor());
+
+        assertEquals("Should extract 'DummyTask' and convert to camelCase", "dummyTask", configurator.getName());
+        assertEquals(Collections.singletonList("dummyTask"), configurator.getNames());
+    }
+
+    @Test
+    public void testNameResolvedFromParameterizedType() {
+        DescriptorConfigurator configurator = new DescriptorConfigurator(new ParameterizedDescriptor());
+
+        assertEquals(
+                "Should unwrap ParameterizedType to its raw class name", "parameterizedTask", configurator.getName());
+    }
+
+    @Test
+    public void testNameResolvedFromDeepInheritance() {
+        DescriptorConfigurator configurator = new DescriptorConfigurator(new DeepTaskDescriptor());
+
+        assertEquals(
+                "Should bypass type erasure and extract from superclass hierarchy",
+                "dummyTask",
+                configurator.getName());
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void testFallbackWithAnonymousTargetClass() {
+
+        Class<?> anonymousTarget = new DummyTask() {}.getClass();
+        Descriptor rawDescriptor = new RawDescriptor(anonymousTarget);
+        DescriptorConfigurator configurator = new DescriptorConfigurator(rawDescriptor);
+
+        assertEquals(
+                "Should unwrap anonymous target class via the fallback logic", "dummyTask", configurator.getName());
+    }
+}


### PR DESCRIPTION
Derive Descriptor names from the generic type when `@Symbol`is absent. Resolve TODO in DescriptorConfigurator by extracting Descriptor<T> type parameter to compute default camelCase names. Includes fallback handling and anonymous class support

Added unit tests covering:
- `@Symbol`-based name resolution
- Generic type extraction
- Parameterized types
- Deep inheritance hierarchies
- Fallback behavior (including anonymous classes)
<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
