### PR TITLE
Generate array schema for multiple attributes

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/SchemaGeneration.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SchemaGeneration.java
@@ -54,9 +54,11 @@ public class SchemaGeneration {
                     if (hetero.getTarget() != null) {
                         definitions.put(hetero.getTarget().getName(), heteroSchema);
                     }
-                } else if (configuratorObject instanceof Attribute) {
-                    Attribute attribute = (Attribute) configuratorObject;
-                    if (attribute.type.isEnum()) {
+                } else if (configuratorObject instanceof Attribute<?, ?> attribute) {
+                    if (attribute.multiple) {
+                        generateMultipleAttributeSchema(
+                                schemaConfiguratorObjects, attribute, context, null, definitions);
+                    } else if (attribute.type.isEnum()) {
                         generateEnumAttributeSchema(schemaConfiguratorObjects, attribute, null);
                     } else {
                         schemaConfiguratorObjects.put(
@@ -251,11 +253,16 @@ public class SchemaGeneration {
             JSONObject definitions) {
         Optional<String> description = getDescription(attribute, baseConfigurator);
 
-        if (attribute.type.getName().equals("java.lang.String")) {
-            JSONObject jsonObject = new JSONObject().put("type", "string");
-            description.ifPresent(desc -> jsonObject.put("description", desc));
-            attributeSchema.put(attribute.getName(), jsonObject);
+        JSONObject itemsSchema = new JSONObject();
 
+        if (attribute.type.getName().equals("java.lang.String")) {
+            itemsSchema.put("type", "string");
+        } else if (attribute.type.isEnum()) {
+            ArrayList<String> values = new ArrayList<>();
+            for (Object obj : attribute.type.getEnumConstants()) {
+                values.add(obj.toString());
+            }
+            itemsSchema.put("type", "string").put("enum", new JSONArray(values));
         } else {
             JSONObject properties = new JSONObject();
             Configurator<Object> lookup = context.lookup(attribute.getType());
@@ -266,18 +273,13 @@ public class SchemaGeneration {
                                 generateNonEnumAttributeObject(attr, baseConfigurator, context, definitions)));
             }
 
-            JSONObject attributeObject = new JSONObject()
-                    .put("type", "array")
-                    .put(
-                            "items",
-                            new JSONArray()
-                                    .put(new JSONObject()
-                                            .put("type", "object")
-                                            .put("properties", properties)
-                                            .put("additionalProperties", false)));
-            description.ifPresent(desc -> attributeObject.put("description", desc));
-            attributeSchema.put(attribute.getName(), attributeObject);
+            itemsSchema.put("type", "object").put("properties", properties).put("additionalProperties", false);
         }
+
+        JSONObject attributeObject = new JSONObject().put("type", "array").put("items", itemsSchema);
+
+        description.ifPresent(desc -> attributeObject.put("description", desc));
+        attributeSchema.put(attribute.getName(), attributeObject);
     }
 
     private static void generateEnumAttributeSchema(

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationTest.java
@@ -5,9 +5,12 @@ import static io.jenkins.plugins.casc.misc.Util.validateSchema;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 @WithJenkinsConfiguredWithCode
@@ -61,6 +64,26 @@ class SchemaGenerationTest {
                 validateSchema(convertYamlFileToJson(this, "invalidHeteroConfig.yml")),
                 contains(
                         "#/jenkins/crumbIssuer/standard: extraneous key [someCompletelyFakeProperty] is not permitted"));
+    }
+
+    @Test
+    void arrayAttributesShouldGenerateAsArrays(JenkinsConfiguredWithCodeRule j) {
+        JSONObject schema = SchemaGeneration.generateSchema();
+        JSONObject jenkinsProps =
+                schema.getJSONObject("properties").getJSONObject("jenkins").getJSONObject("properties");
+        JSONObject agentProtocols = jenkinsProps.getJSONObject("agentProtocols");
+
+        assertNotNull(agentProtocols, "agentProtocols should exist in the generated schema");
+        assertEquals("array", agentProtocols.getString("type"), "agentProtocols should be generated as an array type");
+
+        JSONObject items = agentProtocols.getJSONObject("items");
+        assertNotNull(items, "agentProtocols should have an 'items' definition");
+        assertEquals("string", items.getString("type"), "agentProtocols items should be of type string");
+    }
+
+    @Test
+    void validArraySchemaShouldSucceed(JenkinsConfiguredWithCodeRule j) throws Exception {
+        assertThat(validateSchema(convertYamlFileToJson(this, "validArraySchemaConfig.yml")), empty());
     }
 
     //    For testing manually

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/SchemaGenerationTest.java
@@ -8,10 +8,17 @@ import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import hudson.Extension;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import java.util.List;
+import jenkins.model.GlobalConfiguration;
+import org.jenkinsci.Symbol;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 @WithJenkinsConfiguredWithCode
 @SuppressWarnings("unused")
@@ -79,6 +86,51 @@ class SchemaGenerationTest {
         JSONObject items = agentProtocols.getJSONObject("items");
         assertNotNull(items, "agentProtocols should have an 'items' definition");
         assertEquals("string", items.getString("type"), "agentProtocols items should be of type string");
+    }
+
+    @Test
+    void arrayEnumAttributesShouldGenerateAsEnumArrays(JenkinsConfiguredWithCodeRule j) {
+        JSONObject schema = SchemaGeneration.generateSchema();
+
+        JSONObject unclassifiedProps =
+                schema.getJSONObject("properties").getJSONObject("unclassified").getJSONObject("properties");
+        JSONObject dummyConfig = unclassifiedProps.getJSONObject("dummyConfig").getJSONObject("properties");
+        JSONObject myEnums = dummyConfig.getJSONObject("myEnums");
+
+        assertNotNull(myEnums, "myEnums should exist in the generated schema");
+        assertEquals("array", myEnums.getString("type"), "myEnums should be generated as an array type");
+
+        JSONObject items = myEnums.getJSONObject("items");
+        assertNotNull(items, "myEnums should have an 'items' definition");
+        assertEquals("string", items.getString("type"), "myEnums items should be of type string");
+
+        JSONArray enumValues = items.getJSONArray("enum");
+        assertEquals(2, enumValues.length());
+        assertEquals("VALUE_A", enumValues.getString(0));
+        assertEquals("VALUE_B", enumValues.getString(1));
+    }
+
+    public enum DummyEnum {
+        VALUE_A,
+        VALUE_B
+    }
+
+    @Extension
+    @Symbol("dummyConfig")
+    public static class DummyConfig extends GlobalConfiguration {
+        private List<DummyEnum> myEnums;
+
+        @DataBoundConstructor
+        public DummyConfig() {}
+
+        public List<DummyEnum> getMyEnums() {
+            return myEnums;
+        }
+
+        @DataBoundSetter
+        public void setMyEnums(List<DummyEnum> myEnums) {
+            this.myEnums = myEnums;
+        }
     }
 
     @Test

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/validArraySchemaConfig.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/validArraySchemaConfig.yml
@@ -1,0 +1,4 @@
+jenkins:
+  agentProtocols:
+    - "JNLP4-connect"
+    - "Ping"


### PR DESCRIPTION
Fixes #2241 

Generate JSON Schema array definitions for attributes marked as multiple instead of emitting scalar string types. Add regression tests to verify array schema generation and validation.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
