### PR TITLE
Add JCasC export action for supported items

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/ItemConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ItemConfigurator.java
@@ -1,11 +1,12 @@
 package io.jenkins.plugins.casc;
 
-import hudson.ExtensionPoint;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.TopLevelItem;
 import io.jenkins.plugins.casc.model.CNode;
 
-public interface ItemConfigurator<T extends TopLevelItem> extends ExtensionPoint {
+public interface ItemConfigurator<T extends TopLevelItem> extends Configurator<T> {
 
+    @NonNull
     String getName();
 
     Class<T> getTarget();

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
@@ -11,6 +11,7 @@ import java.io.StringWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.yaml.snakeyaml.nodes.Node;
 
 @SuppressWarnings("ClassCanBeRecord")
@@ -70,8 +71,11 @@ public class ExportItemAction implements Action {
         return "# Could not generate JCasC configuration.";
     }
 
+    @RequirePOST
     @SuppressWarnings("unused")
     public void doDownloadYaml(StaplerResponse2 rsp) throws Exception {
+        item.checkPermission(TopLevelItem.CONFIGURE);
+
         String yamlConfig = getConfig();
 
         rsp.setContentType("application/x-yaml;charset=UTF-8");

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc.core;
 
 import hudson.model.Action;
+import hudson.model.Item;
 import hudson.model.TopLevelItem;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfigurationContext;
@@ -26,7 +27,7 @@ public class ExportItemAction implements Action {
 
     @Override
     public String getIconFileName() {
-        return item.hasPermission(TopLevelItem.CONFIGURE) ? "symbol-code" : null;
+        return item.hasPermission(Item.EXTENDED_READ) ? "symbol-document-text-outline plugin-ionicons-api" : null;
     }
 
     @Override
@@ -44,7 +45,7 @@ public class ExportItemAction implements Action {
     }
 
     public String getConfig() {
-        item.checkPermission(TopLevelItem.CONFIGURE);
+        item.checkPermission(Item.EXTENDED_READ);
 
         try {
             ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
@@ -65,7 +66,7 @@ public class ExportItemAction implements Action {
             }
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, "Failed to export JCasC for item: " + item.getFullName(), e);
-            return "# Error exporting configuration: " + e.getMessage();
+            return "# Error exporting configuration.";
         }
 
         return "# Could not generate JCasC configuration.";
@@ -74,7 +75,7 @@ public class ExportItemAction implements Action {
     @RequirePOST
     @SuppressWarnings("unused")
     public void doDownloadYaml(StaplerResponse2 rsp) throws Exception {
-        item.checkPermission(TopLevelItem.CONFIGURE);
+        item.checkPermission(Item.EXTENDED_READ);
 
         String yamlConfig = getConfig();
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
@@ -1,0 +1,86 @@
+package io.jenkins.plugins.casc.core;
+
+import hudson.model.Action;
+import hudson.model.TopLevelItem;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.model.CNode;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.kohsuke.stapler.StaplerResponse2;
+import org.yaml.snakeyaml.nodes.Node;
+
+@SuppressWarnings("ClassCanBeRecord")
+public class ExportItemAction implements Action {
+
+    private static final Logger LOGGER = Logger.getLogger(ExportItemAction.class.getName());
+    private final TopLevelItem item;
+
+    public ExportItemAction(TopLevelItem item) {
+        this.item = item;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return item.hasPermission(TopLevelItem.CONFIGURE) ? "symbol-code" : null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Export";
+    }
+
+    @Override
+    public String getUrlName() {
+        return "jcasc-export";
+    }
+
+    public TopLevelItem getItem() {
+        return item;
+    }
+
+    public String getConfig() {
+        item.checkPermission(TopLevelItem.CONFIGURE);
+
+        try {
+            ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+            ItemExporter exporter = new ItemExporter();
+            CNode rootNode = exporter.export(item, context);
+
+            if (rootNode == null) {
+                return "# No JCasC configurator found for this item type.";
+            }
+
+            ConfigurationAsCode casc = ConfigurationAsCode.get();
+            Node yamlNode = casc.toYaml(rootNode);
+
+            if (yamlNode != null) {
+                StringWriter writer = new StringWriter();
+                ConfigurationAsCode.serializeYamlNode(yamlNode, writer);
+                return writer.toString();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to export JCasC for item: " + item.getFullName(), e);
+            return "# Error exporting configuration: " + e.getMessage();
+        }
+
+        return "# Could not generate JCasC configuration.";
+    }
+
+    @SuppressWarnings("unused")
+    public void doDownloadYaml(StaplerResponse2 rsp) throws Exception {
+        String yamlConfig = getConfig();
+
+        rsp.setContentType("application/x-yaml;charset=UTF-8");
+
+        String safeName = item.getName().replaceAll("[^a-zA-Z0-9_-]", "_").toLowerCase();
+        rsp.setHeader("Content-Disposition", "attachment; filename=" + safeName + "-jcasc.yaml");
+
+        PrintWriter writer = rsp.getWriter();
+        writer.print(yamlConfig);
+        writer.flush();
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
@@ -32,7 +32,7 @@ public class ExportItemAction implements Action {
 
     @Override
     public String getDisplayName() {
-        return "Export";
+        return "Export Configuration";
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemAction.java
@@ -37,10 +37,14 @@ public class ExportItemAction implements Action {
 
     @Override
     public String getUrlName() {
-        return "jcasc-export";
+        return "configuration-as-code-export";
     }
 
     public TopLevelItem getItem() {
+        return item;
+    }
+
+    public TopLevelItem getObject() {
         return item;
     }
 

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemActionFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ExportItemActionFactory.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins.casc.core;
+
+import static hudson.ExtensionList.lookup;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.TopLevelItem;
+import io.jenkins.plugins.casc.ItemConfigurator;
+import java.util.Collection;
+import jenkins.model.TransientActionFactory;
+
+@Extension
+public class ExportItemActionFactory extends TransientActionFactory<TopLevelItem> {
+
+    @Override
+    public Class<TopLevelItem> type() {
+        return TopLevelItem.class;
+    }
+
+    @Override
+    @NonNull
+    public Collection<? extends Action> createFor(@NonNull TopLevelItem target) {
+        for (ItemConfigurator<?> configurator : lookup(ItemConfigurator.class)) {
+            if (configurator.getTarget().isAssignableFrom(target.getClass())) {
+                return singletonList(new ExportItemAction(target));
+            }
+        }
+        return emptyList();
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/FreestyleItemConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/FreestyleItemConfigurator.java
@@ -37,6 +37,8 @@ public class FreestyleItemConfigurator extends BaseConfigurator<FreeStyleProject
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Set<Attribute<FreeStyleProject, ?>> describe() {
         Set<Attribute<FreeStyleProject, ?>> attributes = super.describe();
+        attributes.removeIf(attribute -> attribute.getName().equals("displayNameOrNull"));
+        attributes.add(new Attribute<FreeStyleProject, String>("name", String.class).getter(FreeStyleProject::getName));
 
         for (Attribute<FreeStyleProject, ?> attribute : attributes) {
             switch (attribute.getName()) {

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ItemExporter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ItemExporter.java
@@ -1,0 +1,48 @@
+package io.jenkins.plugins.casc.core;
+
+import hudson.ExtensionList;
+import hudson.model.TopLevelItem;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ItemConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
+
+public class ItemExporter {
+
+    public CNode export(TopLevelItem item, ConfigurationContext context) throws Exception {
+        ItemConfigurator<?> configurator = findConfigurator(item.getClass());
+        if (configurator == null) {
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        Configurator<Object> baseConfigurator = (Configurator<Object>) configurator;
+        CNode itemNode = baseConfigurator.describe(item, context);
+
+        if (itemNode == null) {
+            return null;
+        }
+
+        Mapping typeMapping = new Mapping();
+        typeMapping.put(configurator.getName(), itemNode);
+
+        Sequence itemsSeq = new Sequence();
+        itemsSeq.add(typeMapping);
+
+        Mapping root = new Mapping();
+        root.put("items", itemsSeq);
+
+        return root;
+    }
+
+    private ItemConfigurator<?> findConfigurator(Class<?> clazz) {
+        for (ItemConfigurator<?> configurator : ExtensionList.lookup(ItemConfigurator.class)) {
+            if (configurator.getTarget().isAssignableFrom(clazz)) {
+                return configurator;
+            }
+        }
+        return null;
+    }
+}

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
@@ -12,7 +12,7 @@
       </f:form>
     </l:app-bar>
 
-    <p>
+    <p class="jenkins-page-description">
       This is the Configuration as Code YAML representation of this item.
     </p>
 

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
@@ -5,27 +5,27 @@
     <st:include page="sidepanel.jelly" it="${it.item}"/>
 
     <l:main-panel>
-      <h1>Export: ${it.item.displayName}</h1>
+      <j:set var="yamlConfig" value="${it.config}" />
+
+      <l:app-bar title="Export: ${it.item.displayName}">
+        <l:copyButton ref="yaml-config" text="${yamlConfig}" message="Copied YAML to clipboard!" tooltip="Copy to Clipboard" />
+
+        <f:form action="downloadYaml" method="post" name="downloadForm">
+          <f:submit icon="symbol-download" primary="false" value="${%Download}"/>
+        </f:form>
+      </l:app-bar>
 
       <p>
         This is the Configuration as Code YAML representation of this item.
       </p>
 
       <f:section title="YAML Configuration">
-        <f:textarea value="${it.config}"
+        <f:textarea
+          id="yaml-config"
+          value="${yamlConfig}"
           codemirror-mode="yaml"
-          codemirror-config="readOnly: true, lineNumbers: true" />
+          codemirror-config="readOnly: true, lineNumbers: true"/>
       </f:section>
-
-      <div style="margin-top: 15px; display: flex; align-items: center;">
-
-        <l:copyButton text="${it.config}" message="Copied YAML to clipboard!" tooltip="Copy to Clipboard" />
-
-        <f:form action="downloadYaml" method="post" style="display: inline-block; margin-left: 10px;">
-          <f:submit value="Download YAML" class="jenkins-button" />
-        </f:form>
-
-      </div>
 
     </l:main-panel>
   </l:layout>

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
@@ -1,0 +1,32 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <l:layout title="Export - ${it.item.displayName}">
+
+    <st:include page="sidepanel.jelly" it="${it.item}"/>
+
+    <l:main-panel>
+      <h1>Export: ${it.item.displayName}</h1>
+
+      <p>
+        This is the Configuration as Code YAML representation of this item.
+      </p>
+
+      <f:section title="YAML Configuration">
+        <f:textarea value="${it.config}"
+          codemirror-mode="yaml"
+          codemirror-config="readOnly: true, lineNumbers: true" />
+      </f:section>
+
+      <div style="margin-top: 15px; display: flex; align-items: center;">
+
+        <l:copyButton text="${it.config}" message="Copied YAML to clipboard!" tooltip="Copy to Clipboard" />
+
+        <a href="downloadYaml" class="jenkins-button" style="margin-left: 20px; text-decoration: none;">
+          Download YAML
+        </a>
+
+      </div>
+
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
@@ -1,32 +1,28 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-  <l:layout title="Export - ${it.item.displayName}">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
 
-    <st:include page="sidepanel.jelly" it="${it.item}"/>
+  <l:job-subpage>
+    <j:set var="yamlConfig" value="${it.config}" />
 
-    <l:main-panel>
-      <j:set var="yamlConfig" value="${it.config}" />
+    <l:app-bar title="Export: ${it.item.displayName}">
+      <l:copyButton ref="yaml-config" text="${yamlConfig}" message="Copied YAML to clipboard!" tooltip="Copy to Clipboard" />
 
-      <l:app-bar title="Export: ${it.item.displayName}">
-        <l:copyButton ref="yaml-config" text="${yamlConfig}" message="Copied YAML to clipboard!" tooltip="Copy to Clipboard" />
+      <f:form action="downloadYaml" method="post" name="downloadForm">
+        <f:submit icon="symbol-download" primary="false" value="${%Download}"/>
+      </f:form>
+    </l:app-bar>
 
-        <f:form action="downloadYaml" method="post" name="downloadForm">
-          <f:submit icon="symbol-download" primary="false" value="${%Download}"/>
-        </f:form>
-      </l:app-bar>
+    <p>
+      This is the Configuration as Code YAML representation of this item.
+    </p>
 
-      <p>
-        This is the Configuration as Code YAML representation of this item.
-      </p>
+    <f:section title="YAML Configuration">
+      <f:textarea
+        id="yaml-config"
+        value="${yamlConfig}"
+        codemirror-mode="yaml"
+        codemirror-config="readOnly: true, lineNumbers: true"/>
+    </f:section>
+  </l:job-subpage>
 
-      <f:section title="YAML Configuration">
-        <f:textarea
-          id="yaml-config"
-          value="${yamlConfig}"
-          codemirror-mode="yaml"
-          codemirror-config="readOnly: true, lineNumbers: true"/>
-      </f:section>
-
-    </l:main-panel>
-  </l:layout>
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/core/ExportItemAction/index.jelly
@@ -21,9 +21,9 @@
 
         <l:copyButton text="${it.config}" message="Copied YAML to clipboard!" tooltip="Copy to Clipboard" />
 
-        <a href="downloadYaml" class="jenkins-button" style="margin-left: 20px; text-decoration: none;">
-          Download YAML
-        </a>
+        <f:form action="downloadYaml" method="post" style="display: inline-block; margin-left: 10px;">
+          <f:submit value="Download YAML" class="jenkins-button" />
+        </f:form>
 
       </div>
 

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionFactoryTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionFactoryTest.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.casc.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ExportItemActionFactoryTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testCreateForSupportedItem() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("supported-job");
+
+        ExportItemActionFactory factory = new ExportItemActionFactory();
+        Collection<? extends Action> actions = factory.createFor(project);
+
+        assertEquals(1, actions.size());
+        assertTrue("Should return an ExportItemAction", actions.iterator().next() instanceof ExportItemAction);
+    }
+}

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
@@ -5,6 +5,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import hudson.model.FreeStyleProject;
+import java.net.URL;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
 import org.htmlunit.html.HtmlPage;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,5 +49,21 @@ public class ExportItemActionTest {
         assertTrue("Page should contain the items root", pageText.contains("items:"));
         assertTrue("Page should contain the freestyle configurator type", pageText.contains("- freestyle:"));
         assertTrue("Page should contain the job name", pageText.contains("name: \"test-job\""));
+    }
+
+    @Test
+    public void testDownloadYamlEndpoint() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("test-job");
+        JenkinsRule.WebClient client = j.createWebClient();
+
+        WebRequest request =
+                new WebRequest(new URL(j.getURL() + project.getUrl() + "jcasc-export/downloadYaml"), HttpMethod.POST);
+
+        client.addCrumb(request);
+
+        WebResponse response = client.getPage(request).getWebResponse();
+
+        assertEquals(200, response.getStatusCode());
+        assertTrue(response.getContentAsString().contains("name: \"test-job\""));
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.casc.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import hudson.model.FreeStyleProject;
+import org.htmlunit.html.HtmlPage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ExportItemActionTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testActionMetadataAndGetConfig() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("test-export-job");
+        ExportItemAction action = new ExportItemAction(project);
+
+        assertEquals("Export", action.getDisplayName());
+        assertEquals("jcasc-export", action.getUrlName());
+        assertEquals(project, action.getItem());
+
+        String yamlConfig = action.getConfig();
+
+        assertNotNull("YAML configuration string should not be null", yamlConfig);
+        assertTrue("YAML should contain items root", yamlConfig.contains("items:"));
+        assertTrue("YAML should contain freestyle type", yamlConfig.contains("- freestyle:"));
+        assertTrue("YAML should contain the job name", yamlConfig.contains("name: \"test-export-job\""));
+    }
+
+    @Test
+    public void testExportUiPageRendersYaml() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("test-job");
+
+        JenkinsRule.WebClient client = j.createWebClient();
+
+        HtmlPage page = client.goTo(project.getUrl() + "jcasc-export/");
+
+        String pageText = page.asNormalizedText();
+
+        assertTrue("Page should contain the items root", pageText.contains("items:"));
+        assertTrue("Page should contain the freestyle configurator type", pageText.contains("- freestyle:"));
+        assertTrue("Page should contain the job name", pageText.contains("name: \"test-job\""));
+    }
+}

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
@@ -24,7 +24,7 @@ public class ExportItemActionTest {
         FreeStyleProject project = j.createFreeStyleProject("test-export-job");
         ExportItemAction action = new ExportItemAction(project);
 
-        assertEquals("Export", action.getDisplayName());
+        assertEquals("Export Configuration", action.getDisplayName());
         assertEquals("jcasc-export", action.getUrlName());
         assertEquals(project, action.getItem());
 

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ExportItemActionTest.java
@@ -25,7 +25,7 @@ public class ExportItemActionTest {
         ExportItemAction action = new ExportItemAction(project);
 
         assertEquals("Export Configuration", action.getDisplayName());
-        assertEquals("jcasc-export", action.getUrlName());
+        assertEquals("configuration-as-code-export", action.getUrlName());
         assertEquals(project, action.getItem());
 
         String yamlConfig = action.getConfig();
@@ -42,7 +42,7 @@ public class ExportItemActionTest {
 
         JenkinsRule.WebClient client = j.createWebClient();
 
-        HtmlPage page = client.goTo(project.getUrl() + "jcasc-export/");
+        HtmlPage page = client.goTo(project.getUrl() + "configuration-as-code-export/");
 
         String pageText = page.asNormalizedText();
 
@@ -56,8 +56,8 @@ public class ExportItemActionTest {
         FreeStyleProject project = j.createFreeStyleProject("test-job");
         JenkinsRule.WebClient client = j.createWebClient();
 
-        WebRequest request =
-                new WebRequest(new URL(j.getURL() + project.getUrl() + "jcasc-export/downloadYaml"), HttpMethod.POST);
+        WebRequest request = new WebRequest(
+                new URL(j.getURL() + project.getUrl() + "configuration-as-code-export/downloadYaml"), HttpMethod.POST);
 
         client.addCrumb(request);
 

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/FreestyleItemConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/FreestyleItemConfiguratorTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -138,12 +139,26 @@ public class FreestyleItemConfiguratorTest {
     }
 
     @Test
-    public void shouldDescribeAttributesCorrectly() {
+    public void shouldDescribeAttributesCorrectly() throws Exception {
         FreestyleItemConfigurator configurator = new FreestyleItemConfigurator();
         Set<Attribute<FreeStyleProject, ?>> attributes = configurator.describe();
 
         boolean foundBuildWrappers = attributes.stream().anyMatch(a -> "buildWrappers".equals(a.getName()));
         assertTrue("Should have renamed buildWrappersList to buildWrappers", foundBuildWrappers);
+
+        boolean foundDisplayNameOrNull = attributes.stream().anyMatch(a -> "displayNameOrNull".equals(a.getName()));
+        assertFalse("Should have removed displayNameOrNull", foundDisplayNameOrNull);
+
+        Attribute<FreeStyleProject, ?> nameAttr = attributes.stream()
+                .filter(a -> "name".equals(a.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull("Should have added 'name' attribute", nameAttr);
+
+        FreeStyleProject dummyProject = j.jenkins.createProject(FreeStyleProject.class, "dummy-project");
+        Object nameValue = nameAttr.getValue(dummyProject);
+        assertEquals("dummy-project", nameValue);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemExporterTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemExporterTest.java
@@ -1,0 +1,47 @@
+package io.jenkins.plugins.casc.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ItemExporterTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testExportFreestyleProject() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("test-job");
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+
+        ItemExporter exporter = new ItemExporter();
+        CNode rootNode = exporter.export(project, context);
+
+        assertNotNull("The exported CNode should not be null", rootNode);
+        assertTrue("The root node should be a Mapping", rootNode instanceof Mapping);
+
+        Mapping rootMapping = (Mapping) rootNode;
+        assertTrue("Root should contain 'items' key", rootMapping.containsKey("items"));
+
+        Sequence itemsSeq = (Sequence) rootMapping.get("items");
+        assertEquals("Should have exactly one item in the sequence", 1, itemsSeq.size());
+
+        Mapping itemMapping = (Mapping) itemsSeq.get(0);
+        assertTrue(
+                "The item should be keyed by its configurator name 'freestyle'", itemMapping.containsKey("freestyle"));
+
+        Mapping freestyleProps = (Mapping) itemMapping.get("freestyle");
+        assertNotNull("Freestyle properties should not be null", freestyleProps.get("name"));
+        assertEquals("test-job", freestyleProps.getScalarValue("name"));
+    }
+}

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemsRootConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemsRootConfiguratorTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.casc.core;
 
 import static io.jenkins.plugins.casc.ConfigurationAsCode.get;
+import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -9,7 +10,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.ItemConfigurator;
@@ -18,6 +21,7 @@ import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import java.io.IOException;
+import java.util.Set;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
@@ -114,7 +118,7 @@ public class ItemsRootConfiguratorTest {
     public static class DummyItemConfigurator implements ItemConfigurator<FreeStyleProject> {
 
         @Override
-        public String getName() {
+        public @NonNull String getName() {
             return "dummy";
         }
 
@@ -173,6 +177,28 @@ public class ItemsRootConfiguratorTest {
             } catch (IOException e) {
                 throw new ConfiguratorException("Failed to configure dummy job: " + name, e);
             }
+        }
+
+        @Override
+        public CNode describe(FreeStyleProject instance, ConfigurationContext context) {
+            return null;
+        }
+
+        @Override
+        @NonNull
+        public Set<Attribute<FreeStyleProject, ?>> describe() {
+            return emptySet();
+        }
+
+        @Override
+        @NonNull
+        public FreeStyleProject configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
+            throw new UnsupportedOperationException("DummyItemConfigurator requires a name to configure");
+        }
+
+        @Override
+        public FreeStyleProject check(CNode config, ConfigurationContext context) throws ConfiguratorException {
+            return null;
         }
     }
 


### PR DESCRIPTION
Addresses https://github.com/jenkinsci/configuration-as-code-plugin/pull/2881#discussion_r3693502417

Add an Export action to supported Jenkins items that generates native JCasC YAML using the corresponding ItemConfigurator. Introduce a generic ItemExporter, attach the action through a TransientActionFactory, render the exported YAML in a dedicated UI with copy/download support, and add tests covering the exporter, action, and UI.

<img width="1470" height="835" alt="Screenshot 2026-08-04 at 3 48 34 AM" src="https://github.com/user-attachments/assets/3d678a4a-2c8a-4e9b-9b4d-7cac283421b6" />


### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
