### PR TITLE
Use separate classpath JAR for JMH benchmark tests on Windows

### DIFF
--- a/test-harness/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/CascJmhBenchmarkStateTest.java
@@ -1,9 +1,7 @@
 package io.jenkins.plugins.casc;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-import hudson.Functions;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,9 +29,6 @@ class CascJmhBenchmarkStateTest {
 
     @Test
     void testJmhBenchmarks() throws Exception {
-        assumeFalse(
-                Functions.isWindows() && System.getenv("CI") != null,
-                "TODO Cannot run program C:\\openjdk-11\\bin\\java.exe: CreateProcess error=206, The filename or extension is too long");
         // number of iterations is kept to a minimum just to verify that the benchmarks work without spending extra
         // time during builds.
         ChainedOptionsBuilder optionsBuilder = new OptionsBuilder()
@@ -44,7 +39,11 @@ class CascJmhBenchmarkStateTest {
                 .shouldFailOnError(true)
                 .result(reportPath)
                 .timeUnit(TimeUnit.MICROSECONDS)
-                .resultFormat(ResultFormatType.JSON);
+                .resultFormat(ResultFormatType.JSON)
+                .jvmArgsAppend(
+                        "-Djmh.separateClasspathJAR=true",
+                        "-Djava.io.tmpdir=" + Paths.get("target").toAbsolutePath());
+
         new BenchmarkFinder(getClass()).findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();
 


### PR DESCRIPTION
Fix Windows JMH benchmark command-line length issue by enabling jmh.separateClasspathJAR in CascJmhBenchmarkStateTest, allowing benchmark forks to run successfully without hitting an error on Windows CI, and removing the need for the previous workaround skip.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
