### PR TITLE
Support configuring API tokens for local users

### DIFF
--- a/integrations/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmApiTokenTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmApiTokenTest.java
@@ -1,15 +1,25 @@
 package io.jenkins.plugins.casc.core;
 
 import static hudson.model.User.getById;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import hudson.model.User;
+import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.util.Secret;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Objects;
 import jenkins.security.ApiTokenProperty;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,5 +91,63 @@ public class HudsonPrivateSecurityRealmApiTokenTest {
         }
 
         assertFalse("Masked tokens should be skipped and not added to the store", hasMaskedToken);
+    }
+
+    @Test
+    @ConfiguredWithCode("HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml")
+    public void export_api_tokens() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        HudsonPrivateSecurityRealmConfigurator configurator = new HudsonPrivateSecurityRealmConfigurator();
+
+        HudsonPrivateSecurityRealm realm = (HudsonPrivateSecurityRealm) j.jenkins.getSecurityRealm();
+
+        CNode node = configurator.describe(realm, context);
+        assertNotNull(node);
+
+        Mapping realmMapping = node.asMapping();
+        Sequence users = realmMapping.get("users").asSequence();
+
+        Mapping userMapping = null;
+        for (CNode userNode : users) {
+            if ("tokenuser".equals(userNode.asMapping().getScalarValue("id"))) {
+                userMapping = userNode.asMapping();
+                break;
+            }
+        }
+        assertNotNull("Exported users should include 'tokenuser'", userMapping);
+
+        Sequence apiTokens = userMapping.get("apiTokens").asSequence();
+        Mapping firstToken = apiTokens.get(0).asMapping();
+
+        assertEquals("Exported token name should be 'test-token'", "test-token", firstToken.getScalarValue("name"));
+
+        String exportedEncryptedToken = firstToken.getScalarValue("token");
+        assertEquals(
+                "Exported token value MUST be masked",
+                "****",
+                Secret.fromString(exportedEncryptedToken).getPlainText());
+    }
+
+    @Test
+    @ConfiguredWithCode("HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml")
+    public void reapply_config_revokes_existing_tokens() throws Exception {
+
+        String yamlResource = Objects.requireNonNull(
+                        this.getClass().getResource("HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml"))
+                .toExternalForm();
+        ConfigurationAsCode.get().configure(yamlResource);
+
+        final User user = getById("tokenuser", false);
+        assertNotNull(user);
+
+        ApiTokenProperty tokenProperty = user.getProperty(ApiTokenProperty.class);
+        assertNotNull(tokenProperty);
+
+        Method getTokenListMethod = ApiTokenProperty.class.getMethod("getTokenList");
+        Collection<?> tokenList = (Collection<?>) getTokenListMethod.invoke(tokenProperty);
+        assertNotNull(tokenList);
+
+        assertFalse("Token list should not be empty after revocation and re-adding", tokenList.isEmpty());
     }
 }

