### PR TITLE
Add opt-in anonymous access for JSON schema endpoint

### DIFF
--- a/docs/features/jsonSchema.md
+++ b/docs/features/jsonSchema.md
@@ -27,6 +27,13 @@ http://json-schema.org/draft-07/schema#
 === How to use
 
 * The schema will be available at /configuration-as-code/schema
+* By default, the endpoint requires `SYSTEM_READ` permission.
+* To allow anonymous access, start Jenkins with the following Java system property:
+
+  ```
+  -Dio.jenkins.plugins.casc.allowAnonymousSchema=true
+  ```
+
 * Users can use various online JSON validators to check against their YAML/json.
 
 === Progress

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -110,7 +110,7 @@ public class ConfigurationAsCode extends ManagementLink {
     public static final String CASC_JENKINS_CONFIG_ENV = "CASC_JENKINS_CONFIG";
     public static final String DEFAULT_JENKINS_YAML_PATH = "jenkins.yaml";
     public static final String YAML_FILES_PATTERN = "glob:**.{yml,yaml,YAML,YML}";
-    private static final String ALLOW_ANONYMOUS_SCHEMA_PROPERTY = "io.jenkins.plugins.casc.allowAnonymousSchema";
+    public static final String ALLOW_ANONYMOUS_SCHEMA_PROPERTY = "io.jenkins.plugins.casc.allowAnonymousSchema";
 
     private static final Logger LOGGER = Logger.getLogger(ConfigurationAsCode.class.getName());
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -110,6 +110,7 @@ public class ConfigurationAsCode extends ManagementLink {
     public static final String CASC_JENKINS_CONFIG_ENV = "CASC_JENKINS_CONFIG";
     public static final String DEFAULT_JENKINS_YAML_PATH = "jenkins.yaml";
     public static final String YAML_FILES_PATTERN = "glob:**.{yml,yaml,YAML,YML}";
+    private static final String ALLOW_ANONYMOUS_SCHEMA_PROPERTY = "io.jenkins.plugins.casc.allowAnonymousSchema";
 
     private static final Logger LOGGER = Logger.getLogger(ConfigurationAsCode.class.getName());
 
@@ -554,7 +555,8 @@ public class ConfigurationAsCode extends ManagementLink {
      */
     @Restricted(NoExternalUse.class)
     public void doSchema(StaplerRequest2 req, StaplerResponse2 res) throws Exception {
-        if (!Jenkins.get().hasPermission(Jenkins.SYSTEM_READ)) {
+        boolean allowAnonymous = Boolean.getBoolean(ALLOW_ANONYMOUS_SCHEMA_PROPERTY);
+        if (!allowAnonymous && !Jenkins.get().hasPermission(Jenkins.SYSTEM_READ)) {
             res.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
@@ -15,6 +15,7 @@ import org.htmlunit.WebResponse;
 import org.htmlunit.util.NameValuePair;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.FlagRule;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
@@ -22,6 +23,10 @@ public class ConfigurationAsCodeApiTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public final FlagRule<String> anonymousSchemaFlag =
+            FlagRule.systemProperty(ConfigurationAsCode.ALLOW_ANONYMOUS_SCHEMA_PROPERTY);
 
     private static final String ENDPOINT = "configuration-as-code/configure";
     private static final String SCHEMA_ENDPOINT = "manage/configuration-as-code/schema";
@@ -224,22 +229,16 @@ public class ConfigurationAsCodeApiTest {
         j.jenkins.setAuthorizationStrategy(
                 new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().toEveryone());
 
-        String propertyName = "io.jenkins.plugins.casc.allowAnonymousSchema";
+        System.setProperty(ConfigurationAsCode.ALLOW_ANONYMOUS_SCHEMA_PROPERTY, "true");
 
-        try {
-            System.setProperty(propertyName, "true");
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
 
-            try (JenkinsRule.WebClient wc = j.createWebClient()) {
-                wc.setThrowExceptionOnFailingStatusCode(false);
+            WebRequest request = new WebRequest(new URL(j.getURL(), SCHEMA_ENDPOINT), HttpMethod.GET);
+            WebResponse response = wc.getPage(request).getWebResponse();
 
-                WebRequest request = new WebRequest(new URL(j.getURL(), SCHEMA_ENDPOINT), HttpMethod.GET);
-                WebResponse response = wc.getPage(request).getWebResponse();
-
-                assertThat(response.getStatusCode(), is(200));
-                assertThat(response.getContentType(), is("application/json"));
-            }
-        } finally {
-            System.clearProperty(propertyName);
+            assertThat(response.getStatusCode(), is(200));
+            assertThat(response.getContentType(), is("application/json"));
         }
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ConfigurationAsCodeApiTest.java
@@ -24,6 +24,7 @@ public class ConfigurationAsCodeApiTest {
     public JenkinsRule j = new JenkinsRule();
 
     private static final String ENDPOINT = "configuration-as-code/configure";
+    private static final String SCHEMA_ENDPOINT = "manage/configuration-as-code/schema";
     private static final String YAML_CONTENT_TYPE = "application/yaml";
     private static final String ADMIN = "admin";
 
@@ -183,6 +184,62 @@ public class ConfigurationAsCodeApiTest {
 
             assertThat(response.getStatusCode(), is(200));
             assertThat(j.jenkins.getSystemMessage(), is("Hello Replace"));
+        }
+    }
+
+    @Test
+    public void testDoSchema_DefaultIsProtected() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(
+                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().toEveryone());
+
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+
+            WebRequest request = new WebRequest(new URL(j.getURL(), SCHEMA_ENDPOINT), HttpMethod.GET);
+            WebResponse response = wc.getPage(request).getWebResponse();
+
+            assertThat(response.getStatusCode(), is(403));
+        }
+    }
+
+    @Test
+    public void testDoSchema_AuthorizedUserCanAccess() throws Exception {
+        configureAdminSecurity();
+
+        try (JenkinsRule.WebClient wc = j.createWebClient().withBasicApiToken(ADMIN)) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+
+            WebRequest request = new WebRequest(new URL(j.getURL(), SCHEMA_ENDPOINT), HttpMethod.GET);
+            WebResponse response = wc.getPage(request).getWebResponse();
+
+            assertThat(response.getStatusCode(), is(200));
+            assertThat(response.getContentType(), is("application/json"));
+        }
+    }
+
+    @Test
+    public void testDoSchema_AnonymousAccessWhenPropertyEnabled() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(
+                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().toEveryone());
+
+        String propertyName = "io.jenkins.plugins.casc.allowAnonymousSchema";
+
+        try {
+            System.setProperty(propertyName, "true");
+
+            try (JenkinsRule.WebClient wc = j.createWebClient()) {
+                wc.setThrowExceptionOnFailingStatusCode(false);
+
+                WebRequest request = new WebRequest(new URL(j.getURL(), SCHEMA_ENDPOINT), HttpMethod.GET);
+                WebResponse response = wc.getPage(request).getWebResponse();
+
+                assertThat(response.getStatusCode(), is(200));
+                assertThat(response.getContentType(), is("application/json"));
+            }
+        } finally {
+            System.clearProperty(propertyName);
         }
     }
 }


### PR DESCRIPTION
Fixes #2858 

This change introduces an optional Java system property (io.jenkins.plugins.casc.allowAnonymousSchema) that allows anonymous access to the Configuration as Code JSON schema endpoint while preserving the existing default behavior of requiring SYSTEM_READ permission. It also adds regression tests covering the default protected behavior, authenticated access, and the opt-in anonymous mode, and updates the JSON schema documentation to describe the new configuration option.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
