### PR TITLE
Add SonarQube scanner tool installation demo

### DIFF
--- a/demos/sonarqube/README.md
+++ b/demos/sonarqube/README.md
@@ -32,6 +32,12 @@ unclassified:
           skipScmCause: true
           skipUpstreamCause: true
           envVar: "envVar"
+
+tool:
+  sonarRunnerInstallation:
+    installations:
+      - name: "SonarScanner"
+        home: "/opt/sonar-scanner"
 ```
 
 ## notes

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SonarQubeTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SonarQubeTest.java
@@ -9,9 +9,11 @@ import static org.junit.Assert.assertTrue;
 
 import hudson.plugins.sonar.SonarGlobalConfiguration;
 import hudson.plugins.sonar.SonarInstallation;
+import hudson.plugins.sonar.SonarRunnerInstallation;
 import hudson.plugins.sonar.model.TriggersConfig;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
+import java.util.Objects;
 import jenkins.model.GlobalConfiguration;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -30,7 +32,7 @@ public class SonarQubeTest {
     public void configure_sonar_globalconfig() {
 
         final SonarGlobalConfiguration configuration = GlobalConfiguration.all().get(SonarGlobalConfiguration.class);
-        assertTrue(configuration.isBuildWrapperEnabled());
+        assertTrue(Objects.requireNonNull(configuration).isBuildWrapperEnabled());
         final SonarInstallation installation = configuration.getInstallations()[0];
         assertEquals("TEST", installation.getName());
         assertEquals("http://url:9000", installation.getServerUrl());
@@ -41,6 +43,19 @@ public class SonarQubeTest {
         assertTrue(triggers.isSkipScmCause());
         assertTrue(triggers.isSkipUpstreamCause());
         assertEquals("envVar", triggers.getEnvVar());
+    }
+
+    @Test
+    @ConfiguredWithReadme("sonarqube/README.md")
+    public void configure_sonar_runner_installation() {
+        SonarRunnerInstallation.DescriptorImpl descriptor =
+                j.jenkins.getDescriptorByType(SonarRunnerInstallation.DescriptorImpl.class);
+        SonarRunnerInstallation[] installations = descriptor.getInstallations();
+
+        assertEquals(1, installations.length);
+        SonarRunnerInstallation installation = installations[0];
+        assertEquals("SonarScanner", installation.getName());
+        assertEquals("/opt/sonar-scanner", installation.getHome());
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #2746 

Adds a SonarQube Scanner tool installation example to the SonarQube demo. The existing demo only documented SonarQube server configuration under unclassified.sonarglobalconfiguration. This change adds an example for
tool.sonarRunnerInstallation and extends the demo test to verify the scanner installation is configured correctly.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature that works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
