### PR TITLE
ISSUE-2682: Preserve the node state between instance restarts

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
@@ -5,6 +5,7 @@ import static io.jenkins.plugins.casc.Attribute.noop;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ProxyConfiguration;
+import hudson.model.Computer;
 import hudson.model.ComputerSet;
 import hudson.model.Descriptor;
 import hudson.model.Node;
@@ -13,6 +14,7 @@ import hudson.model.labels.LabelAtom;
 import hudson.node_monitors.NodeMonitor;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.EphemeralNode;
+import hudson.slaves.OfflineCause;
 import hudson.util.DescribableList;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.BaseConfigurator;
@@ -21,8 +23,6 @@ import io.jenkins.plugins.casc.RootElementConfigurator;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.vavr.control.Try;
-import hudson.model.Computer;
-import hudson.slaves.OfflineCause;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,7 +78,7 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
                     Set<String> configuredNodeNames =
                             configuredNodes.stream().map(Node::getNodeName).collect(Collectors.toSet());
 
-                    // Capture temporarily offline state before replacing nodes so it survives reload.
+                    // Capture offline state before replacing nodes so it survives reload.
                     // Jenkins core may reset Computer state when setNode() is called with a new instance.
                     Map<String, OfflineCause> previousOfflineCauses = new HashMap<>();
                     for (Node node : jenkins.getNodes()) {
@@ -97,7 +97,7 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
                     nodesToKeep.addAll(configuredNodes);
                     jenkins.setNodes(nodesToKeep);
 
-                    // Restore temporarily offline state for nodes that were offline before the reload.
+                    // Restore offline state for nodes that were offline before the reload.
                     previousOfflineCauses.forEach((name, cause) -> {
                         Computer computer = jenkins.getComputer(name);
                         if (computer != null) {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
@@ -21,9 +21,13 @@ import io.jenkins.plugins.casc.RootElementConfigurator;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.vavr.control.Try;
+import hudson.model.Computer;
+import hudson.slaves.OfflineCause;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -71,14 +75,35 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
                         .filter(node -> !isCloudNode(node))
                         .collect(Collectors.toList()))
                 .setter((jenkins, configuredNodes) -> {
-                    List<String> configuredNodesNames =
-                            configuredNodes.stream().map(Node::getNodeName).collect(Collectors.toList());
+                    Set<String> configuredNodeNames =
+                            configuredNodes.stream().map(Node::getNodeName).collect(Collectors.toSet());
+
+                    // Capture temporarily offline state before replacing nodes so it survives reload.
+                    // Jenkins core may reset Computer state when setNode() is called with a new instance.
+                    Map<String, OfflineCause> previousOfflineCauses = new HashMap<>();
+                    for (Node node : jenkins.getNodes()) {
+                        if (configuredNodeNames.contains(node.getNodeName())) {
+                            Computer computer = node.toComputer();
+                            if (computer != null && computer.isTemporarilyOffline()) {
+                                previousOfflineCauses.put(node.getNodeName(), computer.getOfflineCause());
+                            }
+                        }
+                    }
+
                     List<Node> nodesToKeep = jenkins.getNodes().stream()
-                            .filter(node -> !configuredNodesNames.contains(node.getNodeName()))
+                            .filter(node -> !configuredNodeNames.contains(node.getNodeName()))
                             .filter(this::isCloudNode)
                             .collect(Collectors.toList());
                     nodesToKeep.addAll(configuredNodes);
                     jenkins.setNodes(nodesToKeep);
+
+                    // Restore temporarily offline state for nodes that were offline before the reload.
+                    previousOfflineCauses.forEach((name, cause) -> {
+                        Computer computer = jenkins.getComputer(name);
+                        if (computer != null) {
+                            computer.setTemporarilyOffline(true, cause);
+                        }
+                    });
                 }));
 
         // Add updateCenter, all legwork will be done by a configurator

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorCloudSupportTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorCloudSupportTest.java
@@ -7,14 +7,17 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.Extension;
+import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.EphemeralNode;
+import hudson.slaves.OfflineCause;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
@@ -92,6 +95,26 @@ class JenkinsConfiguratorCloudSupportTest {
         assertNotNull(j.jenkins.getNode("agent1"), "Slave 1");
         assertNotNull(j.jenkins.getNode("agent2"), "Slave 1");
         assertNotNull(j.jenkins.getNode("testCloud"), "Slave cloud");
+    }
+
+    @Test
+    @ConfiguredWithCode("JenkinsConfiguratorCloudSupportTest.yml")
+    void should_preserve_offline_state_after_reload(JenkinsConfiguredWithCodeRule j) throws Exception {
+        Node agent1 = j.jenkins.getNode("agent1");
+        assertNotNull(agent1, "agent1 should exist before reload");
+        Computer computer = agent1.toComputer();
+        assertNotNull(computer, "agent1 computer should exist");
+        computer.setTemporarilyOffline(true, new OfflineCause.UserCause(null, "maintenance"));
+        assertTrue(computer.isTemporarilyOffline(), "agent1 should be offline before reload");
+
+        ConfigurationAsCode.get()
+                .configure(this.getClass()
+                        .getResource("JenkinsConfiguratorCloudSupportTest.yml")
+                        .toString());
+
+        Computer reloadedComputer = j.jenkins.getComputer("agent1");
+        assertNotNull(reloadedComputer, "agent1 computer should exist after reload");
+        assertTrue(reloadedComputer.isTemporarilyOffline(), "agent1 should remain offline after config reload");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

### Description Summary
When JCasC reloads, static nodes are replaced with fresh instances constructed from YAML. In newer Jenkins core versions, this causes Computer.setNode() to reset the temporarilyOffline flag, bringing offline agents back online unexpectedly. This change proposes fixing this by capturing each reconfigured node's offline state before jenkins.setNodes() and restoring it afterward via computer.setTemporarilyOffline(). Also, changed configuredNodesNames from List to Set for O(1) membership checks in the node filter.

### Issue
https://github.com/jenkinsci/jenkins/issues/26750

### Testing
Provided unit test coverage 