### PR TITLE
Support folder-scoped credentials in FolderItemConfigurator

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -87,6 +87,16 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <version>1.19.0</version>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/FolderCredentialsPropertyConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/FolderCredentialsPropertyConfigurator.java
@@ -1,0 +1,60 @@
+package io.jenkins.plugins.casc.core;
+
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider.FolderCredentialsProperty;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class FolderCredentialsPropertyConfigurator extends BaseConfigurator<FolderCredentialsProperty> {
+
+    @Override
+    public Class<FolderCredentialsProperty> getTarget() {
+        return FolderCredentialsProperty.class;
+    }
+
+    @Override
+    protected FolderCredentialsProperty instance(Mapping mapping, ConfigurationContext context)
+            throws ConfiguratorException {
+        return new FolderCredentialsProperty(new DomainCredentials[0]);
+    }
+
+    @Override
+    @NonNull
+    public Set<Attribute<FolderCredentialsProperty, ?>> describe() {
+        Set<Attribute<FolderCredentialsProperty, ?>> attributes = new LinkedHashSet<>();
+
+        attributes.add(new MultivaluedAttribute<FolderCredentialsProperty, DomainCredentials>(
+                        "domainCredentials", DomainCredentials.class)
+                .getter(FolderCredentialsProperty::getDomainCredentials)
+                .setter((instance, domainCredentialsCollection) -> {
+                    Map<Domain, List<Credentials>> domainCredentialsMap = new HashMap<>();
+
+                    if (domainCredentialsCollection != null) {
+                        for (DomainCredentials dc : domainCredentialsCollection) {
+                            domainCredentialsMap.put(dc.getDomain(), dc.getCredentials());
+                        }
+                    }
+
+                    instance.setDomainCredentialsMap(domainCredentialsMap);
+                }));
+
+        return attributes;
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/FolderItemConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/FolderItemConfigurator.java
@@ -1,0 +1,78 @@
+package io.jenkins.plugins.casc.core;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.TopLevelItem;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.ItemConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.util.Set;
+import jenkins.model.Jenkins;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+@Extension
+@Restricted(NoExternalUse.class)
+public class FolderItemConfigurator extends BaseConfigurator<Folder> implements ItemConfigurator<Folder> {
+
+    @Override
+    public Class<Folder> getTarget() {
+        return Folder.class;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return "folder";
+    }
+
+    @Override
+    @NonNull
+    public Set<Attribute<Folder, ?>> describe() {
+        Set<Attribute<Folder, ?>> attributes = super.describe();
+
+        attributes.removeIf(attribute -> attribute.getName().equals("displayNameOrNull"));
+        attributes.add(new Attribute<Folder, String>("name", String.class).getter(Folder::getName));
+
+        return attributes;
+    }
+
+    @Override
+    protected Folder instance(Mapping mapping, ConfigurationContext context) {
+        throw new UnsupportedOperationException("Folders must be configured with a name.");
+    }
+
+    @Override
+    public Folder configure(String name, CNode config, ConfigurationContext context) throws ConfiguratorException {
+        try {
+            Jenkins jenkins = Jenkins.get();
+            TopLevelItem item = jenkins.getItem(name);
+            Folder folder;
+
+            if (item == null) {
+                folder = jenkins.createProject(Folder.class, name);
+            } else if (item instanceof Folder) {
+                folder = (Folder) item;
+            } else {
+                throw new IllegalStateException("An item named '" + name + "' already exists, but it is a "
+                        + item.getClass().getSimpleName() + " and not a Folder.");
+            }
+
+            if (config != null) {
+                super.configure(config.asMapping(), folder, false, context);
+            }
+
+            folder.save();
+            return folder;
+        } catch (ConfiguratorException ce) {
+            throw ce;
+        } catch (Exception e) {
+            throw new ConfiguratorException("Failed to configure folder: " + name, e);
+        }
+    }
+}

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -67,12 +67,22 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/FolderItemConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/FolderItemConfiguratorTest.java
@@ -1,0 +1,146 @@
+package io.jenkins.plugins.casc.core;
+
+import static io.jenkins.plugins.casc.ConfigurationAsCode.get;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider.FolderCredentialsProperty;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.domains.DomainCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.util.List;
+import java.util.Objects;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class FolderItemConfiguratorTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("folder-job.yaml")
+    public void shouldCreateFolder() {
+        Folder folder = Jenkins.get().getItemByFullName("my-folder", Folder.class);
+
+        assertNotNull("Folder should have been created by JCasC", folder);
+        assertEquals("My Folder", folder.getDisplayName());
+        assertEquals("Configured via JCasC", folder.getDescription());
+    }
+
+    @Test
+    public void shouldUpdateExistingFolder() throws Exception {
+        Folder existing = j.jenkins.createProject(Folder.class, "existing-folder");
+        existing.setDisplayName("Old Folder");
+        existing.setDescription("Old Description");
+        existing.save();
+
+        get().configure(Objects.requireNonNull(getClass().getResource("folder-job-update.yaml"))
+                .toExternalForm());
+
+        Folder updated = Jenkins.get().getItemByFullName("existing-folder", Folder.class);
+        assertNotNull(updated);
+        assertEquals("Updated Folder", updated.getDisplayName());
+        assertEquals("Updated via JCasC", updated.getDescription());
+    }
+
+    @Test
+    @ConfiguredWithCode("folder-job.yaml")
+    public void shouldRoundTripFolderExport() throws Exception {
+        Folder folder = Jenkins.get().getItemByFullName("my-folder", Folder.class);
+        assertNotNull(folder);
+
+        FolderItemConfigurator configurator = new FolderItemConfigurator();
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+
+        CNode node = configurator.describe(folder, context);
+        assertNotNull("Configurator should describe the folder", node);
+
+        Mapping mapping = node.asMapping();
+        assertEquals("my-folder", mapping.getScalarValue("name"));
+        assertEquals("My Folder", mapping.getScalarValue("displayName"));
+        assertEquals("Configured via JCasC", mapping.getScalarValue("description"));
+    }
+
+    @Test
+    @ConfiguredWithCode("folder-with-credentials.yaml")
+    public void shouldConfigureFolderCredentials() {
+        Folder folder = Jenkins.get().getItemByFullName("secure-folder", Folder.class);
+        assertNotNull("Folder should have been created", folder);
+
+        FolderCredentialsProperty credentialsProperty = folder.getProperties().get(FolderCredentialsProperty.class);
+        assertNotNull("FolderCredentialsProperty should be configured on the folder", credentialsProperty);
+
+        List<DomainCredentials> domainCredentials = credentialsProperty.getDomainCredentials();
+        assertEquals("Should contain one domain credential block", 1, domainCredentials.size());
+
+        List<Credentials> credentialsList = domainCredentials.get(0).getCredentials();
+        assertEquals("Should contain one credential", 1, credentialsList.size());
+
+        Credentials credential = credentialsList.get(0);
+        assertTrue(
+                "Credential should be a Username/Password instance",
+                credential instanceof UsernamePasswordCredentialsImpl);
+
+        UsernamePasswordCredentialsImpl upCred = (UsernamePasswordCredentialsImpl) credential;
+        assertEquals("folder-secret-id", upCred.getId());
+        assertEquals("my-user", upCred.getUsername());
+        assertEquals("A secret for this folder", upCred.getDescription());
+    }
+
+    @Test
+    @ConfiguredWithCode("folder-with-credentials.yaml")
+    public void shouldRoundTripFolderCredentialsExport() throws Exception {
+        Folder folder = Jenkins.get().getItemByFullName("secure-folder", Folder.class);
+        assertNotNull(folder);
+
+        FolderItemConfigurator configurator = new FolderItemConfigurator();
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+
+        CNode node = configurator.describe(folder, context);
+        assertNotNull(node);
+
+        Mapping mapping = node.asMapping();
+        assertEquals("secure-folder", mapping.getScalarValue("name"));
+
+        CNode propertiesNode = mapping.get("properties");
+        assertNotNull(propertiesNode);
+
+        Mapping credsPropertyMapping = null;
+        for (CNode propNode : propertiesNode.asSequence()) {
+            Mapping propMapping = propNode.asMapping();
+            if (propMapping.containsKey("folderCredentialsProperty")) {
+                credsPropertyMapping =
+                        propMapping.get("folderCredentialsProperty").asMapping();
+                break;
+            }
+        }
+        assertNotNull("folderCredentialsProperty should be exported", credsPropertyMapping);
+
+        CNode domainCredsNode = credsPropertyMapping.get("domainCredentials");
+        assertNotNull("domainCredentials should be exported", domainCredsNode);
+
+        Mapping firstDomainCred = domainCredsNode.asSequence().get(0).asMapping();
+        CNode credentialsNode = firstDomainCred.get("credentials");
+        assertNotNull(credentialsNode);
+
+        Mapping firstCredential = credentialsNode
+                .asSequence()
+                .get(0)
+                .asMapping()
+                .get("usernamePassword")
+                .asMapping();
+        assertEquals("folder-secret-id", firstCredential.getScalarValue("id"));
+        assertEquals("my-user", firstCredential.getScalarValue("username"));
+        assertEquals("A secret for this folder", firstCredential.getScalarValue("description"));
+    }
+}

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/core/folder-job-update.yaml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/core/folder-job-update.yaml
@@ -1,0 +1,6 @@
+items:
+  - folder:
+      name: existing-folder
+      displayName: Updated Folder
+      description: Updated via JCasC
+      

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/core/folder-job.yaml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/core/folder-job.yaml
@@ -1,0 +1,5 @@
+items:
+  - folder:
+      name: my-folder
+      displayName: My Folder
+      description: Configured via JCasC

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/core/folder-with-credentials.yaml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/core/folder-with-credentials.yaml
@@ -1,0 +1,13 @@
+items:
+  - folder:
+      name: "secure-folder"
+      properties:
+        - folderCredentialsProperty:
+            domainCredentials:
+              - credentials:
+                  - usernamePassword:
+                      scope: SYSTEM
+                      id: "folder-secret-id"
+                      username: "my-user"
+                      password: "my-password"
+                      description: "A secret for this folder"


### PR DESCRIPTION
Addresses https://github.com/jenkinsci/cloudbees-folder-plugin/pull/749#discussion_r3693652335

Add folder-scoped credentials support to FolderItemConfigurator by introducing a dedicated FolderCredentialsPropertyConfigurator that integrates with the existing JCasC credentials infrastructure. Folder credentials are now imported and exported as part of folder configuration, while preserving BaseConfigurator delegation for other folder properties. Also add comprehensive tests covering folder creation, updates, credential import, and round-trip export, along with the required test dependencies.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
