### PR TITLE
Improve unknown root element error message with troubleshooting guidance

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -841,7 +841,12 @@ public class ConfigurationAsCode extends ManagementLink {
             });
 
             if (!unknownKeys.isEmpty()) {
-                throw new UnknownConfiguratorException(unknownKeys, "No configurator for the following root elements:");
+                String message = String.format(
+                        "No configurator found for the following root element(s): %s. "
+                                + "This may indicate that the required plugin is not installed or failed to load. "
+                                + "Verify that the plugin is installed and check the Jenkins startup logs for plugin loading errors.",
+                        String.join(", ", unknownKeys));
+                throw new UnknownConfiguratorException(unknownKeys, message);
             }
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -842,10 +842,10 @@ public class ConfigurationAsCode extends ManagementLink {
 
             if (!unknownKeys.isEmpty()) {
                 String message = String.format(
-                        "No configurator found for the following root element(s): %s. "
+                        "No configurator found for the following root %s: %s. "
                                 + "This may indicate that the required plugin is not installed or failed to load. "
                                 + "Verify that the plugin is installed and check the Jenkins startup logs for plugin loading errors.",
-                        String.join(", ", unknownKeys));
+                        unknownKeys.size() > 1 ? "elements" : "element", String.join(", ", unknownKeys));
                 throw new UnknownConfiguratorException(unknownKeys, message);
             }
         }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
@@ -68,7 +68,7 @@ class ErrorPageTest {
         Files.write(cascFile, "invalid:\n  systemMessage2: Hello World\n".getBytes());
 
         String pageContent = reloadConfiguration();
-        assertThat(pageContent, containsString("No configurator found for the following root element(s):"));
+        assertThat(pageContent, containsString("No configurator found for the following root element:"));
         assertThat(pageContent, containsString("invalid"));
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/ErrorPageTest.java
@@ -68,7 +68,7 @@ class ErrorPageTest {
         Files.write(cascFile, "invalid:\n  systemMessage2: Hello World\n".getBytes());
 
         String pageContent = reloadConfiguration();
-        assertThat(pageContent, containsString("No configurator for the following root elements"));
+        assertThat(pageContent, containsString("No configurator found for the following root element(s):"));
         assertThat(pageContent, containsString("invalid"));
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
@@ -19,7 +19,7 @@ class UnknownRootElementTest {
                 .configure(Objects.requireNonNull(getClass().getResource("unknown1.yml"))
                         .toExternalForm()));
 
-        assertThat(ex.getMessage(), containsString("No configurator found for the following root element(s): alice"));
+        assertThat(ex.getMessage(), containsString("No configurator found for the following root element: alice"));
     }
 
     @Test
@@ -29,7 +29,7 @@ class UnknownRootElementTest {
                         .toExternalForm()));
 
         assertThat(
-                ex.getMessage(), containsString("No configurator found for the following root element(s): bob, alice"));
+                ex.getMessage(), containsString("No configurator found for the following root elements: bob, alice"));
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
@@ -1,9 +1,11 @@
 package io.jenkins.plugins.casc;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -13,20 +15,21 @@ class UnknownRootElementTest {
 
     @Test
     void oneUnknown(JenkinsRule j) {
-        assertThrows(
-                ConfiguratorException.class,
-                () -> ConfigurationAsCode.get()
-                        .configure(getClass().getResource("unknown1.yml").toExternalForm()),
-                "No configurator for the following root elements alice");
+        ConfiguratorException ex = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
+                .configure(Objects.requireNonNull(getClass().getResource("unknown1.yml"))
+                        .toExternalForm()));
+
+        assertThat(ex.getMessage(), containsString("No configurator found for the following root element(s): alice"));
     }
 
     @Test
     void twoUnknown(JenkinsRule j) {
-        assertThrows(
-                ConfiguratorException.class,
-                () -> ConfigurationAsCode.get()
-                        .configure(getClass().getResource("unknown2.yml").toExternalForm()),
-                "No configurator for the following root elements bob, alice");
+        ConfiguratorException ex = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
+                .configure(Objects.requireNonNull(getClass().getResource("unknown2.yml"))
+                        .toExternalForm()));
+
+        assertThat(
+                ex.getMessage(), containsString("No configurator found for the following root element(s): bob, alice"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1845 

When Configuration as Code encounters unknown root elements, provide a more descriptive error message that explains the missing configurator may be caused by a required plugin not being installed or failing to load, and guide users to check the Jenkins startup logs for plugin loading errors. Update the corresponding tests to validate the new error message.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->