### PR TITLE
Refactor GlobalConfigurationCategoryConfigurator to remove raw type cast in describe()

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/GlobalConfigurationCategoryConfigurator.java
@@ -80,17 +80,22 @@ public class GlobalConfigurationCategoryConfigurator extends BaseConfigurator<Gl
         return category;
     }
 
-    @SuppressWarnings("RedundantCast") // TODO remove once we are on JDK 11
     @NonNull
     @Override
-    public Set describe() {
-        return (Set) Jenkins.get().getExtensionList(Descriptor.class).stream()
+    public Set<Attribute<GlobalConfigurationCategory, ?>> describe() {
+        return Jenkins.get().getExtensionList(Descriptor.class).stream()
                 .filter(d -> d.getCategory() == category)
                 .filter(d -> d.getGlobalConfigPage() != null)
                 .map(DescriptorConfigurator::new)
                 .filter(GlobalConfigurationCategoryConfigurator::reportDescriptorWithoutSetters)
-                .map(c -> new Attribute<GlobalConfigurationCategory, Object>(c.getNames(), c.getTarget()).setter(NOP))
+                .map(c -> new Attribute<GlobalConfigurationCategory, Object>(c.getNames(), c.getTarget())
+                        .setter(typedNop()))
                 .collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T, V> Attribute.Setter<T, V> typedNop() {
+        return (Attribute.Setter<T, V>) NOP;
     }
 
     public static boolean reportDescriptorWithoutSetters(Configurator c) {


### PR DESCRIPTION
Refactor GlobalConfigurationCategoryConfigurator.describe() to eliminate raw types and remove the redundant cast required for pre-JDK 11 compatibility by introducing generics (Set<Attribute<GlobalConfigurationCategory, ?>>). Replace the inline unchecked cast of NOP with a helper method (typedNop()) that encapsulates the suppression, keeps the code clean, and maintains existing behavior.

<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test case? That demonstrates a feature that works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
