### PR TITLE
Add GitHub OAuth matrix authorization examples

### DIFF
--- a/demos/matrix-auth/README.md
+++ b/demos/matrix-auth/README.md
@@ -75,6 +75,25 @@ https://plugins.jenkins.io/github-oauth/
 
 You can configure authorization based on GitHub users, organizations, or teams.
 
-- **username** - specific GitHub username.
-- **organization** - every user that belongs to a specific GitHub organization.
-- **organization*team** - specific GitHub team of a GitHub organization.
+- **username** - specific GitHub username (mapped as `user`).
+- **organization** - every user that belongs to a specific GitHub organization (mapped as `group`).
+- **organization*team** - specific GitHub team of a GitHub organization (mapped as `group`).
+
+```yaml
+jenkins:
+  authorizationStrategy:
+    globalMatrix:
+      entries:
+        - user:
+            name: "octocat"
+            permissions:
+              - "Overall/Administer"
+        - group:
+            name: "myorg"
+            permissions:
+              - "Overall/Read"
+        - group:
+            name: "myorg*myteam"
+            permissions:
+              - "Job/Build"
+```

--- a/demos/matrix-auth/README.md
+++ b/demos/matrix-auth/README.md
@@ -75,9 +75,9 @@ https://plugins.jenkins.io/github-oauth/
 
 You can configure authorization based on GitHub users, organizations, or teams.
 
-- **username** - specific GitHub username (mapped as `user`).
-- **organization** - every user that belongs to a specific GitHub organization (mapped as `group`).
-- **organization*team** - specific GitHub team of a GitHub organization (mapped as `group`).
+- **username** - specific GitHub username.
+- **organization** - every user that belongs to a specific GitHub organization.
+- **organization*team** - specific GitHub team of a GitHub organization.
 
 ```yaml
 jenkins:

--- a/integrations/src/test/java/io/jenkins/plugins/casc/MatrixAuthorizationTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/MatrixAuthorizationTest.java
@@ -1,6 +1,9 @@
 package io.jenkins.plugins.casc;
 
+import static jenkins.model.Jenkins.ADMINISTER;
+import static jenkins.model.Jenkins.READ;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.Job;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
@@ -56,5 +59,29 @@ public class MatrixAuthorizationTest {
 
         Set<PermissionEntry> readPermission = gms.getGrantedPermissionEntries().get(Jenkins.READ);
         Assertions.assertEquals("anonymous", readPermission.iterator().next().getSid());
+    }
+
+    @Test
+    @ConfiguredWithReadme("matrix-auth/README.md#2")
+    public void checkGithubCorrectlyConfiguredPermissions() {
+        assertEquals(
+                "The configured instance must use the Global Matrix Authentication Strategy",
+                GlobalMatrixAuthorizationStrategy.class,
+                Jenkins.get().getAuthorizationStrategy().getClass());
+        GlobalMatrixAuthorizationStrategy gms =
+                (GlobalMatrixAuthorizationStrategy) Jenkins.get().getAuthorizationStrategy();
+
+        Set<PermissionEntry> adminPermission = gms.getGrantedPermissionEntries().get(ADMINISTER);
+        assertTrue(
+                adminPermission.contains(PermissionEntry.user("octocat")),
+                "octocat user should have Administer permission");
+
+        Set<PermissionEntry> readPermission = gms.getGrantedPermissionEntries().get(READ);
+        assertTrue(readPermission.contains(PermissionEntry.group("myorg")), "myorg group should have Read permission");
+
+        Set<PermissionEntry> buildPermission = gms.getGrantedPermissionEntries().get(Job.BUILD);
+        assertTrue(
+                buildPermission.contains(PermissionEntry.group("myorg*myteam")),
+                "myorg*myteam group should have Build permission");
     }
 }


### PR DESCRIPTION
Fixes #1980 

Add Configuration as Code examples showing how to configure GitHub OAuth users, organizations, and teams with the Matrix Authorization Strategy plugin. Document the mapping of GitHub usernames to user entries and GitHub organizations and organization combinations to group entries, and add a README-backed integration test to verify the examples.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
