### PR TITLE
Return configuration reload errors as JSON

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
@@ -1,15 +1,19 @@
 package io.jenkins.plugins.casc;
 
+import static java.util.logging.Level.SEVERE;
+
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.logging.Logger;
+import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -56,8 +60,24 @@ public class TokenReloadAction implements UnprotectedRootAction {
                             token.getBytes(StandardCharsets.UTF_8), requestToken.getBytes(StandardCharsets.UTF_8))) {
                 LOGGER.info("Configuration reload triggered via token");
 
-                try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
-                    ConfigurationAsCode.get().configure();
+                try {
+                    try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
+                        ConfigurationAsCode.get().configure();
+                    }
+                } catch (ConfiguratorException e) {
+                    LOGGER.log(SEVERE, "Failed to reload Jenkins Configuration as Code via token", e);
+
+                    response.setContentType("application/json");
+                    response.setCharacterEncoding("UTF-8");
+                    response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+                    JSONObject errorJson = new JSONObject();
+                    errorJson.put("status", "error");
+
+                    String message = e.getMessage() != null ? e.getMessage() : "Unknown configuration error";
+                    errorJson.put("message", "Failed to reload configuration: " + message);
+
+                    response.getWriter().write(errorJson.toString());
                 }
             } else {
                 response.sendError(401);

--- a/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/TokenReloadAction.java
@@ -7,13 +7,13 @@ import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.util.HttpResponses;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.logging.Logger;
-import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -46,7 +46,7 @@ public class TokenReloadAction implements UnprotectedRootAction {
     }
 
     @RequirePOST
-    public void doIndex(StaplerRequest2 request, StaplerResponse2 response) throws IOException {
+    public void doIndex(StaplerRequest2 request, StaplerResponse2 response) throws IOException, ServletException {
         String token = getReloadToken();
 
         if (token == null || token.isEmpty()) {
@@ -60,24 +60,15 @@ public class TokenReloadAction implements UnprotectedRootAction {
                             token.getBytes(StandardCharsets.UTF_8), requestToken.getBytes(StandardCharsets.UTF_8))) {
                 LOGGER.info("Configuration reload triggered via token");
 
-                try {
-                    try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
-                        ConfigurationAsCode.get().configure();
-                    }
+                try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
+                    ConfigurationAsCode.get().configure();
                 } catch (ConfiguratorException e) {
                     LOGGER.log(SEVERE, "Failed to reload Jenkins Configuration as Code via token", e);
 
-                    response.setContentType("application/json");
-                    response.setCharacterEncoding("UTF-8");
-                    response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-
-                    JSONObject errorJson = new JSONObject();
-                    errorJson.put("status", "error");
-
                     String message = e.getMessage() != null ? e.getMessage() : "Unknown configuration error";
-                    errorJson.put("message", "Failed to reload configuration: " + message);
 
-                    response.getWriter().write(errorJson.toString());
+                    HttpResponses.errorJSON("Failed to reload configuration: " + message)
+                            .generateResponse(request, response, this);
                 }
             } else {
                 response.sendError(401);

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.casc.misc.Env;
 import io.jenkins.plugins.casc.misc.EnvVarsRule;
 import io.jenkins.plugins.casc.misc.Envs;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URL;
@@ -101,7 +102,7 @@ public class TokenReloadActionTest {
     }
 
     @Test
-    public void reloadIsDisabledByDefault() throws IOException {
+    public void reloadIsDisabledByDefault() throws IOException, ServletException {
         System.clearProperty("casc.reload.token");
 
         RequestImpl request = newRequest(null);
@@ -118,7 +119,7 @@ public class TokenReloadActionTest {
     }
 
     @Test
-    public void reloadReturnsUnauthorizedIfTokenDoesNotMatch() throws IOException {
+    public void reloadReturnsUnauthorizedIfTokenDoesNotMatch() throws IOException, ServletException {
         System.setProperty("casc.reload.token", "someSecretValue");
 
         RequestImpl request = newRequest(null);
@@ -128,7 +129,7 @@ public class TokenReloadActionTest {
     }
 
     @Test
-    public void reloadReturnsOkWhenCalledWithValidToken() throws IOException {
+    public void reloadReturnsOkWhenCalledWithValidToken() throws IOException, ServletException {
         System.setProperty("casc.reload.token", "someSecretValue");
 
         tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
@@ -138,7 +139,7 @@ public class TokenReloadActionTest {
 
     @Test
     @Envs({@Env(name = "CASC_RELOAD_TOKEN", value = "someSecretValue")})
-    public void reloadReturnsOkWhenCalledWithValidTokenSetByEnvVar() throws IOException {
+    public void reloadReturnsOkWhenCalledWithValidTokenSetByEnvVar() throws IOException, ServletException {
         tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
 
         assertConfigReloaded();
@@ -146,7 +147,7 @@ public class TokenReloadActionTest {
 
     @Test
     @Envs({@Env(name = "CASC_RELOAD_TOKEN", value = "someSecretValue")})
-    public void reloadShouldNotUseTokenFromPropertyIfEnvVarIsSet() throws IOException {
+    public void reloadShouldNotUseTokenFromPropertyIfEnvVarIsSet() throws IOException, ServletException {
         System.setProperty("casc.reload.token", "otherSecretValue");
 
         tokenReloadAction.doIndex(newRequest("otherSecretValue"), new ResponseImpl(null, response));
@@ -156,7 +157,7 @@ public class TokenReloadActionTest {
 
     @Test
     @Envs({@Env(name = "CASC_RELOAD_TOKEN", value = "")})
-    public void reloadShouldUsePropertyAsTokenIfEnvVarIsEmpty() throws IOException {
+    public void reloadShouldUsePropertyAsTokenIfEnvVarIsEmpty() throws IOException, ServletException {
         System.setProperty("casc.reload.token", "someSecretValue");
 
         tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
@@ -188,8 +189,8 @@ public class TokenReloadActionTest {
             WebRequest request = new WebRequest(url, HttpMethod.POST);
             WebResponse response = wc.getPage(request).getWebResponse();
 
-            assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
-            assertEquals("application/json", response.getContentType());
+            assertEquals(HttpServletResponse.SC_OK, response.getStatusCode());
+            assertTrue("Content-Type should be JSON", response.getContentType().contains("application/json"));
 
             String body = response.getContentAsString();
             assertTrue(

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.casc;
 
+import static java.nio.file.Files.createTempFile;
+import static java.nio.file.Files.write;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -10,6 +13,10 @@ import io.jenkins.plugins.casc.misc.Envs;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -45,7 +52,7 @@ public class TokenReloadActionTest {
     @Rule
     public RuleChain chain = RuleChain.outerRule(environment).around(j);
 
-    private HttpServletResponse response;
+    private MockHttpServletResponse response;
 
     private RequestImpl newRequest(String authorization) {
         Map<String, String> parameters = new HashMap<>();
@@ -157,5 +164,84 @@ public class TokenReloadActionTest {
     @Test
     public void displayName() {
         assertEquals("Reload Configuration as Code", tokenReloadAction.getDisplayName());
+    }
+
+    @Test
+    public void reloadReturnsInternalServerErrorAndJsonOnFailure() throws IOException {
+        System.setProperty("casc.reload.token", "someSecretValue");
+
+        StringWriter stringWriter = new java.io.StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+
+        response = new MockHttpServletResponse() {
+            private String contentType;
+            private String characterEncoding;
+            private int status;
+
+            @Override
+            public PrintWriter getWriter() {
+                return printWriter;
+            }
+
+            @Override
+            public void setContentType(String type) {
+                this.contentType = type;
+            }
+
+            @Override
+            public String getContentType() {
+                return this.contentType;
+            }
+
+            @Override
+            public void setCharacterEncoding(String charset) {
+                this.characterEncoding = charset;
+            }
+
+            @Override
+            public String getCharacterEncoding() {
+                return this.characterEncoding;
+            }
+
+            @Override
+            public void setStatus(int sc) {
+                this.status = sc;
+            }
+
+            @Override
+            public int getStatus() {
+                return this.status;
+            }
+        };
+
+        Path tempFile = createTempFile("invalid-casc-config", ".yaml");
+        write(tempFile, asList("unclassified:", "  this_fake_property_forces_a_configurator_exception: true"));
+        System.setProperty("casc.jenkins.config", tempFile.toAbsolutePath().toString());
+
+        try {
+            tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
+
+            assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response.getStatus());
+
+            assertEquals("application/json", response.getContentType());
+
+            String body = stringWriter.toString();
+            assertTrue("Response body should contain error status key", body.contains("\"status\""));
+            assertTrue("Response body should indicate an error state", body.contains("\"error\""));
+            assertTrue(
+                    "Response body should contain the failure contextual message",
+                    body.contains("Failed to reload configuration"));
+
+            List<LogRecord> messages = loggerRule.getRecords();
+            boolean hasSevereLog = messages.stream()
+                    .anyMatch(record -> record.getLevel() == Level.SEVERE
+                            && record.getMessage()
+                                    .contains("Failed to reload Jenkins Configuration as Code via token"));
+
+            assertTrue("Expected a SEVERE log message regarding reload failure", hasSevereLog);
+
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
@@ -55,7 +55,7 @@ public class TokenReloadActionTest {
     @Rule
     public RuleChain chain = RuleChain.outerRule(environment).around(j);
 
-    private MockHttpServletResponse response;
+    private HttpServletResponse response;
 
     private RequestImpl newRequest(String authorization) {
         Map<String, String> parameters = new HashMap<>();

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/TokenReloadActionTest.java
@@ -13,8 +13,7 @@ import io.jenkins.plugins.casc.misc.Envs;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -24,11 +23,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.RuleChain;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.kohsuke.stapler.RequestImpl;
 import org.kohsuke.stapler.ResponseImpl;
@@ -167,70 +170,34 @@ public class TokenReloadActionTest {
     }
 
     @Test
-    public void reloadReturnsInternalServerErrorAndJsonOnFailure() throws IOException {
+    public void reloadReturnsInternalServerErrorAndJsonOnFailure() throws Exception {
+        String oldToken = System.getProperty("casc.reload.token");
+        String oldConfig = System.getProperty("casc.jenkins.config");
+
         System.setProperty("casc.reload.token", "someSecretValue");
-
-        StringWriter stringWriter = new java.io.StringWriter();
-        PrintWriter printWriter = new PrintWriter(stringWriter);
-
-        response = new MockHttpServletResponse() {
-            private String contentType;
-            private String characterEncoding;
-            private int status;
-
-            @Override
-            public PrintWriter getWriter() {
-                return printWriter;
-            }
-
-            @Override
-            public void setContentType(String type) {
-                this.contentType = type;
-            }
-
-            @Override
-            public String getContentType() {
-                return this.contentType;
-            }
-
-            @Override
-            public void setCharacterEncoding(String charset) {
-                this.characterEncoding = charset;
-            }
-
-            @Override
-            public String getCharacterEncoding() {
-                return this.characterEncoding;
-            }
-
-            @Override
-            public void setStatus(int sc) {
-                this.status = sc;
-            }
-
-            @Override
-            public int getStatus() {
-                return this.status;
-            }
-        };
 
         Path tempFile = createTempFile("invalid-casc-config", ".yaml");
         write(tempFile, asList("unclassified:", "  this_fake_property_forces_a_configurator_exception: true"));
         System.setProperty("casc.jenkins.config", tempFile.toAbsolutePath().toString());
 
         try {
-            tokenReloadAction.doIndex(newRequest("someSecretValue"), new ResponseImpl(null, response));
+            JenkinsRule.WebClient wc = j.createWebClient();
+            wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
 
-            assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response.getStatus());
+            URL url = new URL(j.getURL(), "reload-configuration-as-code/?casc-reload-token=someSecretValue");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            WebResponse response = wc.getPage(request).getWebResponse();
 
+            assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
             assertEquals("application/json", response.getContentType());
 
-            String body = stringWriter.toString();
-            assertTrue("Response body should contain error status key", body.contains("\"status\""));
-            assertTrue("Response body should indicate an error state", body.contains("\"error\""));
+            String body = response.getContentAsString();
             assertTrue(
                     "Response body should contain the failure contextual message",
                     body.contains("Failed to reload configuration"));
+            assertTrue(
+                    "Response body should expose the specific invalid YAML property",
+                    body.contains("this_fake_property_forces_a_configurator_exception"));
 
             List<LogRecord> messages = loggerRule.getRecords();
             boolean hasSevereLog = messages.stream()
@@ -242,6 +209,17 @@ public class TokenReloadActionTest {
 
         } finally {
             Files.deleteIfExists(tempFile);
+            if (oldToken != null) {
+                System.setProperty("casc.reload.token", oldToken);
+            } else {
+                System.clearProperty("casc.reload.token");
+            }
+
+            if (oldConfig != null) {
+                System.setProperty("casc.jenkins.config", oldConfig);
+            } else {
+                System.clearProperty("casc.jenkins.config");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2304 

Return structured error responses when JCasC reload fails. Return an HTTP 500 response with a JSON error body when a Configuration as Code reload triggered via the reload endpoint fails, rather than a generic server error. This provides clients with actionable error details while preserving successful reload behavior. Add integration tests covering reload failures, JSON error responses, and server-side logging.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
