### PR TITLE
Avoid warnings for ignored abstract non-Describable properties

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -259,7 +259,9 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
         if (!c.isPrimitive() && !c.isEnum() && Modifier.isAbstract(c.getModifiers())) {
             if (!Describable.class.isAssignableFrom(c)) {
                 // Not a Describable, so we don't know how to detect concrete implementation type
-                LOGGER.warning("Can't handle " + getTarget() + "#" + name + ": type is abstract but not Describable.");
+                LOGGER.log(
+                        Level.FINE,
+                        "Can't handle " + getTarget() + "#" + name + ": type is abstract but not Describable.");
                 return null;
             }
             attribute = new DescribableAttribute(name, c);


### PR DESCRIPTION
Fixes #2532

JCasC currently emits a warning when attribute discovery encounters an abstract non-Describable type, despite ignoring the attribute by returning null. For properties such as SCMSource#owner, this results in confusing log messages even though the configuration proceeds normally.

Reduce the log level from WARNING to FINE to avoid unnecessary log noise while retaining diagnostic information for troubleshooting.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
