### PR TITLE
Document how to create Configuration as Code test YAML

### DIFF
--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -254,6 +254,13 @@ You can find some examples here
 1. [kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml)
 2. [azure-cosmosdb-plugin](https://github.com/jenkinsci/azure-cosmosdb-plugin/blob/main/src/test/resources/io/jenkins/plugins/azurecosmosdb/configuration-as-code.yml)
 
+#### How to create the YAML file
+
+You can build your test configuration file using one of two approaches:
+
+* **Export from a running Jenkins instance:** Configure your plugin's global properties using the standard UI and save. Navigate to **Manage Jenkins** > **Configuration as Code** and click the **Export configuration** button. On the resulting page, you can view or **Download** the generated YAML. Copy the specific sections relevant to your plugin into your test file.
+* **Author manually:** To determine the supported JCasC keys and structure for your plugin, refer to the Configuration as Code reference by clicking Documentation on the Configuration as Code page or by visiting `<JENKINS_URL>/configuration-as-code/reference`.
+
 ### Backward compatibility test
 
 About the latter, in case you need to introduce some breaking changes, you can define a backward compatibility test case:

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -254,7 +254,13 @@ You can find some examples here
 1. [kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml)
 2. [azure-cosmosdb-plugin](https://github.com/jenkinsci/azure-cosmosdb-plugin/blob/main/src/test/resources/io/jenkins/plugins/azurecosmosdb/configuration-as-code.yml)
 
-#### How to create the YAML file
+#### Location and creation of the YAML file
+
+Place `configuration-as-code.yml` under your plugin's `src/test/resources` directory, alongside your test package, so it can be located by `@ConfiguredWithCode(...)`.
+
+You can find some examples here:
+1. [kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/test/resources/org/csanchez/jenkins/plugins/kubernetes/casc/configuration-as-code.yaml)
+2. [azure-cosmosdb-plugin](https://github.com/jenkinsci/azure-cosmosdb-plugin/blob/main/src/test/resources/io/jenkins/plugins/azurecosmosdb/configuration-as-code.yml)
 
 You can build your test configuration file using one of two approaches:
 


### PR DESCRIPTION
Fixes #2446 

Document how to create configuration-as-code.yml for JCasC plugin tests by describing the two recommended approaches: exporting configuration from a running Jenkins instance using the Configuration as Code UI or writing the YAML manually using the Configuration as Code reference.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
