### PR TITLE
Improve error message for multiple implementations in HeteroDescribableConfigurator

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfigurator.java
@@ -301,7 +301,9 @@ public class HeteroDescribableConfigurator<T extends Describable<T>> implements 
     private Tuple2<String, Option<CNode>> configureMapping(CNode config) {
         Mapping mapping = unchecked(config::asMapping).apply();
         if (mapping.size() != 1) {
-            throw new IllegalArgumentException("Single entry map expected to configure a " + target.getName());
+            String keys = String.join(", ", mapping.keySet());
+            throw new IllegalArgumentException("Single entry map expected to configure a " + target.getName()
+                    + " but found multiple entries: [" + keys + "]");
         } else {
             Map.Entry<String, CNode> next = mapping.entrySet().iterator().next();
             return Tuple.of(next.getKey(), Option.some(next.getValue()));

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfiguratorTest.java
@@ -6,14 +6,21 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import hudson.markup.RawHtmlMarkupFormatter;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.security.SecurityRealm;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.UnknownAttributesException;
 import java.util.Objects;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 public class HeteroDescribableConfiguratorTest {
 
@@ -54,5 +61,70 @@ public class HeteroDescribableConfiguratorTest {
                 thrown.getMessage(),
                 containsString(
                         "No hudson.markup.MarkupFormatter implementation found for some-invalid-formatter-name"));
+    }
+
+    @Test
+    public void shouldFailWhenMultipleImplementationsProvidedForNestedSingleValuedDescribable() {
+        ConfiguratorException exception = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
+                .configure(Objects.requireNonNull(getClass().getResource("multiple-implementations.yml"))
+                        .toExternalForm()));
+
+        String errorMessage = exception.getMessage();
+        if (exception.getCause() != null) {
+            errorMessage += " " + exception.getCause().getMessage();
+        }
+
+        assertThat(errorMessage, containsString("found multiple entries"));
+        assertThat(errorMessage, containsString("wellKnown"));
+        assertThat(errorMessage, containsString("manual"));
+    }
+
+    public static class DummySecurityRealm extends SecurityRealm {
+        private final DummyServerConfiguration serverConfiguration;
+
+        @DataBoundConstructor
+        public DummySecurityRealm(DummyServerConfiguration serverConfiguration) {
+            this.serverConfiguration = serverConfiguration;
+        }
+
+        @SuppressWarnings("unused")
+        public DummyServerConfiguration getServerConfiguration() {
+            return serverConfiguration;
+        }
+
+        @Override
+        public SecurityComponents createSecurityComponents() {
+            return new SecurityComponents();
+        }
+
+        @TestExtension
+        @Symbol("dummyOic")
+        public static class DescriptorImpl extends Descriptor<SecurityRealm> {}
+    }
+
+    public abstract static class DummyServerConfiguration implements Describable<DummyServerConfiguration> {
+        @SuppressWarnings("unchecked")
+        @Override
+        public Descriptor<DummyServerConfiguration> getDescriptor() {
+            return Jenkins.get().getDescriptorOrDie(getClass());
+        }
+    }
+
+    public static class WellKnownConfig extends DummyServerConfiguration {
+        @DataBoundConstructor
+        public WellKnownConfig() {}
+
+        @TestExtension
+        @Symbol("wellKnown")
+        public static class DescriptorImpl extends Descriptor<DummyServerConfiguration> {}
+    }
+
+    public static class ManualConfig extends DummyServerConfiguration {
+        @DataBoundConstructor
+        public ManualConfig() {}
+
+        @TestExtension
+        @Symbol("manual")
+        public static class DescriptorImpl extends Descriptor<DummyServerConfiguration> {}
     }
 }

--- a/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/multiple-implementations.yml
+++ b/plugin/src/test/resources/io/jenkins/plugins/casc/impl/configurators/multiple-implementations.yml
@@ -1,0 +1,6 @@
+jenkins:
+  securityRealm:
+    dummyOic:
+      serverConfiguration:
+        wellKnown: {}
+        manual: {}


### PR DESCRIPTION
Fixes #2589 

JCasC actually already correctly rejects multiple implementations for a single-valued HeteroDescribable (like serverConfiguration in the OpenID Connect plugin) and fails the configuration. The underlying validation logic is already working as intended.

However, when this conflict occurs, JCasC throws a very generic IllegalArgumentException:

`Single entry map expected to configure a <type>`

While technically correct, the error does not identify which configuration entries caused the conflict, requiring users to inspect the configuration manually to determine the source of the problem.

This PR improves HeteroDescribableConfigurator.configureMapping to explicitly list the conflicting keys provided by the user, making configuration mistakes immediately clear.

Added a test covering a nested single-valued Describable configured with multiple implementations and verifying that the conflicting entries are reported in the exception message.

<!-- Please describe your pull request here. -->

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
