### PR TITLE
Preserve setter generic type information during attribute resolution

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/BaseConfigurator.java
@@ -153,7 +153,22 @@ public abstract class BaseConfigurator<T> implements Configurator<T> {
 
             TypePair getterType = TypePair.ofReturnType(g);
             if (type.rawType.isAssignableFrom(getterType.rawType)) {
-                type = getterType;
+                Class<?> setterComponent = getComponentType(type);
+
+                boolean setterIsUntyped =
+                        setterComponent == null || setterComponent == Object.class || setterComponent == type.rawType;
+
+                if (setterIsUntyped) {
+                    Class<?> getterComponent = getComponentType(getterType);
+
+                    boolean getterIsTyped = getterComponent != null
+                            && getterComponent != Object.class
+                            && getterComponent != getterType.rawType;
+
+                    if (getterIsTyped) {
+                        type = new TypePair(getterType.type, type.rawType);
+                    }
+                }
             }
 
             if (Map.class.isAssignableFrom(type.rawType)) {

--- a/plugin/src/test/java/io/jenkins/plugins/casc/BaseConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/BaseConfiguratorTest.java
@@ -11,6 +11,7 @@ import hudson.util.PersistedList;
 import io.jenkins.plugins.casc.model.Mapping;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -239,6 +240,18 @@ public class BaseConfiguratorTest {
 
         @Restricted(Beta.class)
         public void setRestrictedSetter(String val) {}
+
+        public List<Dog> getCollectionToList() {
+            return null;
+        }
+
+        public void setCollectionToList(Collection<Animal> vals) {}
+
+        public List<Dog> getPriorityStrategies() {
+            return null;
+        }
+
+        public void setPriorityStrategies(List<? extends Animal> vals) {}
     }
 
     public static class DummyConfigurator extends BaseConfigurator<DummyTarget> {
@@ -290,7 +303,7 @@ public class BaseConfiguratorTest {
         Map<String, Class<?>> resolvedAttributes =
                 attributes.stream().collect(Collectors.toMap(Attribute::getName, attr -> (Class<?>) attr.getType()));
 
-        assertEquals("Should discover exactly 24 configurable properties", 24, resolvedAttributes.size());
+        assertEquals("Should discover exactly 26 configurable properties", 26, resolvedAttributes.size());
 
         assertEquals("Standard setter should resolve to String", String.class, resolvedAttributes.get("standard"));
 
@@ -344,6 +357,16 @@ public class BaseConfiguratorTest {
                 "Should map wrapper setter with primitive getter",
                 Integer.class,
                 resolvedAttributes.get("wrapperSetter"));
+
+        assertEquals(
+                "When setter takes Collection and getter returns List, the setter's type is used",
+                Animal.class,
+                resolvedAttributes.get("collectionToList"));
+
+        assertEquals(
+                "When setter and getter share the same raw type, the setter's generic signature is preserved",
+                Animal.class,
+                resolvedAttributes.get("priorityStrategies"));
 
         assertEquals(boolean.class, resolvedAttributes.get("primitiveBoolean"));
         assertEquals(long.class, resolvedAttributes.get("primitiveLong"));
@@ -401,7 +424,9 @@ public class BaseConfiguratorTest {
                         "primitiveShort",
                         "voidEdgeCase",
                         "restrictedList",
-                        "restrictedSetter"),
+                        "restrictedSetter",
+                        "collectionToList",
+                        "priorityStrategies"),
                 resolvedAttributes.keySet());
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/BaseConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/BaseConfiguratorTest.java
@@ -252,6 +252,13 @@ public class BaseConfiguratorTest {
         }
 
         public void setPriorityStrategies(List<? extends Animal> vals) {}
+
+        public List<Dog> getUntypedCollection() {
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        public void setUntypedCollection(Collection val) {}
     }
 
     public static class DummyConfigurator extends BaseConfigurator<DummyTarget> {
@@ -303,7 +310,7 @@ public class BaseConfiguratorTest {
         Map<String, Class<?>> resolvedAttributes =
                 attributes.stream().collect(Collectors.toMap(Attribute::getName, attr -> (Class<?>) attr.getType()));
 
-        assertEquals("Should discover exactly 26 configurable properties", 26, resolvedAttributes.size());
+        assertEquals("Should discover exactly 27 configurable properties", 27, resolvedAttributes.size());
 
         assertEquals("Standard setter should resolve to String", String.class, resolvedAttributes.get("standard"));
 
@@ -368,6 +375,11 @@ public class BaseConfiguratorTest {
                 Animal.class,
                 resolvedAttributes.get("priorityStrategies"));
 
+        assertEquals(
+                "When setter is untyped but getter is typed, it should fallback to the getter's generic component type",
+                Dog.class,
+                resolvedAttributes.get("untypedCollection"));
+
         assertEquals(boolean.class, resolvedAttributes.get("primitiveBoolean"));
         assertEquals(long.class, resolvedAttributes.get("primitiveLong"));
         assertEquals(double.class, resolvedAttributes.get("primitiveDouble"));
@@ -426,7 +438,8 @@ public class BaseConfiguratorTest {
                         "restrictedList",
                         "restrictedSetter",
                         "collectionToList",
-                        "priorityStrategies"),
+                        "priorityStrategies",
+                        "untypedCollection"),
                 resolvedAttributes.keySet());
     }
 


### PR DESCRIPTION
Fixes #2866 

This PR fixes a bug in BaseConfigurator where the generic type information declared by a setter could be replaced by the corresponding getter's generic type during attribute resolution.

When a Jenkins plugin declared a broader or wildcard generic type in its setter (for example, List<? extends PriorityStrategy>) but exposed a narrower collection type from its getter, JCasC would use the getter's generic type in place of the setter's declared generic type. As a result, polymorphic HeteroDescribable collections could no longer be configured correctly.

describe() now treats the setter's generic signature as the source of type information. The getter is only used to recover generic information when the setter provides no meaningful generic type.

Testing

- Added regression tests to BaseConfiguratorTest covering mismatched getter/setter collection signatures.
- Manually verified the fix using a Jenkins instance configured with the Priority Sorter plugin. A configuration that previously failed with an UnknownAttributesException now loads successfully.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
