### PR TITLE
Document escaping of literal ${...} values

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ credentials:
                   privateKey: ${SSH_PRIVATE_KEY}
 ```
 
-> **Note:** JCasC treats `${VAR}` as a variable interpolation expression across all configuration blocks. If you need a literal `${...}` string (such as in inline shell scripts or agent tools like `${WORKSPACE}`), you must escape it as `^${VAR}` to prevent JCasC from replacing it. For more details, see [Handling Secrets](./docs/features/secrets.adoc).
+> **Note:** JCasC treats `${VAR}` as a variable interpolation expression across all configuration blocks. If you need a literal `${...}` string, you must escape it as `^${VAR}` to prevent JCasC from replacing it. For more details, see [Handling Secrets](./docs/features/secrets.adoc).
 
 Additionally, we want to have a well-documented syntax file and tooling to assist in writing and testing,
 so end users have full guidance in using this toolset and do not have to search for examples on the Internet.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ credentials:
                   privateKey: ${SSH_PRIVATE_KEY}
 ```
 
+> **Note:** JCasC treats `${VAR}` as a variable interpolation expression across all configuration blocks. If you need a literal `${...}` string (such as in inline shell scripts or agent tools like `${WORKSPACE}`), you must escape it as `^${VAR}` to prevent JCasC from replacing it. For more details, see [Handling Secrets](./docs/features/secrets.adoc).
+
 Additionally, we want to have a well-documented syntax file and tooling to assist in writing and testing,
 so end users have full guidance in using this toolset and do not have to search for examples on the Internet.
 

--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -47,7 +47,7 @@ Default variable substitution using the `:-` operator from `bash` is also availa
 For example, `key: "${VALUE:-defaultvalue}"` will evaluate to `defaultvalue` if `$VALUE` is unset. 
 To escape a string from secret interpolation, put `^` in front of the value. 
 For example, `Jenkins: "^${some_var}"` will produce the literal `Jenkins: "${some_var}"`.
-This escaping mechanism applies to all JCasC configuration values, not only secrets. It is useful when embedding content such as shell scripts, tool definitions, or other configuration that should preserve `${...}` for later evaluation.
+This escaping mechanism applies to all JCasC configuration values, not only secrets.
 
 Example:
 

--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -47,6 +47,18 @@ Default variable substitution using the `:-` operator from `bash` is also availa
 For example, `key: "${VALUE:-defaultvalue}"` will evaluate to `defaultvalue` if `$VALUE` is unset. 
 To escape a string from secret interpolation, put `^` in front of the value. 
 For example, `Jenkins: "^${some_var}"` will produce the literal `Jenkins: "${some_var}"`.
+This escaping mechanism applies to all JCasC configuration values, not only secrets. It is useful when embedding content such as shell scripts, tool definitions, or other configuration that should preserve `${...}` for later evaluation.
+
+Example:
+
+```yaml
+tool:
+  customTool:
+    script: |
+      echo "^${WORKSPACE}"
+```
+
+JCasC removes the leading ^ during processing, leaving the literal ${WORKSPACE} in the final configuration.
 
 === Additional variable substitution
 
@@ -341,4 +353,3 @@ You can enable this by setting the following environment variable or Java system
 == Useful links
 
 * link:https://jenkins.io/doc/developer/security/secrets/[Jenkins Developer Guide: Storing Secrets in Jenkins]
-


### PR DESCRIPTION
Fixes #2517

Improve the documentation for escaping literal ${...} expressions in JCasC configurations.

Changes

- Add a note to the README explaining that JCasC performs variable interpolation across all configuration values and that literal ${...} expressions should be escaped as ^${...}.
- Expand the "Passing secrets through variables" documentation to clarify that this escaping mechanism applies to all JCasC configuration values, not just secrets.
- Add an example demonstrating how to preserve ${...} in an embedded shell script or tool definition.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
