### PR TITLE
Add demo for Locale plugin configuration

### DIFF
--- a/demos/locale/README.md
+++ b/demos/locale/README.md
@@ -1,0 +1,15 @@
+# Locale Plugin
+
+This demo shows how to configure the Jenkins UI language using the [Locale Plugin](https://plugins.jenkins.io/locale/) via Jenkins Configuration as Code.
+
+This plugin is commonly used to set the Jenkins UI language globally and optionally ignore the browser's language preferences.
+
+## Configuration
+
+The Locale configuration is located under the `appearance` root element.
+
+```yaml
+appearance:
+  locale:
+    systemLocale: "en"
+    ignoreAcceptLanguage: true

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -89,6 +89,11 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>locale</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>pipeline-groovy-lib</artifactId>
       <scope>test</scope>
     </dependency>

--- a/integrations/src/test/java/io/jenkins/plugins/casc/LocalePluginTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/LocalePluginTest.java
@@ -1,0 +1,23 @@
+package io.jenkins.plugins.casc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import hudson.plugins.locale.PluginImpl;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LocalePluginTest {
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("locale.yaml")
+    public void should_configure_locale_plugin() {
+        PluginImpl localePlugin = PluginImpl.get();
+        assertEquals("en", localePlugin.getSystemLocale());
+        assertTrue("Expected ignoreAcceptLanguage to be true", localePlugin.isIgnoreAcceptLanguage());
+    }
+}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/locale.yaml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/locale.yaml
@@ -1,0 +1,4 @@
+appearance:
+  locale:
+    systemLocale: "en"
+    ignoreAcceptLanguage: true


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #2748 

Add Locale plugin demo documentation and integration tests. Introduces a README file explaining how to configure the global UI language via appearance: locale, and adds LocalePluginTest with its test resource YAML to verify that the configuration loads correctly.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature that works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