--- a/integrations/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmApiTokenTest.java
+++ b/integrations/src/test/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmApiTokenTest.java
@@ -1,0 +1,85 @@
+package io.jenkins.plugins.casc.core;
+
+import static hudson.model.User.getById;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import hudson.model.User;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import jenkins.security.ApiTokenProperty;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class HudsonPrivateSecurityRealmApiTokenTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml")
+    public void configure_api_tokens() throws Exception {
+        final User user = getById("tokenuser", false);
+        assertNotNull("User 'tokenuser' should exist", user);
+
+        ApiTokenProperty tokenProperty = user.getProperty(ApiTokenProperty.class);
+        assertNotNull("User should have ApiTokenProperty", tokenProperty);
+
+        Method getTokenListMethod = ApiTokenProperty.class.getMethod("getTokenList");
+        Collection<?> tokenList = (Collection<?>) getTokenListMethod.invoke(tokenProperty);
+
+        boolean hasTestToken = false;
+        if (tokenList != null) {
+            for (Object t : tokenList) {
+                String tName;
+                try {
+                    tName = (String) t.getClass().getField("name").get(t);
+                } catch (Exception e) {
+                    tName = (String) t.getClass().getMethod("getName").invoke(t);
+                }
+
+                if ("test-token".equals(tName)) {
+                    hasTestToken = true;
+                    break;
+                }
+            }
+        }
+
+        assertTrue("User should have an API token named 'test-token'", hasTestToken);
+    }
+
+    @Test
+    @ConfiguredWithCode("HudsonPrivateSecurityRealmConfiguratorTest_maskedTokens.yml")
+    public void skip_masked_api_tokens() throws Exception {
+        final User user = getById("maskeduser", false);
+        assertNotNull("User 'maskeduser' should exist", user);
+
+        ApiTokenProperty tokenProperty = user.getProperty(ApiTokenProperty.class);
+        assertNotNull("User should have ApiTokenProperty", tokenProperty);
+
+        Method getTokenListMethod = ApiTokenProperty.class.getMethod("getTokenList");
+        Collection<?> tokenList = (Collection<?>) getTokenListMethod.invoke(tokenProperty);
+
+        boolean hasMaskedToken = false;
+        if (tokenList != null) {
+            for (Object t : tokenList) {
+                String tName;
+                try {
+                    tName = (String) t.getClass().getField("name").get(t);
+                } catch (Exception e) {
+                    tName = (String) t.getClass().getMethod("getName").invoke(t);
+                }
+
+                if ("masked-token".equals(tName)) {
+                    hasMaskedToken = true;
+                    break;
+                }
+            }
+        }
+
+        assertFalse("Masked tokens should be skipped and not added to the store", hasMaskedToken);
+    }
+}

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml
@@ -7,4 +7,3 @@ jenkins:
           apiTokens:
             - name: "test-token"
               token: "111234567890abcdef1234567890abcdef"
-

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest_apiTokens.yml
@@ -1,0 +1,10 @@
+jenkins:
+  securityRealm:
+    local:
+      users:
+        - id: "tokenuser"
+          password: "password123"
+          apiTokens:
+            - name: "test-token"
+              token: "111234567890abcdef1234567890abcdef"
+

--- a/integrations/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest_maskedTokens.yml
+++ b/integrations/src/test/resources/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfiguratorTest_maskedTokens.yml
@@ -1,0 +1,9 @@
+jenkins:
+  securityRealm:
+    local:
+      users:
+        - id: "maskeduser"
+          password: "password123"
+          apiTokens:
+            - name: "masked-token"
+              token: "****"

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
@@ -12,10 +12,13 @@ import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator;
 import io.jenkins.plugins.casc.model.CNode;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import jenkins.security.ApiTokenProperty;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -30,6 +33,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurator<HudsonPrivateSecurityRealm> {
     // matches HudsonPrivateSecurityRealm.JBCRYPT_HEADER
     private static final String HASHED_PASSWORD_PREFIX = "#jbcrypt:";
+    private static final String MASKED_TOKEN_VALUE = "****";
 
     public HudsonPrivateSecurityRealmConfigurator() {
         super(HudsonPrivateSecurityRealm.class);
@@ -74,6 +78,38 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                             .collect(Collectors.toList());
                     user.setProperties(properties);
 
+                    ApiTokenProperty tokenProperty = u.getProperty(ApiTokenProperty.class);
+                    if (tokenProperty != null) {
+                        try {
+                            Method getTokenListMethod = ApiTokenProperty.class.getMethod("getTokenList");
+                            Collection<?> tokenList = (Collection<?>) getTokenListMethod.invoke(tokenProperty);
+
+                            if (tokenList != null && !tokenList.isEmpty()) {
+                                List<ApiToken> exportedTokens = tokenList.stream()
+                                        .map(t -> {
+                                            try {
+                                                String name;
+                                                try {
+                                                    name = (String) t.getClass()
+                                                            .getField("name")
+                                                            .get(t);
+                                                } catch (Exception e) {
+                                                    name = (String) t.getClass()
+                                                            .getMethod("getName")
+                                                            .invoke(t);
+                                                }
+                                                return new ApiToken(name, MASKED_TOKEN_VALUE);
+                                            } catch (Exception e) {
+                                                return null;
+                                            }
+                                        })
+                                        .filter(Objects::nonNull)
+                                        .collect(Collectors.toList());
+                                user.setApiTokens(exportedTokens);
+                            }
+                        } catch (Exception ignored) {
+                        }
+                    }
                     return user;
                 })
                 .collect(Collectors.toList());
