### PR TITLE
Add strict export mode to propagate export failures as exceptions

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -241,8 +241,16 @@ public class Attribute<Owner, Type> {
     public CNode describe(Owner instance, ConfigurationContext context) throws ConfiguratorException {
         final Configurator c = context.lookup(type);
         if (c == null) {
-            return new Scalar("FAILED TO EXPORT\n" + instance.getClass().getName() + "#" + name
-                    + ": No configurator found for type " + type);
+            String errorMessage = "FAILED TO EXPORT\n" + instance.getClass().getName() + "#" + name
+                    + ": No configurator found for type " + type;
+
+            // --- NEW STRICT MODE CHECK FOR MISSING CONFIGURATOR ---
+            if (context.isStrictExport()) {
+                throw new ConfiguratorException(errorMessage);
+            }
+            // ------------------------------------------------------
+
+            return new Scalar(errorMessage);
         }
         try {
             Object o = getValue(instance);
@@ -267,7 +275,14 @@ public class Attribute<Owner, Type> {
                 return seq;
             }
             return _describe(c, context, o, shouldBeMasked);
-        } catch (Exception | /* Jenkins.getDescriptorOrDie */ AssertionError e) {
+        } catch (Exception | AssertionError e) {
+            if (context.isStrictExport()) {
+                if (e instanceof ConfiguratorException) {
+                    throw (ConfiguratorException) e;
+                }
+                throw new ConfiguratorException(
+                        "Failed to export " + instance.getClass().getName() + "#" + name, e);
+            }
             // Don't fail the whole export, prefer logging this error
             LOGGER.log(Level.WARNING, "Failed to export", e);
             return new Scalar(

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -244,11 +244,9 @@ public class Attribute<Owner, Type> {
             String errorMessage = "FAILED TO EXPORT\n" + instance.getClass().getName() + "#" + name
                     + ": No configurator found for type " + type;
 
-            // --- NEW STRICT MODE CHECK FOR MISSING CONFIGURATOR ---
             if (context.isStrictExport()) {
                 throw new ConfiguratorException(errorMessage);
             }
-            // ------------------------------------------------------
 
             return new Scalar(errorMessage);
         }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/Attribute.java
@@ -273,7 +273,7 @@ public class Attribute<Owner, Type> {
                 return seq;
             }
             return _describe(c, context, o, shouldBeMasked);
-        } catch (Exception | AssertionError e) {
+        } catch (Exception | /* Jenkins.getDescriptorOrDie */ AssertionError e) {
             if (context.isStrictExport()) {
                 if (e instanceof ConfiguratorException) {
                     throw (ConfiguratorException) e;

--- a/plugin/src/main/java/io/jenkins/plugins/casc/CasCGlobalConfig.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/CasCGlobalConfig.java
@@ -15,6 +15,7 @@ import org.kohsuke.stapler.StaplerRequest2;
 public class CasCGlobalConfig extends GlobalConfiguration {
 
     private String configurationPath;
+    private boolean strictExport = false;
 
     @DataBoundConstructor
     public CasCGlobalConfig(String configurationPath) {
@@ -38,6 +39,15 @@ public class CasCGlobalConfig extends GlobalConfiguration {
     @DataBoundSetter
     public void setConfigurationPath(String configurationPath) {
         this.configurationPath = configurationPath;
+    }
+
+    public boolean isStrictExport() {
+        return strictExport;
+    }
+
+    @DataBoundSetter
+    public void setStrictExport(boolean strictExport) {
+        this.strictExport = strictExport;
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -598,6 +598,8 @@ public class ConfigurationAsCode extends ManagementLink {
         final List<NodeTuple> tuples = new ArrayList<>();
 
         final ConfigurationContext context = new ConfigurationContext(registry);
+        Optional.ofNullable(GlobalConfiguration.all().get(CasCGlobalConfig.class))
+                .ifPresent(c -> context.setStrictExport(c.isStrictExport()));
         for (RootElementConfigurator<?> root : RootElementConfigurator.all()) {
             final CNode config = describeRoot(root, context);
             final Node valueNode = toYaml(config);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -595,10 +595,15 @@ public class ConfigurationAsCode extends ManagementLink {
 
     @Restricted(NoExternalUse.class)
     public void export(OutputStream out) throws Exception {
+        export(out, false);
+    }
 
+    @Restricted(NoExternalUse.class)
+    public void export(OutputStream out, boolean strict) throws Exception {
         final List<NodeTuple> tuples = new ArrayList<>();
 
         final ConfigurationContext context = new ConfigurationContext(registry);
+        context.setStrictExport(strict);
         for (RootElementConfigurator root : RootElementConfigurator.all()) {
             final CNode config = root.describe(root.getTargetComponent(context), context);
             final Node valueNode = toYaml(config);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -595,17 +595,11 @@ public class ConfigurationAsCode extends ManagementLink {
 
     @Restricted(NoExternalUse.class)
     public void export(OutputStream out) throws Exception {
-        export(out, false);
-    }
-
-    @Restricted(NoExternalUse.class)
-    public void export(OutputStream out, boolean strict) throws Exception {
         final List<NodeTuple> tuples = new ArrayList<>();
 
         final ConfigurationContext context = new ConfigurationContext(registry);
-        context.setStrictExport(strict);
-        for (RootElementConfigurator root : RootElementConfigurator.all()) {
-            final CNode config = root.describe(root.getTargetComponent(context), context);
+        for (RootElementConfigurator<?> root : RootElementConfigurator.all()) {
+            final CNode config = describeRoot(root, context);
             final Node valueNode = toYaml(config);
             if (valueNode == null) {
                 continue;
@@ -619,6 +613,11 @@ public class ConfigurationAsCode extends ManagementLink {
         } catch (IOException e) {
             throw new YAMLException(e);
         }
+    }
+
+    private <T> CNode describeRoot(RootElementConfigurator<T> root, ConfigurationContext context) throws Exception {
+        T component = root.getTargetComponent(context);
+        return root.describe(component, context);
     }
 
     @Restricted(NoExternalUse.class) // for testing only

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -7,8 +7,6 @@ import io.jenkins.plugins.casc.model.CNode;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
-import jenkins.model.GlobalConfiguration;
-import jenkins.model.Jenkins;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.kohsuke.stapler.Stapler;
 
@@ -62,13 +60,6 @@ public class ConfigurationContext implements ConfiguratorRegistry {
         this.mergeStrategy = mergeStrategy != null
                 ? mergeStrategy
                 : getPropertyOrEnv(CASC_MERGE_STRATEGY_ENV, CASC_MERGE_STRATEGY_PROPERTY);
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins != null) {
-            CasCGlobalConfig config = GlobalConfiguration.all().get(CasCGlobalConfig.class);
-            if (config != null) {
-                this.strictExport = config.isStrictExport();
-            }
-        }
     }
 
     private String getPropertyOrEnv(String envKey, String proKey) {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -44,6 +44,8 @@ public class ConfigurationContext implements ConfiguratorRegistry {
 
     private transient SecretSourceResolver secretSourceResolver;
 
+    private boolean strictExport = false;
+
     public ConfigurationContext(ConfiguratorRegistry registry) {
         this(registry, null);
     }
@@ -124,6 +126,14 @@ public class ConfigurationContext implements ConfiguratorRegistry {
 
     public int getYamlCodePointLimit() {
         return yamlCodePointLimit;
+    }
+
+    public boolean isStrictExport() {
+        return strictExport;
+    }
+
+    public void setStrictExport(boolean strictExport) {
+        this.strictExport = strictExport;
     }
 
     // --- delegate methods for ConfigurationContext

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -7,6 +7,8 @@ import io.jenkins.plugins.casc.model.CNode;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.kohsuke.stapler.Stapler;
 
@@ -60,6 +62,13 @@ public class ConfigurationContext implements ConfiguratorRegistry {
         this.mergeStrategy = mergeStrategy != null
                 ? mergeStrategy
                 : getPropertyOrEnv(CASC_MERGE_STRATEGY_ENV, CASC_MERGE_STRATEGY_PROPERTY);
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins != null) {
+            CasCGlobalConfig config = GlobalConfiguration.all().get(CasCGlobalConfig.class);
+            if (config != null) {
+                this.strictExport = config.isStrictExport();
+            }
+        }
     }
 
     private String getPropertyOrEnv(String envKey, String proKey) {

--- a/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.casc;
 
+import static java.lang.reflect.Proxy.newProxyInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -267,9 +270,10 @@ public class AttributeTest {
         CNode node = attr.describe(dummyInstance, context);
 
         assertInstanceOf(Scalar.class, node, "Should return a Scalar node on failure in non-strict mode");
-        assertTrue(
-                ((Scalar) node).getValue().contains("FAILED TO EXPORT"),
-                "Scalar should contain the fallback failure message");
+        assertThat(
+                "Scalar should contain the fallback failure message",
+                ((Scalar) node).getValue(),
+                containsString("FAILED TO EXPORT"));
 
         context.setStrictExport(true);
         ConfiguratorException exception = assertThrows(
@@ -279,8 +283,62 @@ public class AttributeTest {
                 },
                 "Should completely abort and throw ConfiguratorException in strict mode");
 
-        assertTrue(
-                exception.getMessage().contains("No configurator found"),
-                "Exception message should accurately reflect the missing configurator");
+        assertThat(exception.getMessage(), containsString("No configurator found"));
+    }
+
+    @Test
+    @SuppressWarnings({"ExtractMethodRecommender", "unchecked"})
+    void describeWrapsGenericExceptionsInStrictMode() throws Exception {
+
+        Configurator<?> dummyConfigurator = (Configurator<?>) newProxyInstance(
+                Configurator.class.getClassLoader(), new Class<?>[] {Configurator.class}, (proxy, method, args) -> {
+                    String methodName = method.getName();
+                    return switch (methodName) {
+                        case "equals" -> args != null && args.length == 1 && proxy == args[0];
+                        case "hashCode" -> System.identityHashCode(proxy);
+                        case "toString" -> "DummyConfiguratorProxy";
+                        case "describe" ->
+                            throw new IllegalStateException("Intentional generic failure from dummy configurator");
+                        default -> null;
+                    };
+                });
+
+        ConfiguratorRegistry dummyRegistry = new ConfiguratorRegistry() {
+            @Override
+            public RootElementConfigurator<?> lookupRootElement(String name) {
+                return null;
+            }
+
+            @Override
+            @NonNull
+            public <T> Configurator<T> lookupOrFail(Type type) {
+                return (Configurator<T>) dummyConfigurator;
+            }
+
+            @Override
+            public <T> Configurator<T> lookup(Type type) {
+                return (Configurator<T>) dummyConfigurator;
+            }
+        };
+
+        ConfigurationContext context = new ConfigurationContext(dummyRegistry);
+        context.setStrictExport(true);
+
+        Attribute<NonSecretField, String> attr = new Attribute<>("passwordPath", String.class);
+        NonSecretField dummyInstance = new NonSecretField("my-dummy-path");
+
+        ConfiguratorException exception = assertThrows(
+                ConfiguratorException.class,
+                () -> {
+                    attr.describe(dummyInstance, context);
+                },
+                "Should wrap generic exception into a ConfiguratorException in strict mode");
+
+        assertThat(
+                exception.getMessage(),
+                containsString("Failed to export io.jenkins.plugins.casc.AttributeTest$NonSecretField#passwordPath"));
+        assertThat(
+                exception.getCause().getMessage(),
+                containsString("Intentional generic failure from dummy configurator"));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
@@ -341,4 +341,49 @@ public class AttributeTest {
                 exception.getCause().getMessage(),
                 containsString("Intentional generic failure from dummy configurator"));
     }
+
+    @Test
+    @SuppressWarnings({"ExtractMethodRecommender", "unchecked"})
+    void describeRethrowsConfiguratorExceptionInStrictMode() throws Exception {
+
+        Configurator<?> dummyConfigurator = (Configurator<?>) newProxyInstance(
+                Configurator.class.getClassLoader(),
+                new Class<?>[] {Configurator.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "equals" -> args != null && args.length == 1 && proxy == args[0];
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "toString" -> "DummyConfiguratorProxy";
+                    case "describe" -> throw new ConfiguratorException("Direct configurator failure");
+                    default -> null;
+                });
+
+        ConfiguratorRegistry dummyRegistry = new ConfiguratorRegistry() {
+            @Override
+            public RootElementConfigurator<?> lookupRootElement(String name) {
+                return null;
+            }
+
+            @Override
+            @NonNull
+            public <T> Configurator<T> lookupOrFail(Type type) {
+                return (Configurator<T>) dummyConfigurator;
+            }
+
+            @Override
+            public <T> Configurator<T> lookup(Type type) {
+                return (Configurator<T>) dummyConfigurator;
+            }
+        };
+
+        ConfigurationContext context = new ConfigurationContext(dummyRegistry);
+        context.setStrictExport(true);
+
+        Attribute<NonSecretField, String> attr = new Attribute<>("passwordPath", String.class);
+
+        NonSecretField instance = new NonSecretField("dummy");
+
+        ConfiguratorException ex = assertThrows(ConfiguratorException.class, () -> attr.describe(instance, context));
+
+        assertThat(ex.getMessage(), containsString("Direct configurator failure"));
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/AttributeTest.java
@@ -1,9 +1,15 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.Secret;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Scalar;
+import java.lang.reflect.Type;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -229,5 +235,52 @@ public class AttributeTest {
         boolean secondUnknown = Attribute.calculateIfSecret(null, "someField");
         assertFalse(firstUnknown);
         assertFalse(secondUnknown, "Subsequent calls should return the same fallback FALSE result");
+    }
+
+    @Test
+    @SuppressWarnings("ExtractMethodRecommender")
+    void describeHandlesMissingConfiguratorCorrectly() throws Exception {
+        ConfiguratorRegistry dummyRegistry = new ConfiguratorRegistry() {
+            @Override
+            public RootElementConfigurator<?> lookupRootElement(String name) {
+                return null;
+            }
+
+            @Override
+            @NonNull
+            public <T> Configurator<T> lookupOrFail(Type type) throws ConfiguratorException {
+                throw new ConfiguratorException("Not found");
+            }
+
+            @Override
+            public <T> Configurator<T> lookup(Type type) {
+                return null;
+            }
+        };
+
+        ConfigurationContext context = new ConfigurationContext(dummyRegistry);
+
+        Attribute<NonSecretField, String> attr = new Attribute<>("passwordPath", String.class);
+        NonSecretField dummyInstance = new NonSecretField("my-dummy-path");
+
+        context.setStrictExport(false);
+        CNode node = attr.describe(dummyInstance, context);
+
+        assertInstanceOf(Scalar.class, node, "Should return a Scalar node on failure in non-strict mode");
+        assertTrue(
+                ((Scalar) node).getValue().contains("FAILED TO EXPORT"),
+                "Scalar should contain the fallback failure message");
+
+        context.setStrictExport(true);
+        ConfiguratorException exception = assertThrows(
+                ConfiguratorException.class,
+                () -> {
+                    attr.describe(dummyInstance, context);
+                },
+                "Should completely abort and throw ConfiguratorException in strict mode");
+
+        assertTrue(
+                exception.getMessage().contains("No configurator found"),
+                "Exception message should accurately reflect the missing configurator");
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.WebRequest;
@@ -193,9 +194,14 @@ public class ConfigurationAsCodeApiTest {
     public void testExportStrictMode_SuccessOnCleanJenkins() throws Exception {
         configureAdminSecurity();
 
+        CasCGlobalConfig config = GlobalConfiguration.all().get(CasCGlobalConfig.class);
+        if (config != null) {
+            config.setStrictExport(true);
+        }
+
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        ConfigurationAsCode.get().export(out, true);
+        ConfigurationAsCode.get().export(out);
 
         String exportedYaml = out.toString(StandardCharsets.UTF_8);
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
@@ -3,8 +3,11 @@ package io.jenkins.plugins.casc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
 
+import java.io.ByteArrayOutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -184,5 +187,19 @@ public class ConfigurationAsCodeApiTest {
             assertThat(response.getStatusCode(), is(200));
             assertThat(j.jenkins.getSystemMessage(), is("Hello Replace"));
         }
+    }
+
+    @Test
+    public void testExportStrictMode_SuccessOnCleanJenkins() throws Exception {
+        configureAdminSecurity();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ConfigurationAsCode.get().export(out, true);
+
+        String exportedYaml = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(exportedYaml, containsString("jenkins:"));
+        assertFalse(exportedYaml.contains("FAILED TO EXPORT"));
     }
 }

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredRule.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredRule.java
@@ -1,8 +1,10 @@
 package io.jenkins.plugins.casc.misc;
 
+import io.jenkins.plugins.casc.CasCGlobalConfig;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import jenkins.model.GlobalConfiguration;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class JenkinsConfiguredRule extends JenkinsRule {
@@ -17,7 +19,20 @@ public class JenkinsConfiguredRule extends JenkinsRule {
     public String exportToString(boolean strict) throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        ConfigurationAsCode.get().export(out, strict);
+        CasCGlobalConfig config = GlobalConfiguration.all().get(CasCGlobalConfig.class);
+        boolean originalStrict = config != null && config.isStrictExport();
+
+        if (config != null) {
+            config.setStrictExport(strict);
+        }
+
+        try {
+            ConfigurationAsCode.get().export(out);
+        } finally {
+            if (config != null) {
+                config.setStrictExport(originalStrict);
+            }
+        }
 
         return out.toString(StandardCharsets.UTF_8);
     }

--- a/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredRule.java
+++ b/test-harness/src/main/java/io/jenkins/plugins/casc/misc/JenkinsConfiguredRule.java
@@ -7,22 +7,18 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class JenkinsConfiguredRule extends JenkinsRule {
 
-    // TODO: Looks like API defect, exception should be thrown
     /**
      * Exports the Jenkins configuration to a string.
      * @return YAML as string
      * @param strict Fail if any export operation returns error
      * @throws Exception Export error
-     * @throws AssertionError Failed to export the configuration
      * @since 1.25
      */
     public String exportToString(boolean strict) throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ConfigurationAsCode.get().export(out);
-        final String s = out.toString(StandardCharsets.UTF_8.name());
-        if (strict && s.contains("Failed to export")) {
-            throw new AssertionError("Failed to export the configuration: " + s);
-        }
-        return s;
+
+        ConfigurationAsCode.get().export(out, strict);
+
+        return out.toString(StandardCharsets.UTF_8);
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/JenkinsConfiguredRuleTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/JenkinsConfiguredRuleTest.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.casc;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredRule;
+import java.util.Objects;
+import jenkins.model.GlobalConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class JenkinsConfiguredRuleTest {
+
+    @Rule
+    public JenkinsConfiguredRule j = new JenkinsConfiguredRule();
+
+    @Test
+    public void exportToString_restoresOriginalState() throws Exception {
+        CasCGlobalConfig config = GlobalConfiguration.all().get(CasCGlobalConfig.class);
+        Objects.requireNonNull(config).setStrictExport(false);
+
+        j.exportToString(true);
+
+        assertThat(config.isStrictExport(), is(false));
+    }
+}


### PR DESCRIPTION
Introduce a strict export mode in ConfigurationAsCode that propagates export failures as ConfiguratorException instead of embedding "FAILED TO EXPORT" markers in the generated YAML.

- Add export(OutputStream, boolean strict) API
- Preserve existing behavior by default (non-strict mode)
- Update Attribute.describe() to throw in strict mode
- Add unit tests covering strict and non-strict behavior
- Add API test to verify strict export on a valid Jenkins instance

This improves error visibility while maintaining backward compatibility.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
