### PR TITLE
Include configuration-as-code section in exported YAML

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationContext.java
@@ -163,7 +163,7 @@ public class ConfigurationContext implements ConfiguratorRegistry {
 
     // Once we introduce some breaking change on the model inference mechanism, we will introduce `TWO` and so on
     // And this new mechanism will only get enabled when configuration file uses this version or later
-    enum Version {
+    public enum Version {
         ONE("1");
 
         private final String value;
@@ -202,7 +202,7 @@ public class ConfigurationContext implements ConfiguratorRegistry {
     /**
      * Policy regarding unknown attributes.
      */
-    enum Unknown {
+    public enum Unknown {
         reject,
         warn
     }
@@ -210,7 +210,7 @@ public class ConfigurationContext implements ConfiguratorRegistry {
     /**
      * Policy regarding {@link org.kohsuke.accmod.Restricted} attributes.
      */
-    enum Restriction {
+    public enum Restriction {
         reject,
         beta,
         warn
@@ -219,7 +219,7 @@ public class ConfigurationContext implements ConfiguratorRegistry {
     /**
      * Policy regarding {@link Deprecated} attributes.
      */
-    enum Deprecation {
+    public enum Deprecation {
         reject,
         warn
     }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/SelfConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/impl/configurators/SelfConfigurator.java
@@ -51,6 +51,11 @@ public class SelfConfigurator extends BaseConfigurator<ConfigurationContext>
     @CheckForNull
     @Override
     public CNode describe(ConfigurationContext instance, ConfigurationContext context) throws Exception {
-        return compare(instance, new ConfigurationContext(null), context);
+        Mapping mapping = new Mapping();
+        mapping.put("version", instance.getVersion().value());
+        mapping.put("deprecated", instance.getDeprecated().name());
+        mapping.put("restricted", instance.getRestricted().name());
+        mapping.put("unknown", instance.getUnknown().name());
+        return mapping;
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/SelfConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/SelfConfiguratorTest.java
@@ -1,13 +1,21 @@
 package io.jenkins.plugins.casc.impl.configurators;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -27,5 +35,37 @@ class SelfConfiguratorTest {
     void self_configure_restricted(JenkinsConfiguredWithCodeRule j) {
         // expected to throw Configurator Exception
         assertThat(j.jenkins.getRawBuildsDir(), is(not("/tmp")));
+    }
+
+    @Test
+    @SuppressWarnings("unused")
+    void export_configuration_as_code_defaults(JenkinsConfiguredWithCodeRule j) throws Exception {
+        ConfigurationContext context = new ConfigurationContext(null);
+        SelfConfigurator configurator = new SelfConfigurator();
+
+        CNode node = configurator.describe(context, context);
+
+        assertThat(node, is(notNullValue()));
+        Mapping mapping = node.asMapping();
+
+        assertThat(mapping.getScalarValue("version"), is("1"));
+        assertThat(mapping.getScalarValue("deprecated"), is("reject"));
+        assertThat(mapping.getScalarValue("restricted"), is("reject"));
+        assertThat(mapping.getScalarValue("unknown"), is("reject"));
+    }
+
+    @Test
+    @SuppressWarnings("unused")
+    void export_pipeline_contains_configuration_as_code(JenkinsConfiguredWithCodeRule j) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ConfigurationAsCode.get().export(out);
+        String exportedYaml = out.toString(StandardCharsets.UTF_8);
+
+        assertThat(exportedYaml, containsString("configuration-as-code:"));
+        assertThat(exportedYaml, containsString("version: \"1\""));
+        assertThat(exportedYaml, containsString("deprecated: \"reject\""));
+        assertThat(exportedYaml, containsString("restricted: \"reject\""));
+        assertThat(exportedYaml, containsString("unknown: \"reject\""));
     }
 }


### PR DESCRIPTION
Fixes #1792

This PR adds export support for the configuration-as-code root element so it is included in the exported jenkins.yaml.

Since JCasC parsing policies are transient and not persisted as Jenkins state, the exported configuration includes the baseline ConfigurationContext defaults rather than reconstructing the original import-time policies. This keeps the export stateless while making the configuration-as-code section discoverable in exported YAML.

Also adds unit and integration tests to verify the exported configuration and prevent regressions.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
