### PR TITLE
Preserve non-YAML agents on JCasc reload

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
@@ -75,7 +75,6 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
                             configuredNodes.stream().map(Node::getNodeName).collect(Collectors.toList());
                     List<Node> nodesToKeep = jenkins.getNodes().stream()
                             .filter(node -> !configuredNodesNames.contains(node.getNodeName()))
-                            .filter(this::isCloudNode)
                             .collect(Collectors.toList());
                     nodesToKeep.addAll(configuredNodes);
                     jenkins.setNodes(nodesToKeep);

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorCloudSupportTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/JenkinsConfiguratorCloudSupportTest.java
@@ -36,7 +36,7 @@ class JenkinsConfiguratorCloudSupportTest {
     }
 
     @Test
-    void should_remove_normal_nodes_configured_after_reload(JenkinsConfiguredWithCodeRule j) throws Exception {
+    void should_preserve_non_yaml_nodes_on_reload(JenkinsConfiguredWithCodeRule j) throws Exception {
         final Node slave = new StaticPretendSlave();
         j.jenkins.addNode(slave);
 
@@ -44,7 +44,10 @@ class JenkinsConfiguratorCloudSupportTest {
                 .configure(this.getClass()
                         .getResource("JenkinsConfiguratorCloudSupportTest.yml")
                         .toString());
-        assertEquals(2, j.jenkins.getNodes().size(), "Base nodes not found");
+        assertEquals(3, j.jenkins.getNodes().size(), "Non-YAML node should be preserved");
+        assertNotNull(j.jenkins.getNode("agent1"), "YAML node agent1");
+        assertNotNull(j.jenkins.getNode("agent2"), "YAML node agent2");
+        assertNotNull(j.jenkins.getNode("testCloud"), "Manually-added node");
     }
 
     @Test


### PR DESCRIPTION
closes #2842

Previously the nodes: setter filtered out any non-cloud, non-YAML agents before calling setNodes(), causing their remoting channels to be torn down and their on-disk config to be deleted. This was inconsistent with how JCasc handles every other list-type section (credentials, jobs, etc.), which leaves resources it did not create untouched.

The isCloudNode() guard remains on the getter (export path) so that cloud-provisioned and ephemeral nodes are still excluded from YAML export.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
