### PR TITLE
Add SSH connector configuration to Docker demo

### DIFF
--- a/demos/docker/README.md
+++ b/demos/docker/README.md
@@ -33,6 +33,16 @@ jenkins:
             instanceCapStr: "10"
             retentionStrategy:
               idleMinutes: 1
+          - labelString: "worker1-agent"
+            dockerTemplateBase:
+              image: "jenkins/ssh-agent:latest-jdk17"
+            remoteFs: "/home/jenkins/agent"
+            connector:
+              ssh:
+                port: 22
+                sshKeyStrategy:
+                  injectSSHKey:
+                    user: "root"
 ```
 
 ## implementation note

--- a/integrations/src/test/java/io/jenkins/plugins/casc/DockerCloudTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/DockerCloudTest.java
@@ -10,6 +10,7 @@ import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import com.nirima.jenkins.plugins.docker.strategy.DockerOnceRetentionStrategy;
 import hudson.model.Label;
 import io.jenkins.docker.connector.DockerComputerAttachConnector;
+import io.jenkins.docker.connector.DockerComputerSSHConnector;
 import io.jenkins.plugins.casc.misc.ConfiguredWithReadme;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithReadmeRule;
 import org.junit.Rule;
@@ -49,6 +50,19 @@ public class DockerCloudTest {
                 "hello=world\nfoo=bar");
         assertTrue(template.getRetentionStrategy() instanceof DockerOnceRetentionStrategy);
         assertEquals(1, ((DockerOnceRetentionStrategy) template.getRetentionStrategy()).getIdleMinutes());
+        final DockerTemplate sshTemplate = docker.getTemplate("jenkins/ssh-agent:latest-jdk17");
+        assertNotNull(sshTemplate);
+        assertEquals("worker1-agent", sshTemplate.getLabelString());
+        assertEquals("/home/jenkins/agent", sshTemplate.getRemoteFs());
+        assertTrue(sshTemplate.getConnector() instanceof DockerComputerSSHConnector);
+
+        DockerComputerSSHConnector sshConnector = (DockerComputerSSHConnector) sshTemplate.getConnector();
+        assertEquals(22, sshConnector.getPort());
+        assertTrue(sshConnector.getSshKeyStrategy() instanceof DockerComputerSSHConnector.InjectSSHKey);
+
+        DockerComputerSSHConnector.InjectSSHKey injectStrategy =
+                (DockerComputerSSHConnector.InjectSSHKey) sshConnector.getSshKeyStrategy();
+        assertEquals("root", injectStrategy.getUser());
     }
 
     @Test
@@ -76,6 +90,9 @@ public class DockerCloudTest {
                 },
                 "hello=world\nfoo=bar");
 
+        DockerTemplate sshTemplate = docker.getTemplate(Label.get("worker1-agent"));
+        assertNotNull(sshTemplate);
+        assertTrue(sshTemplate.getConnector() instanceof DockerComputerSSHConnector);
         ConfigurationAsCode.get()
                 .configure(getClass().getResource("DockerCloudTest2.yml").toExternalForm());
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes #2739 

Adds a Docker plugin demo showing how to configure an SSH agent using the ssh connector and injectSSHKey strategy. The existing Docker demo only documented the attach connector. This change adds an SSH-based agent template example to docker/README.md and extends DockerCloudTest to verify that the SSH connector, SSH key strategy, and associated configuration are loaded correctly.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature that works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
