### PR TITLE
Add support for GitHub organization folders

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -87,6 +87,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>branch-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <version>1.19.0</version>
@@ -102,6 +107,11 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-branch-source</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/OrganizationFolderItemConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/OrganizationFolderItemConfigurator.java
@@ -1,0 +1,85 @@
+package io.jenkins.plugins.casc.core;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.ItemConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.util.Set;
+import jenkins.branch.OrganizationFolder;
+import jenkins.model.Jenkins;
+
+@Extension
+public class OrganizationFolderItemConfigurator extends BaseConfigurator<OrganizationFolder>
+        implements ItemConfigurator<OrganizationFolder> {
+
+    @Override
+    @NonNull
+    public String getName() {
+        return "organizationFolder";
+    }
+
+    @Override
+    public Class<OrganizationFolder> getTarget() {
+        return OrganizationFolder.class;
+    }
+
+    @Override
+    @NonNull
+    public Set<Attribute<OrganizationFolder, ?>> describe() {
+        Set<Attribute<OrganizationFolder, ?>> attributes = super.describe();
+
+        attributes.removeIf(attribute -> attribute.getName().equals("displayNameOrNull"));
+        attributes.add(
+                new Attribute<OrganizationFolder, String>("name", String.class).getter(OrganizationFolder::getName));
+
+        return attributes;
+    }
+
+    @Override
+    protected OrganizationFolder instance(Mapping mapping, ConfigurationContext context) {
+        throw new UnsupportedOperationException("Organization folders must be created with a name");
+    }
+
+    @Override
+    public OrganizationFolder configure(String name, CNode config, ConfigurationContext context)
+            throws ConfiguratorException {
+        try {
+            Jenkins jenkins = Jenkins.get();
+            hudson.model.TopLevelItem existingItem = jenkins.getItem(name);
+            OrganizationFolder folder;
+
+            if (existingItem == null) {
+                folder = jenkins.createProject(OrganizationFolder.class, name);
+            } else if (existingItem instanceof OrganizationFolder) {
+                folder = (OrganizationFolder) existingItem;
+            } else {
+                throw new ConfiguratorException("An item named '" + name
+                        + "' already exists but is not an OrganizationFolder (it is a "
+                        + existingItem.getClass().getName() + ").");
+            }
+
+            Mapping mapping = config.asMapping();
+            configure(mapping, folder, false, context);
+            folder.save();
+
+            folder.scheduleBuild(new hudson.model.Cause() {
+                @Override
+                public String getShortDescription() {
+                    return "Triggered by Jenkins Configuration as Code";
+                }
+            });
+
+            return folder;
+
+        } catch (ConfiguratorException ce) {
+            throw ce;
+        } catch (Exception e) {
+            throw new ConfiguratorException("Failed to configure organization folder: " + name, e);
+        }
+    }
+}

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -67,12 +67,22 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>branch-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-branch-source</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/core/OrganizationFolderItemConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/core/OrganizationFolderItemConfiguratorTest.java
@@ -1,0 +1,84 @@
+package io.jenkins.plugins.casc.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import java.util.Objects;
+import jenkins.branch.OrganizationFolder;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMNavigator;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class OrganizationFolderItemConfiguratorTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("OrganizationFolder.yml")
+    public void should_configure_organization_folder() {
+        OrganizationFolder folder = (OrganizationFolder) j.jenkins.getItem("my-github-org");
+
+        assertThat("Organization Folder should be created", folder, is(notNullValue()));
+        assertEquals("my-github-org", folder.getName());
+        assertEquals(
+                "Should have exactly one navigator", 1, folder.getNavigators().size());
+        assertTrue(
+                "Navigator should be of type GitHubSCMNavigator",
+                folder.getNavigators().get(0) instanceof GitHubSCMNavigator);
+
+        GitHubSCMNavigator navigator =
+                (GitHubSCMNavigator) folder.getNavigators().get(0);
+        assertEquals("test-org", navigator.getRepoOwner());
+    }
+
+    @Test
+    @ConfiguredWithCode("OrganizationFolder.yml")
+    public void should_update_existing_organization_folder_on_reload() {
+        ConfigurationAsCode.get()
+                .configure(Objects.requireNonNull(
+                                OrganizationFolderItemConfiguratorTest.class.getResource("OrganizationFolder.yml"))
+                        .toExternalForm());
+
+        OrganizationFolder folder = (OrganizationFolder) j.jenkins.getItem("my-github-org");
+
+        assertThat("Organization Folder should still exist", folder, is(notNullValue()));
+        assertEquals("my-github-org", folder.getName());
+        assertEquals(1, folder.getNavigators().size());
+    }
+
+    @Test
+    public void should_fail_gracefully_when_item_exists_with_wrong_type() throws Exception {
+        j.jenkins.createProject(FreeStyleProject.class, "my-github-org");
+
+        try {
+            ConfigurationAsCode.get()
+                    .configure(Objects.requireNonNull(
+                                    OrganizationFolderItemConfiguratorTest.class.getResource("OrganizationFolder.yml"))
+                            .toExternalForm());
+            fail("Expected a ConfiguratorException to be thrown");
+        } catch (ConfiguratorException e) {
+            assertTrue(
+                    "Message should contain our custom error",
+                    e.getMessage().contains("already exists but is not an OrganizationFolder"));
+        }
+    }
+
+    @Test
+    public void should_describe_name_attribute() {
+        assertThat(
+                new OrganizationFolderItemConfigurator()
+                        .describe().stream()
+                                .anyMatch(attribute -> attribute.getName().equals("name")),
+                is(true));
+    }
+}

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/core/OrganizationFolder.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/core/OrganizationFolder.yml
@@ -1,0 +1,6 @@
+items:
+  - organizationFolder:
+      name: "my-github-org"
+      navigators:
+        - github:
+            repoOwner: "test-org"


### PR DESCRIPTION
Add JCasC support for configuring Jenkins Organization Folders, including GitHub SCM navigators and repository owners.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled in the information
-->
