### PR TITLE
Document creating jobs in nested folders with Job DSL

### DIFF
--- a/demos/jobs/README.md
+++ b/demos/jobs/README.md
@@ -14,7 +14,7 @@ The Job DSL plugin uses groovy syntax for its job configuration DSL, so a mix of
 
 [gitea.yaml](gitea.yaml) file is an example of a configuration file with Jenkins and an Organization Folder Job Type with automatic branch discovering in Gitea. It requires [Branch API plugin](https://github.com/jenkinsci/branch-api-plugin) and [Gitea plugin](https://github.com/jenkinsci/gitea-plugin) to be able to run this demo. `$GITEA_URL` is a system environment variable that needs to be defined before Jenkins is started.
 
-[pipeline.yaml](pipeline.yaml) file is an example of configuring a folder and a declarative pipeline job within that folder.
+[pipeline.yaml](pipeline.yaml) file is an example of configuring a folder and a declarative pipeline job within that folder using Job DSL path-based job names.
 
 [multibranch-github.yaml](multibranch-github.yaml) file is an example of a multibranch pipeline job configured with GitHub as branch source, an orphaned item strategy and periodic scan triggers of 5 mins.
 

--- a/demos/jobs/README.md
+++ b/demos/jobs/README.md
@@ -14,7 +14,7 @@ The Job DSL plugin uses groovy syntax for its job configuration DSL, so a mix of
 
 [gitea.yaml](gitea.yaml) file is an example of a configuration file with Jenkins and an Organization Folder Job Type with automatic branch discovering in Gitea. It requires [Branch API plugin](https://github.com/jenkinsci/branch-api-plugin) and [Gitea plugin](https://github.com/jenkinsci/gitea-plugin) to be able to run this demo. `$GITEA_URL` is a system environment variable that needs to be defined before Jenkins is started.
 
-[pipeline.yaml](pipeline.yaml) file is an example of configuring a folder and a declarative pipeline job within that folder using Job DSL path-based job names.
+[pipeline.yaml](pipeline.yaml) file is an example of configuring a folder and a declarative pipeline job within that folder using an external file.
 
 [multibranch-github.yaml](multibranch-github.yaml) file is an example of a multibranch pipeline job configured with GitHub as branch source, an orphaned item strategy and periodic scan triggers of 5 mins.
 

--- a/docs/user/seed-jobs.md
+++ b/docs/user/seed-jobs.md
@@ -49,7 +49,6 @@ jobs:
 
 ### Processing External Files and Folders
 
-Files referenced by the `- file:` directive are evaluated as Job DSL scripts. The location of a file on disk does not determine the folder structure in Jenkins, and raw Declarative Pipeline definitions (`pipeline { ... }`) must be wrapped in a Job DSL job definition such as `pipelineJob(...)`.
 
 **Example: Local Job DSL script file (`/var/jenkins_home/dsl/bootstrap.groovy`)**
 ```groovy

--- a/docs/user/seed-jobs.md
+++ b/docs/user/seed-jobs.md
@@ -47,6 +47,41 @@ jobs:
       }
 ```
 
+### Processing External Files and Folders
+
+Files referenced by the `- file:` directive are evaluated as Job DSL scripts. The location of a file on disk does not determine the folder structure in Jenkins, and raw Declarative Pipeline definitions (`pipeline { ... }`) must be wrapped in a Job DSL job definition such as `pipelineJob(...)`.
+
+**Example: Local Job DSL script file (`/var/jenkins_home/dsl/bootstrap.groovy`)**
+```groovy
+folder('Non-Production-CAF')
+folder('Non-Production-CAF/bootstrap')
+
+pipelineJob('Non-Production-CAF/bootstrap/bootstrap-levels-nprd') {
+    definition {
+        cps {
+            script('''
+                pipeline {
+                    agent any
+                    stages {
+                        stage('Bootstrap') {
+                            steps {
+                                echo 'Running bootstrap job from within the folder!'
+                            }
+                        }
+                    }
+                }
+            '''.stripIndent())
+            sandbox()
+        }
+    }
+}
+```
+**Corresponding `jenkins.yaml` configuration:**
+```yaml
+jobs:
+  - file: /var/jenkins_home/dsl/bootstrap.groovy
+```
+
 ## Examples
 
 Please refer to [demos](../demos/jobs) for examples to configure more complex jobs.

--- a/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/SeedJobTest.java
@@ -56,6 +56,16 @@ public class SeedJobTest {
     }
 
     @Test
+    @ConfiguredWithCode("SeedJobTest_withFolders.yml")
+    public void configure_jobs_in_folders() {
+        final Jenkins jenkins = Jenkins.get();
+
+        assertNotNull(jenkins.getItem("Non-Production-CAF"));
+        assertNotNull(jenkins.getItemByFullName("Non-Production-CAF/bootstrap"));
+        assertNotNull(jenkins.getItemByFullName("Non-Production-CAF/bootstrap/bootstrap-levels-nprd"));
+    }
+
+    @Test
     @ConfiguredWithCode("SeedJobTest_withSecurityConfig.yml")
     @Envs(@Env(name = "SEED_JOB_FOLDER_FILE_PATH", value = "."))
     public void configure_seed_job_with_security_config() throws Exception {

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/SeedJobTest_withFolders.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/SeedJobTest_withFolders.yml
@@ -1,0 +1,12 @@
+jobs:
+  - script: |
+      folder('Non-Production-CAF')
+      folder('Non-Production-CAF/bootstrap')
+      pipelineJob('Non-Production-CAF/bootstrap/bootstrap-levels-nprd') {
+          definition {
+              cps {
+                  script("pipeline { agent any; stages { stage('Test') { steps { echo 'Automated success' } } } }")
+                  sandbox()
+              }
+          }
+      }


### PR DESCRIPTION
Fixes #2529 

Document how Job DSL files loaded through the `file:` directive create jobs within Jenkins folders and clarify that files are evaluated as Job DSL scripts rather than raw Declarative Pipeline definitions. Add an example showing nested folder creation and job placement using path-based job names, and add a regression test verifying that jobs defined through JCasC can be successfully created inside nested folder hierarchies.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates a feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
