### PR TITLE
Add variable interpolation support for CasC items

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -114,6 +114,14 @@
           <failOnError>false</failOnError>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>21</source>
+          <target>21</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -114,14 +114,6 @@
           <failOnError>false</failOnError>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>21</source>
-          <target>21</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/CNodeInterpolator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/CNodeInterpolator.java
@@ -17,7 +17,12 @@ public class CNodeInterpolator {
         if (node instanceof Scalar scalar) {
             String original = scalar.getValue();
             String resolved = context.getSecretSourceResolver().resolve(original);
-            return original.equals(resolved) ? scalar : new Scalar(resolved);
+
+            if (original.equals(resolved)) {
+                return scalar;
+            }
+
+            return new Scalar(resolved, scalar.getSource());
         }
 
         if (node instanceof Mapping mapping) {
@@ -28,17 +33,10 @@ public class CNodeInterpolator {
                 CNode originalChild = entry.getValue();
                 CNode interpolatedChild = interpolate(originalChild, context);
 
-                if (newMapping == null && originalChild != interpolatedChild) {
-                    newMapping = new Mapping();
-                    for (Map.Entry<String, CNode> previous : mapping.entrySet()) {
-                        if (previous.getKey().equals(key)) {
-                            break;
-                        }
-                        newMapping.put(previous.getKey(), previous.getValue());
+                if (originalChild != interpolatedChild) {
+                    if (newMapping == null) {
+                        newMapping = mapping.clone();
                     }
-                }
-
-                if (newMapping != null) {
                     newMapping.put(key, interpolatedChild);
                 }
             }
@@ -48,22 +46,17 @@ public class CNodeInterpolator {
 
         if (node instanceof Sequence sequence) {
             Sequence newSequence = null;
-            int index = 0;
 
-            for (CNode child : sequence) {
+            for (int i = 0; i < sequence.size(); i++) {
+                CNode child = sequence.get(i);
                 CNode interpolatedChild = interpolate(child, context);
 
-                if (newSequence == null && child != interpolatedChild) {
-                    newSequence = new Sequence();
-                    for (int i = 0; i < index; i++) {
-                        newSequence.add(sequence.get(i));
+                if (child != interpolatedChild) {
+                    if (newSequence == null) {
+                        newSequence = sequence.clone();
                     }
+                    newSequence.set(i, interpolatedChild);
                 }
-
-                if (newSequence != null) {
-                    newSequence.add(interpolatedChild);
-                }
-                index++;
             }
 
             return newSequence != null ? newSequence : sequence;

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/CNodeInterpolator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/CNodeInterpolator.java
@@ -1,0 +1,72 @@
+package io.jenkins.plugins.casc.core;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Scalar;
+import io.jenkins.plugins.casc.model.Sequence;
+import java.util.Map;
+
+public class CNodeInterpolator {
+
+    public static CNode interpolate(CNode node, ConfigurationContext context) {
+        if (node == null) {
+            return null;
+        }
+
+        if (node instanceof Scalar scalar) {
+            String original = scalar.getValue();
+            String resolved = context.getSecretSourceResolver().resolve(original);
+            return original.equals(resolved) ? scalar : new Scalar(resolved);
+        }
+
+        if (node instanceof Mapping mapping) {
+            Mapping newMapping = null;
+
+            for (Map.Entry<String, CNode> entry : mapping.entrySet()) {
+                String key = entry.getKey();
+                CNode originalChild = entry.getValue();
+                CNode interpolatedChild = interpolate(originalChild, context);
+
+                if (newMapping == null && originalChild != interpolatedChild) {
+                    newMapping = new Mapping();
+                    for (Map.Entry<String, CNode> previous : mapping.entrySet()) {
+                        if (previous.getKey().equals(key)) break;
+                        newMapping.put(previous.getKey(), previous.getValue());
+                    }
+                }
+
+                if (newMapping != null) {
+                    newMapping.put(key, interpolatedChild);
+                }
+            }
+
+            return newMapping != null ? newMapping : mapping;
+        }
+
+        if (node instanceof Sequence sequence) {
+            Sequence newSequence = null;
+            int index = 0;
+
+            for (CNode child : sequence) {
+                CNode interpolatedChild = interpolate(child, context);
+
+                if (newSequence == null && child != interpolatedChild) {
+                    newSequence = new Sequence();
+                    for (int i = 0; i < index; i++) {
+                        newSequence.add(sequence.get(i));
+                    }
+                }
+
+                if (newSequence != null) {
+                    newSequence.add(interpolatedChild);
+                }
+                index++;
+            }
+
+            return newSequence != null ? newSequence : sequence;
+        }
+
+        return node;
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/CNodeInterpolator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/CNodeInterpolator.java
@@ -31,7 +31,9 @@ public class CNodeInterpolator {
                 if (newMapping == null && originalChild != interpolatedChild) {
                     newMapping = new Mapping();
                     for (Map.Entry<String, CNode> previous : mapping.entrySet()) {
-                        if (previous.getKey().equals(key)) break;
+                        if (previous.getKey().equals(key)) {
+                            break;
+                        }
                         newMapping.put(previous.getKey(), previous.getValue());
                     }
                 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/ItemsRootConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/ItemsRootConfigurator.java
@@ -39,11 +39,12 @@ public class ItemsRootConfigurator implements RootElementConfigurator<Jenkins> {
     @Override
     @NonNull
     public Jenkins configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        check(config, context);
+        CNode interpolatedConfig = CNodeInterpolator.interpolate(config, context);
+        doCheck(interpolatedConfig);
         Jenkins jenkins = Jenkins.get();
 
         try (ACLContext ignored = ACL.as2(ACL.SYSTEM2)) {
-            for (CNode itemNode : config.asSequence()) {
+            for (CNode itemNode : interpolatedConfig.asSequence()) {
                 Mapping itemMapping = itemNode.asMapping();
                 Entry<String, CNode> entry = itemMapping.entrySet().iterator().next();
                 String type = entry.getKey();
@@ -74,7 +75,12 @@ public class ItemsRootConfigurator implements RootElementConfigurator<Jenkins> {
 
     @Override
     public Jenkins check(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        for (CNode itemNode : config.asSequence()) {
+        CNode interpolatedConfig = CNodeInterpolator.interpolate(config, context);
+        return doCheck(interpolatedConfig);
+    }
+
+    private Jenkins doCheck(CNode interpolatedConfig) throws ConfiguratorException {
+        for (CNode itemNode : interpolatedConfig.asSequence()) {
             Mapping itemMapping = itemNode.asMapping();
 
             if (itemMapping.size() != 1) {

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/CNodeInterpolatorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/CNodeInterpolatorTest.java
@@ -1,0 +1,151 @@
+package io.jenkins.plugins.casc.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.SecretSource;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Scalar;
+import io.jenkins.plugins.casc.model.Sequence;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class CNodeInterpolatorTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private ConfigurationContext context;
+
+    @Before
+    public void setUp() {
+        context = new ConfigurationContext(ConfiguratorRegistry.get());
+    }
+
+    @Test
+    public void shouldReturnNullForNullNode() {
+        assertNull(CNodeInterpolator.interpolate(null, context));
+    }
+
+    @Test
+    public void shouldInterpolateScalarAndAllocateNew() {
+        Scalar original = new Scalar("${VAR}");
+        CNode result = CNodeInterpolator.interpolate(original, context);
+
+        assertNotSame(original, result);
+        assertEquals("resolved_value", result.asScalar().getValue());
+    }
+
+    @Test
+    public void shouldRespectEscapedVariables() {
+        Scalar original = new Scalar("^${VAR}");
+        CNode result = CNodeInterpolator.interpolate(original, context);
+
+        assertNotSame(original, result);
+        assertEquals("${VAR}", result.asScalar().getValue());
+    }
+
+    @Test
+    public void shouldResolveUnknownVariableToEmptyString() {
+        Scalar original = new Scalar("${UNKNOWN}");
+        CNode result = CNodeInterpolator.interpolate(original, context);
+
+        assertEquals("", result.asScalar().getValue());
+    }
+
+    @Test
+    public void shouldInterpolateMappingValuesButNotKeys() {
+        Mapping original = new Mapping();
+        original.put("${VAR}", new Scalar("${VAR}"));
+        original.put("plain_key", new Scalar("plain_value"));
+
+        CNode resultNode = CNodeInterpolator.interpolate(original, context);
+
+        assertNotSame(original, resultNode);
+        Mapping result = resultNode.asMapping();
+
+        assertTrue(result.containsKey("${VAR}"));
+        assertEquals("resolved_value", result.getScalarValue("${VAR}"));
+
+        assertTrue(result.containsKey("plain_key"));
+        assertEquals("plain_value", result.getScalarValue("plain_key"));
+    }
+
+    @Test
+    public void shouldInterpolateSequenceAndAllocateNew() {
+        Sequence original = new Sequence();
+        original.add(new Scalar("plain_text"));
+        original.add(new Scalar("${VAR}"));
+
+        CNode resultNode = CNodeInterpolator.interpolate(original, context);
+
+        assertNotSame(original, resultNode);
+        Sequence result = resultNode.asSequence();
+
+        assertEquals(2, result.size());
+        assertEquals("plain_text", result.get(0).asScalar().getValue());
+        assertEquals("resolved_value", result.get(1).asScalar().getValue());
+    }
+
+    @Test
+    public void shouldReturnSameNodeWhenNothingChanges() {
+        Mapping mapping = new Mapping();
+        mapping.put("name", new Scalar("plain"));
+
+        CNode result = CNodeInterpolator.interpolate(mapping, context);
+
+        assertSame(mapping, result);
+    }
+
+    @Test
+    public void shouldInterpolateNestedStructures() {
+        Scalar targetScalar = new Scalar("${VAR}");
+        Mapping innerMapping = new Mapping();
+        innerMapping.put("target", targetScalar);
+
+        Sequence sequence = new Sequence();
+        sequence.add(innerMapping);
+        sequence.add(new Scalar("plain_text"));
+
+        Mapping rootMapping = new Mapping();
+        rootMapping.put("sequence", sequence);
+        rootMapping.put("static_sibling", new Scalar("static_value"));
+
+        CNode resultNode = CNodeInterpolator.interpolate(rootMapping, context);
+
+        assertNotSame(rootMapping, resultNode);
+        Mapping result = resultNode.asMapping();
+
+        Sequence resultSequence = result.get("sequence").asSequence();
+        assertNotSame(sequence, resultSequence);
+
+        Mapping resultInnerMapping = resultSequence.get(0).asMapping();
+        assertNotSame(innerMapping, resultInnerMapping);
+
+        assertEquals("resolved_value", resultInnerMapping.getScalarValue("target"));
+        assertEquals("static_value", result.getScalarValue("static_sibling"));
+    }
+
+    @TestExtension
+    public static class DummySecretSource extends SecretSource {
+        @NonNull
+        @Override
+        public Optional<String> reveal(@NonNull String secret) {
+            if ("VAR".equals(secret)) {
+                return Optional.of("resolved_value");
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/CNodeInterpolatorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/CNodeInterpolatorTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.casc.core;
 
+import static io.jenkins.plugins.casc.core.CNodeInterpolator.interpolate;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -14,6 +15,7 @@ import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
 import io.jenkins.plugins.casc.model.Scalar;
 import io.jenkins.plugins.casc.model.Sequence;
+import io.jenkins.plugins.casc.model.Source;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,13 +37,13 @@ public class CNodeInterpolatorTest {
 
     @Test
     public void shouldReturnNullForNullNode() {
-        assertNull(CNodeInterpolator.interpolate(null, context));
+        assertNull(interpolate(null, context));
     }
 
     @Test
     public void shouldInterpolateScalarAndAllocateNew() {
         Scalar original = new Scalar("${VAR}");
-        CNode result = CNodeInterpolator.interpolate(original, context);
+        CNode result = interpolate(original, context);
 
         assertNotSame(original, result);
         assertEquals("resolved_value", result.asScalar().getValue());
@@ -50,7 +52,7 @@ public class CNodeInterpolatorTest {
     @Test
     public void shouldRespectEscapedVariables() {
         Scalar original = new Scalar("^${VAR}");
-        CNode result = CNodeInterpolator.interpolate(original, context);
+        CNode result = interpolate(original, context);
 
         assertNotSame(original, result);
         assertEquals("${VAR}", result.asScalar().getValue());
@@ -59,7 +61,7 @@ public class CNodeInterpolatorTest {
     @Test
     public void shouldResolveUnknownVariableToEmptyString() {
         Scalar original = new Scalar("${UNKNOWN}");
-        CNode result = CNodeInterpolator.interpolate(original, context);
+        CNode result = interpolate(original, context);
 
         assertEquals("", result.asScalar().getValue());
     }
@@ -70,7 +72,7 @@ public class CNodeInterpolatorTest {
         original.put("${VAR}", new Scalar("${VAR}"));
         original.put("plain_key", new Scalar("plain_value"));
 
-        CNode resultNode = CNodeInterpolator.interpolate(original, context);
+        CNode resultNode = interpolate(original, context);
 
         assertNotSame(original, resultNode);
         Mapping result = resultNode.asMapping();
@@ -88,7 +90,7 @@ public class CNodeInterpolatorTest {
         original.add(new Scalar("plain_text"));
         original.add(new Scalar("${VAR}"));
 
-        CNode resultNode = CNodeInterpolator.interpolate(original, context);
+        CNode resultNode = interpolate(original, context);
 
         assertNotSame(original, resultNode);
         Sequence result = resultNode.asSequence();
@@ -103,7 +105,7 @@ public class CNodeInterpolatorTest {
         Mapping mapping = new Mapping();
         mapping.put("name", new Scalar("plain"));
 
-        CNode result = CNodeInterpolator.interpolate(mapping, context);
+        CNode result = interpolate(mapping, context);
 
         assertSame(mapping, result);
     }
@@ -122,7 +124,7 @@ public class CNodeInterpolatorTest {
         rootMapping.put("sequence", sequence);
         rootMapping.put("static_sibling", new Scalar("static_value"));
 
-        CNode resultNode = CNodeInterpolator.interpolate(rootMapping, context);
+        CNode resultNode = interpolate(rootMapping, context);
 
         assertNotSame(rootMapping, resultNode);
         Mapping result = resultNode.asMapping();
@@ -143,7 +145,7 @@ public class CNodeInterpolatorTest {
         original.put("plain_key", new Scalar("plain_value"));
         original.put("var_key", new Scalar("${VAR}"));
 
-        CNode resultNode = CNodeInterpolator.interpolate(original, context);
+        CNode resultNode = interpolate(original, context);
 
         assertNotSame(original, resultNode);
         Mapping result = resultNode.asMapping();
@@ -158,7 +160,7 @@ public class CNodeInterpolatorTest {
         original.add(new Scalar("plain_text1"));
         original.add(new Scalar("plain_text2"));
 
-        CNode result = CNodeInterpolator.interpolate(original, context);
+        CNode result = interpolate(original, context);
 
         assertSame(original, result);
     }
@@ -172,7 +174,7 @@ public class CNodeInterpolatorTest {
             }
 
             @Override
-            public io.jenkins.plugins.casc.model.Source getSource() {
+            public Source getSource() {
                 return null;
             }
 
@@ -186,7 +188,7 @@ public class CNodeInterpolatorTest {
             }
         };
 
-        CNode resultNode = CNodeInterpolator.interpolate(customNode, context);
+        CNode resultNode = interpolate(customNode, context);
 
         assertSame(customNode, resultNode);
     }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/CNodeInterpolatorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/CNodeInterpolatorTest.java
@@ -137,6 +137,60 @@ public class CNodeInterpolatorTest {
         assertEquals("static_value", result.getScalarValue("static_sibling"));
     }
 
+    @Test
+    public void shouldBackfillMappingWhenSubsequentEntryChanges() {
+        Mapping original = new Mapping();
+        original.put("plain_key", new Scalar("plain_value"));
+        original.put("var_key", new Scalar("${VAR}"));
+
+        CNode resultNode = CNodeInterpolator.interpolate(original, context);
+
+        assertNotSame(original, resultNode);
+        Mapping result = resultNode.asMapping();
+
+        assertEquals("plain_value", result.getScalarValue("plain_key"));
+        assertEquals("resolved_value", result.getScalarValue("var_key"));
+    }
+
+    @Test
+    public void shouldReturnSameSequenceWhenNothingChanges() {
+        Sequence original = new Sequence();
+        original.add(new Scalar("plain_text1"));
+        original.add(new Scalar("plain_text2"));
+
+        CNode result = CNodeInterpolator.interpolate(original, context);
+
+        assertSame(original, result);
+    }
+
+    @Test
+    public void shouldReturnSameNodeForUnknownCNodeType() {
+        CNode customNode = new CNode() {
+            @Override
+            public Type getType() {
+                return null;
+            }
+
+            @Override
+            public io.jenkins.plugins.casc.model.Source getSource() {
+                return null;
+            }
+
+            @Override
+            public CNode clone() {
+                try {
+                    return (CNode) super.clone();
+                } catch (CloneNotSupportedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        CNode resultNode = CNodeInterpolator.interpolate(customNode, context);
+
+        assertSame(customNode, resultNode);
+    }
+
     @TestExtension
     public static class DummySecretSource extends SecretSource {
         @NonNull

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemsRootConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemsRootConfiguratorTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -20,6 +21,7 @@ import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Sequence;
 import java.io.IOException;
 import java.util.Set;
 import jenkins.model.Jenkins;
@@ -225,5 +227,46 @@ public class ItemsRootConfiguratorTest {
                     "Message did not match. Got: " + e.getMessage(),
                     e.getMessage().contains("exactly one type key"));
         }
+    }
+
+    @Test
+    public void shouldCheckValidConfiguration() {
+        ItemsRootConfigurator configurator = new ItemsRootConfigurator();
+        ConfigurationContext context = new ConfigurationContext(io.jenkins.plugins.casc.ConfiguratorRegistry.get());
+
+        Mapping properties = new Mapping();
+        properties.put("name", new io.jenkins.plugins.casc.model.Scalar("my-check-job"));
+
+        Mapping item = new Mapping();
+        item.put("dummy", properties);
+
+        Sequence itemsSequence = new Sequence();
+        itemsSequence.add(item);
+
+        Jenkins result = configurator.check(itemsSequence, context);
+
+        assertNotNull("Check should return a non-null Jenkins instance", result);
+    }
+
+    @Test
+    public void shouldFailCheckOnUnknownType() {
+        ItemsRootConfigurator configurator = new ItemsRootConfigurator();
+        ConfigurationContext context = new ConfigurationContext(io.jenkins.plugins.casc.ConfiguratorRegistry.get());
+
+        Mapping properties = new Mapping();
+        properties.put("name", new io.jenkins.plugins.casc.model.Scalar("my-check-job"));
+
+        Mapping item = new Mapping();
+        item.put("unknown_type", properties);
+
+        Sequence itemsSequence = new Sequence();
+        itemsSequence.add(item);
+
+        ConfiguratorException e =
+                assertThrows(ConfiguratorException.class, () -> configurator.check(itemsSequence, context));
+
+        assertTrue(
+                "Message did not match. Got: " + e.getMessage(),
+                e.getMessage().contains("No ItemConfigurator found for type: unknown_type"));
     }
 }

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemsRootConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/ItemsRootConfiguratorTest.java
@@ -16,11 +16,13 @@ import hudson.model.FreeStyleProject;
 import io.jenkins.plugins.casc.Attribute;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.ItemConfigurator;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Scalar;
 import io.jenkins.plugins.casc.model.Sequence;
 import java.io.IOException;
 import java.util.Set;
@@ -232,10 +234,10 @@ public class ItemsRootConfiguratorTest {
     @Test
     public void shouldCheckValidConfiguration() {
         ItemsRootConfigurator configurator = new ItemsRootConfigurator();
-        ConfigurationContext context = new ConfigurationContext(io.jenkins.plugins.casc.ConfiguratorRegistry.get());
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
 
         Mapping properties = new Mapping();
-        properties.put("name", new io.jenkins.plugins.casc.model.Scalar("my-check-job"));
+        properties.put("name", new Scalar("my-check-job"));
 
         Mapping item = new Mapping();
         item.put("dummy", properties);
@@ -251,10 +253,10 @@ public class ItemsRootConfiguratorTest {
     @Test
     public void shouldFailCheckOnUnknownType() {
         ItemsRootConfigurator configurator = new ItemsRootConfigurator();
-        ConfigurationContext context = new ConfigurationContext(io.jenkins.plugins.casc.ConfiguratorRegistry.get());
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
 
         Mapping properties = new Mapping();
-        properties.put("name", new io.jenkins.plugins.casc.model.Scalar("my-check-job"));
+        properties.put("name", new Scalar("my-check-job"));
 
         Mapping item = new Mapping();
         item.put("unknown_type", properties);


### PR DESCRIPTION
Add variable interpolation support to the items root configurator by preprocessing the item configuration tree before validation and configuration. Introduce a CNodeInterpolator that recursively resolves scalar values using the existing SecretSourceResolver while preserving escaped expressions and avoiding unnecessary allocations through lazy copying. Add unit tests covering scalar, sequence, mapping, nested structure, unresolved variable, and escaped variable interpolation to verify the new behavior.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
