### PR TITLE
Clarify use of readFile for SSH private key credentials

### DIFF
--- a/demos/credentials/README.md
+++ b/demos/credentials/README.md
@@ -50,6 +50,9 @@ credentials:
                 directEntry:
                   privateKey: "${SSH_PRIVATE_KEY}"
           # Another option passing via a file via ${readFile:/path/to/file}
+          # Use `readFile` because `privateKey` expects the raw PEM contents.
+          # Do not use `readFileBase64`, which returns Base64-encoded file contents and
+          # will cause the SSH private key to be rejected.
           - basicSSHUserPrivateKey:
               scope: SYSTEM
               id: ssh_with_passphrase_provided_via_file


### PR DESCRIPTION
Fixes #2424 

Document correct use of readFile for SSH private key credentials. Clarify that basicSSHUserPrivateKey.privateKey expects the raw PEM contents and should be populated using readFile rather than readFileBase64.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
