### PR TITLE
Document readFile preserving trailing whitespace and trim usage

### DIFF
--- a/demos/embedded-userdatabase/README.md
+++ b/demos/embedded-userdatabase/README.md
@@ -31,7 +31,8 @@ jenkins:
         - id: "admin"
           name: "Admin"
           description: "Superwoman"
-          password: "somethingsecret"
+          # Use trim when reading secrets from files that may contain trailing newlines
+          password: "${trim:${readFile:/run/secrets/admin_password}}"
           properties:
             - mailer:
                 emailAddress: "admin3@example.com"

--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -108,10 +108,18 @@ ${fileBase64:/secret/certificate.p12}
 
 Reads the secret from the specified file.
 
+The file contents are returned as-is, including any trailing whitespace characters. If the target configuration expects the value without trailing whitespace, you can combine `readFile` with `trim`.
+
 Example:
 
 ```
 ${readFile:/secret/file.txt}
+```
+
+Safe Password Example:
+
+```
+${trim:${readFile:/secret/file-user-password.txt}}
 ```
 
 ==== readFileBase64


### PR DESCRIPTION
Fixes #2522.

JCasC's `readFile` helper returns file contents as stored, including any trailing whitespace characters. When a file-based secret contains a trailing newline or other trailing whitespace, fields that expect the value without trailing whitespace (such as Jenkins local user passwords) may not behave as expected.

Update to documentation include:
- Clarify `readFile` handling of trailing whitespace.
- Show how `trim` can be combined with `readFile`.
- Add a `securityRealm` example demonstrating a trimmed file-based password.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test case? That demonstrates a feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