@@ -90,13 +126,79 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                     updatedUser.addProperty(property);
                 }
             }
+
+            if (user.getApiTokens() != null && !user.getApiTokens().isEmpty()) {
+                ApiTokenProperty tokenProperty = updatedUser.getProperty(ApiTokenProperty.class);
+                if (tokenProperty == null) {
+                    tokenProperty = new ApiTokenProperty();
+                    updatedUser.addProperty(tokenProperty);
+                }
+
+                try {
+                    Method getTokenListMethod = ApiTokenProperty.class.getMethod("getTokenList");
+                    Collection<?> tokenList = (Collection<?>) getTokenListMethod.invoke(tokenProperty);
+
+                    Method getTokenStoreMethod = ApiTokenProperty.class.getMethod("getTokenStore");
+                    Object tokenStore = getTokenStoreMethod.invoke(tokenProperty);
+
+                    Method revokeTokenMethod = null;
+                    Method addFixedNewTokenMethod = null;
+
+                    for (Method m : tokenStore.getClass().getMethods()) {
+                        if ("revokeToken".equals(m.getName()) && m.getParameterCount() == 1) {
+                            revokeTokenMethod = m;
+                        } else if ("addFixedNewToken".equals(m.getName()) && m.getParameterCount() == 2) {
+                            addFixedNewTokenMethod = m;
+                        }
+                    }
+
+                    if (addFixedNewTokenMethod != null) {
+                        for (ApiToken apiToken : user.getApiTokens()) {
+                            if (MASKED_TOKEN_VALUE.equals(apiToken.token())) {
+                                continue;
+                            }
+
+                            if (tokenList != null) {
+                                for (Object t : tokenList) {
+                                    String tName;
+                                    String tUuid;
+                                    try {
+                                        tName = (String)
+                                                t.getClass().getField("name").get(t);
+                                        tUuid = (String)
+                                                t.getClass().getField("uuid").get(t);
+                                    } catch (Exception ex) {
+                                        tName = (String) t.getClass()
+                                                .getMethod("getName")
+                                                .invoke(t);
+                                        tUuid = (String) t.getClass()
+                                                .getMethod("getUuid")
+                                                .invoke(t);
+                                    }
+
+                                    if (Objects.equals(tName, apiToken.name()) && revokeTokenMethod != null) {
+                                        revokeTokenMethod.invoke(tokenStore, tUuid);
+                                    }
+                                }
+                            }
+
+                            addFixedNewTokenMethod.invoke(tokenStore, apiToken.name(), apiToken.token());
+                        }
+                    } else {
+                        throw new IOException("ApiTokenStore does not expose addFixedNewToken(String, String)");
+                    }
+                } catch (Exception e) {
+                    throw new IOException("Failed to configure API tokens via reflection", e);
+                }
+            }
+            updatedUser.save();
         }
     }
 
     private static User createAccount(HudsonPrivateSecurityRealm target, UserWithPassword user) throws IOException {
         User updatedUser;
         if (StringUtils.isNotBlank(user.password)) {
-            if (StringUtils.startsWith(user.password, HASHED_PASSWORD_PREFIX)) {
+            if (user.password.startsWith(HASHED_PASSWORD_PREFIX)) {
                 updatedUser = target.createAccountWithHashedPassword(user.id, user.password);
             } else {
                 updatedUser = target.createAccount(user.id, user.password);
@@ -114,6 +216,7 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
         private String name;
         private String description;
         private List<UserProperty> properties;
+        private List<ApiToken> apiTokens;
 
         @DataBoundConstructor
         public UserWithPassword(String id, String password) {
@@ -151,5 +254,20 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
         public List<UserProperty> getProperties() {
             return properties;
         }
+
+        @DataBoundSetter
+        public void setApiTokens(List<ApiToken> apiTokens) {
+            this.apiTokens = apiTokens;
+        }
+
+        public List<ApiToken> getApiTokens() {
+            return apiTokens;
+        }
+    }
+
+    public record ApiToken(String name, String token) {
+
+        @DataBoundConstructor
+        public ApiToken {}
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
@@ -6,6 +6,7 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.util.Secret;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
@@ -98,7 +99,7 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                                                             .getMethod("getName")
                                                             .invoke(t);
                                                 }
-                                                return new ApiToken(name, MASKED_TOKEN_VALUE);
+                                                return new ApiToken(name, Secret.fromString(MASKED_TOKEN_VALUE));
                                             } catch (Exception e) {
                                                 return null;
                                             }
@@ -154,7 +155,7 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
 
                     if (addFixedNewTokenMethod != null) {
                         for (ApiToken apiToken : user.getApiTokens()) {
-                            if (MASKED_TOKEN_VALUE.equals(apiToken.token())) {
+                            if (MASKED_TOKEN_VALUE.equals(Secret.toString(apiToken.token()))) {
                                 continue;
                             }
 
@@ -182,7 +183,8 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                                 }
                             }
 
-                            addFixedNewTokenMethod.invoke(tokenStore, apiToken.name(), apiToken.token());
+                            addFixedNewTokenMethod.invoke(
+                                    tokenStore, apiToken.name(), Secret.toString(apiToken.token()));
                         }
                     } else {
                         throw new IOException("ApiTokenStore does not expose addFixedNewToken(String, String)");
@@ -265,7 +267,7 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
         }
     }
 
-    public record ApiToken(String name, String token) {
+    public record ApiToken(String name, Secret token) {
 
         @DataBoundConstructor
         public ApiToken {}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java
@@ -94,13 +94,13 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                                                     name = (String) t.getClass()
                                                             .getField("name")
                                                             .get(t);
-                                                } catch (Exception e) {
+                                                } catch (ReflectiveOperationException e) {
                                                     name = (String) t.getClass()
                                                             .getMethod("getName")
                                                             .invoke(t);
                                                 }
                                                 return new ApiToken(name, Secret.fromString(MASKED_TOKEN_VALUE));
-                                            } catch (Exception e) {
+                                            } catch (ReflectiveOperationException e) {
                                                 return null;
                                             }
                                         })
@@ -108,7 +108,7 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                                         .collect(Collectors.toList());
                                 user.setApiTokens(exportedTokens);
                             }
-                        } catch (Exception ignored) {
+                        } catch (ReflectiveOperationException ignored) {
                         }
                     }
                     return user;
@@ -168,7 +168,7 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                                                 t.getClass().getField("name").get(t);
                                         tUuid = (String)
                                                 t.getClass().getField("uuid").get(t);
-                                    } catch (Exception ex) {
+                                    } catch (ReflectiveOperationException ex) {
                                         tName = (String) t.getClass()
                                                 .getMethod("getName")
                                                 .invoke(t);
@@ -189,7 +189,7 @@ public class HudsonPrivateSecurityRealmConfigurator extends DataBoundConfigurato
                     } else {
                         throw new IOException("ApiTokenStore does not expose addFixedNewToken(String, String)");
                     }
-                } catch (Exception e) {
+                } catch (ReflectiveOperationException e) {
                     throw new IOException("Failed to configure API tokens via reflection", e);
                 }
             }


### PR DESCRIPTION
Fixes #1830 

Allow Configuration as Code to configure fixed API tokens for users defined in the local security realm. Also export configured API tokens as masked values and add integration tests covering token configuration and masked token
handling.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
