### PR TITLE
Suppress warnings for missing files when using fallback

### DIFF
--- a/docs/features/secrets.adoc
+++ b/docs/features/secrets.adoc
@@ -134,6 +134,12 @@ Safe Password Example:
 ${trim:${readFile:/secret/file-user-password.txt}}
 ```
 
+Fallback Example:
+
+```
+${readFile:/secret/file-user-password.txt:-fallback-password}
+```
+
 ==== readFileBase64
 
 Read the specified binary file into a base64 representation.

--- a/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/SecretSourceResolver.java
@@ -8,12 +8,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.commons.text.lookup.StringLookup;
@@ -155,7 +156,7 @@ public class SecretSourceResolver {
         public String lookup(String key) {
             return context.getSecretSources().stream()
                     .map(source -> unchecked(() -> source.reveal(key)).apply())
-                    .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
+                    .flatMap(Optional::stream)
                     .findFirst()
                     .orElse(null);
         }
@@ -187,7 +188,10 @@ public class SecretSourceResolver {
         @Override
         public String lookup(@NonNull final String key) {
             try {
-                return new String(Files.readAllBytes(Paths.get(key)), StandardCharsets.UTF_8);
+                return Files.readString(Paths.get(key));
+            } catch (NoSuchFileException e) {
+                LOGGER.log(Level.FINE, String.format("Configuration import: File '%s' not found.", key));
+                return null;
             } catch (IOException | InvalidPathException e) {
                 LOGGER.log(
                         Level.WARNING,
@@ -229,6 +233,9 @@ public class SecretSourceResolver {
             try {
                 byte[] fileContent = Files.readAllBytes(Paths.get(key));
                 return Base64.getEncoder().encodeToString(fileContent);
+            } catch (NoSuchFileException e) {
+                LOGGER.log(Level.FINE, String.format("Configuration import: File '%s' not found.", key));
+                return null;
             } catch (IOException | InvalidPathException e) {
                 LOGGER.log(
                         Level.WARNING,

--- a/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/SecretSourceResolverTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -326,8 +327,6 @@ public class SecretSourceResolverTest {
     @Test
     public void resolve_FileNotFound() {
         resolve("${readFile:./hello-world-not-found.txt}");
-        assertTrue(logContains(
-                "Configuration import: Error looking up file './hello-world-not-found.txt' with UTF-8 encoding."));
         assertTrue(
                 logContains("Configuration import: Found unresolved variable 'readFile:./hello-world-not-found.txt'."));
     }
@@ -335,7 +334,6 @@ public class SecretSourceResolverTest {
     @Test
     public void resolve_FileBase64NotFound() {
         resolve("${readFileBase64:./hello-world-not-found.txt}");
-        assertTrue(logContains("Configuration import: Error looking up file './hello-world-not-found.txt'."));
         assertTrue(logContains(
                 "Configuration import: Found unresolved variable 'readFileBase64:./hello-world-not-found.txt'."));
     }
@@ -575,5 +573,39 @@ public class SecretSourceResolverTest {
             resolve("${FOO}:${MISSING}");
         });
         assertThat(exception.getMessage(), containsString("MISSING"));
+    }
+
+    @Test
+    public void resolve_FileNotFoundWithFallback() {
+        String output = resolve("${readFile:./hello-world-not-found.txt:-fallback_value}");
+
+        assertThat(output, equalTo("fallback_value"));
+
+        assertFalse(
+                "Should not log error for missing file when using fallback",
+                logContains("Configuration import: Error looking up file './hello-world-not-found.txt'"));
+
+        assertFalse(
+                "Should not log unresolved variable warning",
+                logContains("Configuration import: Found unresolved variable 'readFile:./hello-world-not-found.txt'"));
+    }
+
+    @Test
+    public void resolve_FileBase64NotFoundWithFallback() {
+        String output = resolve("${readFileBase64:./hello-world-not-found.txt:-fallback_base64}");
+
+        assertThat(output, equalTo("fallback_base64"));
+
+        assertFalse(
+                "Should not log error for missing file when using fallback",
+                logContains("Configuration import: Error looking up file './hello-world-not-found.txt'"));
+    }
+
+    @Test
+    public void resolve_FileAliasNotFoundWithFallback() {
+        String output = resolve("${file:./hello-world-not-found.txt:-fallback}");
+
+        assertThat(output, equalTo("fallback"));
+        assertFalse(logContains("Configuration import: Error looking up file './hello-world-not-found.txt'"));
     }
 }


### PR DESCRIPTION
Fixes #2229 

Suppress warnings for missing readFile lookups when using fallback values. When a readFile or file lookup is used with the standard :- fallback syntax, a missing file is an expected condition because the fallback value is used. Treat NoSuchFileException as a non-warning case by returning null without emitting a warning, while continuing to log other I/O and path-related errors. Add regression tests to verify fallback behavior remains warning-free.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
