### PR TITLE
Add credential-based authentication for HTTP configuration sources

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/CascHttpSettings.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/CascHttpSettings.java
@@ -1,0 +1,278 @@
+package io.jenkins.plugins.casc.fetcher;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest2;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+
+@Extension
+public class CascHttpSettings extends GlobalConfiguration {
+
+    private List<RemoteConfig> remoteConfigs = new ArrayList<>();
+
+    public CascHttpSettings() {
+        load();
+    }
+
+    public static CascHttpSettings get() {
+        return GlobalConfiguration.all().get(CascHttpSettings.class);
+    }
+
+    public List<RemoteConfig> getRemoteConfigs() {
+        return remoteConfigs != null ? unmodifiableList(remoteConfigs) : emptyList();
+    }
+
+    @DataBoundSetter
+    public void setRemoteConfigs(List<RemoteConfig> remoteConfigs) {
+        this.remoteConfigs = remoteConfigs != null ? new ArrayList<>(remoteConfigs) : new ArrayList<>();
+        save();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        if (!json.has("remoteConfigs")) {
+            setRemoteConfigs(emptyList());
+        }
+        save();
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Configuration as Code HTTP Fetcher";
+    }
+
+    public static RemoteConfig getConfigForUrl(String url) {
+        CascHttpSettings settings = get();
+        if (settings == null || settings.getRemoteConfigs().isEmpty() || StringUtils.isBlank(url)) {
+            return null;
+        }
+
+        URI targetUri;
+        try {
+            targetUri = new URI(url);
+        } catch (URISyntaxException e) {
+            return null;
+        }
+
+        RemoteConfig bestMatch = null;
+        int longestMatchLength = -1;
+
+        for (RemoteConfig config : settings.getRemoteConfigs()) {
+            String prefix = config.getUrlPrefix();
+            if (StringUtils.isBlank(prefix)) {
+                continue;
+            }
+
+            URI prefixUri;
+            try {
+                prefixUri = new URI(prefix);
+            } catch (URISyntaxException e) {
+                continue;
+            }
+
+            if (matches(targetUri, prefixUri)) {
+                int matchLength = prefix.length();
+                if (matchLength > longestMatchLength) {
+                    longestMatchLength = matchLength;
+                    bestMatch = config;
+                }
+            }
+        }
+
+        return bestMatch;
+    }
+
+    private static boolean matches(URI target, URI prefix) {
+        if (prefix.getScheme() != null && !prefix.getScheme().equalsIgnoreCase(target.getScheme())) {
+            return false;
+        }
+        if (prefix.getHost() != null && !prefix.getHost().equalsIgnoreCase(target.getHost())) {
+            return false;
+        }
+        int prefixPort = getEffectivePort(prefix);
+        int targetPort = getEffectivePort(target);
+        if (prefixPort != targetPort) {
+            return false;
+        }
+
+        String targetPath = target.getPath() == null ? "/" : target.getPath();
+        String prefixPath = prefix.getPath() == null ? "/" : prefix.getPath();
+
+        if (!prefixPath.endsWith("/")) {
+            prefixPath += "/";
+        }
+        if (!targetPath.endsWith("/")) {
+            targetPath += "/";
+        }
+
+        return targetPath.startsWith(prefixPath);
+    }
+
+    private static int getEffectivePort(URI uri) {
+        if (uri.getPort() != -1) {
+            return uri.getPort();
+        }
+        if ("https".equalsIgnoreCase(uri.getScheme())) {
+            return 443;
+        }
+        if ("http".equalsIgnoreCase(uri.getScheme())) {
+            return 80;
+        }
+        return -1;
+    }
+
+    public enum AuthMethod {
+        NONE("No Authentication"),
+        BASIC("Basic Authentication (Username / Password)"),
+        BEARER("Bearer Token"),
+        API_KEY("API Key (Custom Header)");
+
+        private final String description;
+
+        AuthMethod(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    public static class RemoteConfig implements Describable<RemoteConfig> {
+
+        private String urlPrefix;
+        private String credentialId;
+        private AuthMethod authMethod;
+        private String headerName;
+
+        @DataBoundConstructor
+        public RemoteConfig(String urlPrefix, String credentialId, AuthMethod authMethod) {
+            this.urlPrefix = urlPrefix;
+            this.credentialId = credentialId;
+            this.authMethod = authMethod != null ? authMethod : AuthMethod.NONE;
+        }
+
+        public String getUrlPrefix() {
+            return urlPrefix;
+        }
+
+        @DataBoundSetter
+        public void setUrlPrefix(String urlPrefix) {
+            this.urlPrefix = urlPrefix;
+        }
+
+        public String getCredentialId() {
+            return credentialId;
+        }
+
+        @DataBoundSetter
+        public void setCredentialId(String credentialId) {
+            this.credentialId = credentialId;
+        }
+
+        public AuthMethod getAuthMethod() {
+            return authMethod;
+        }
+
+        @DataBoundSetter
+        public void setAuthMethod(AuthMethod authMethod) {
+            this.authMethod = authMethod != null ? authMethod : AuthMethod.NONE;
+        }
+
+        public String getHeaderName() {
+            return headerName;
+        }
+
+        @DataBoundSetter
+        public void setHeaderName(String headerName) {
+            this.headerName = headerName;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Descriptor<RemoteConfig> getDescriptor() {
+            return Jenkins.get().getDescriptorOrDie(getClass());
+        }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<RemoteConfig> {
+
+            @Override
+            @NonNull
+            public String getDisplayName() {
+                return "Remote HTTP Configuration";
+            }
+
+            @SuppressWarnings("unused")
+            public ListBoxModel doFillAuthMethodItems() {
+                ListBoxModel items = new ListBoxModel();
+                for (AuthMethod method : AuthMethod.values()) {
+                    items.add(method.getDescription(), method.name());
+                }
+                return items;
+            }
+
+            @SuppressWarnings("unused")
+            public FormValidation doCheckUrlPrefix(@QueryParameter String value) {
+                if (StringUtils.isBlank(value)) {
+                    return FormValidation.error("URL Prefix cannot be empty.");
+                }
+                try {
+                    URI uri = new URI(value);
+                    if (uri.getScheme() == null
+                            || (!uri.getScheme().equalsIgnoreCase("http")
+                                    && !uri.getScheme().equalsIgnoreCase("https"))) {
+                        return FormValidation.error("URL Prefix must start with http:// or https://");
+                    }
+
+                    if (uri.getHost() == null) {
+                        return FormValidation.error(
+                                "URL Prefix must include a valid host (e.g., https://example.com).");
+                    }
+
+                    if (uri.getQuery() != null) {
+                        return FormValidation.error(
+                                "URL Prefix should not contain query parameters (e.g., ?key=value). It must be a base path only.");
+                    }
+
+                    if (uri.getFragment() != null) {
+                        return FormValidation.error(
+                                "URL Prefix should not contain URL fragments (e.g., #section). It must be a base path only.");
+                    }
+
+                } catch (Exception e) {
+                    return FormValidation.error("Invalid URL format: " + e.getMessage());
+                }
+                return FormValidation.ok();
+            }
+
+            @SuppressWarnings("unused")
+            public FormValidation doCheckCredentialId(@QueryParameter String value, @QueryParameter String authMethod) {
+                if (!AuthMethod.NONE.name().equals(authMethod) && StringUtils.isBlank(value)) {
+                    return FormValidation.error("Credential ID is required when authentication is enabled.");
+                }
+                return FormValidation.ok();
+            }
+        }
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/CascHttpSettings.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/CascHttpSettings.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins.casc.fetcher;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
@@ -18,9 +21,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableList;
+import org.kohsuke.stapler.verb.GET;
+import org.kohsuke.stapler.verb.POST;
 
 @Extension
 public class CascHttpSettings extends GlobalConfiguration {
@@ -223,8 +225,10 @@ public class CascHttpSettings extends GlobalConfiguration {
                 return "Remote HTTP Configuration";
             }
 
+            @GET
             @SuppressWarnings("unused")
             public ListBoxModel doFillAuthMethodItems() {
+                Jenkins.get().checkPermission(Jenkins.ADMINISTER);
                 ListBoxModel items = new ListBoxModel();
                 for (AuthMethod method : AuthMethod.values()) {
                     items.add(method.getDescription(), method.name());
@@ -232,8 +236,10 @@ public class CascHttpSettings extends GlobalConfiguration {
                 return items;
             }
 
+            @POST
             @SuppressWarnings("unused")
             public FormValidation doCheckUrlPrefix(@QueryParameter String value) {
+                Jenkins.get().checkPermission(Jenkins.ADMINISTER);
                 if (StringUtils.isBlank(value)) {
                     return FormValidation.error("URL Prefix cannot be empty.");
                 }
@@ -266,8 +272,10 @@ public class CascHttpSettings extends GlobalConfiguration {
                 return FormValidation.ok();
             }
 
+            @POST
             @SuppressWarnings("unused")
             public FormValidation doCheckCredentialId(@QueryParameter String value, @QueryParameter String authMethod) {
+                Jenkins.get().checkPermission(Jenkins.ADMINISTER);
                 if (!AuthMethod.NONE.name().equals(authMethod) && StringUtils.isBlank(value)) {
                     return FormValidation.error("Credential ID is required when authentication is enabled.");
                 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
@@ -38,7 +38,6 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
             throw new IOException("Invalid URL: " + location, e);
         }
 
-        // Extract credentialId from query parameters and sanitize the URI
         String rawQuery = originalUri.getQuery();
         String credentialId = null;
         String sanitizedQuery = null;
@@ -61,7 +60,6 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
             }
         }
 
-        // Rebuild the URI without the credentialId parameter
         URI requestUri;
         try {
             requestUri = new URI(
@@ -89,7 +87,6 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
         HttpRequest.Builder requestBuilder =
                 ProxyConfiguration.newHttpRequestBuilder(requestUri).GET().timeout(Duration.ofSeconds(30));
 
-        // Handle credentials and fail fast if requested credential cannot be resolved
         if (credentialId != null && !credentialId.isEmpty()) {
             if (credentials == null) {
                 throw new IOException("Credential ID specified in URL, but no credential resolver was provided.");
@@ -106,7 +103,6 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
                 if (token != null) {
                     requestBuilder.header("Authorization", "Bearer " + token.getToken());
                 } else {
-                    // Fail fast: throw IOException instead of falling back to unauthenticated request
                     throw new IOException(
                             "Unable to resolve credentials with ID '" + credentialId + "' for configuration source.");
                 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
@@ -11,11 +11,18 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 
 @Extension(ordinal = -100)
 public class DefaultHttpFetcher implements CasCConfigFetcher {
+
+    private static final String CREDENTIAL_ID_PARAM = "cascCredentialId";
+    private static final String FALLBACK_CREDENTIAL_ID_PARAM = "credentialId";
 
     @Override
     public boolean supports(String location) {
@@ -24,14 +31,52 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
 
     @Override
     public FetchResult fetch(String location, FetchCredentials credentials) throws IOException {
-        URI uri;
+        URI originalUri;
         try {
-            uri = new URI(location);
+            originalUri = new URI(location);
         } catch (URISyntaxException e) {
             throw new IOException("Invalid URL: " + location, e);
         }
 
-        String path = uri.getPath();
+        // Extract credentialId from query parameters and sanitize the URI
+        String rawQuery = originalUri.getQuery();
+        String credentialId = null;
+        String sanitizedQuery = null;
+
+        if (rawQuery != null && !rawQuery.isEmpty()) {
+            List<String> remainingParams = new ArrayList<>();
+            for (String param : rawQuery.split("&")) {
+                String[] pair = param.split("=", 2);
+                String key = pair[0];
+                String value = pair.length > 1 ? pair[1] : "";
+
+                if (CREDENTIAL_ID_PARAM.equalsIgnoreCase(key) || FALLBACK_CREDENTIAL_ID_PARAM.equalsIgnoreCase(key)) {
+                    credentialId = value;
+                } else {
+                    remainingParams.add(param);
+                }
+            }
+            if (!remainingParams.isEmpty()) {
+                sanitizedQuery = String.join("&", remainingParams);
+            }
+        }
+
+        // Rebuild the URI without the credentialId parameter
+        URI requestUri;
+        try {
+            requestUri = new URI(
+                    originalUri.getScheme(),
+                    originalUri.getUserInfo(),
+                    originalUri.getHost(),
+                    originalUri.getPort(),
+                    originalUri.getPath(),
+                    sanitizedQuery,
+                    originalUri.getFragment());
+        } catch (URISyntaxException e) {
+            throw new IOException("Failed to sanitize URI: " + location, e);
+        }
+
+        String path = requestUri.getPath();
         String fileName =
                 (path != null && path.contains("/")) ? path.substring(path.lastIndexOf('/') + 1) : "casc.yaml";
 
@@ -41,24 +86,48 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
 
         HttpClient client = ProxyConfiguration.newHttpClient();
 
-        HttpRequest request = ProxyConfiguration.newHttpRequestBuilder(uri)
-                .GET()
-                .timeout(Duration.ofSeconds(30))
-                .build();
+        HttpRequest.Builder requestBuilder =
+                ProxyConfiguration.newHttpRequestBuilder(requestUri).GET().timeout(Duration.ofSeconds(30));
 
+        // Handle credentials and fail fast if requested credential cannot be resolved
+        if (credentialId != null && !credentialId.isEmpty()) {
+            if (credentials == null) {
+                throw new IOException("Credential ID specified in URL, but no credential resolver was provided.");
+            }
+
+            FetchAuthData.UsernamePassword userPass =
+                    credentials.get(credentialId, FetchAuthData.UsernamePassword.class);
+            if (userPass != null) {
+                String authString = userPass.getUsername() + ":" + userPass.getPassword();
+                String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
+                requestBuilder.header("Authorization", "Basic " + encodedAuth);
+            } else {
+                FetchAuthData.Token token = credentials.get(credentialId, FetchAuthData.Token.class);
+                if (token != null) {
+                    requestBuilder.header("Authorization", "Bearer " + token.getToken());
+                } else {
+                    // Fail fast: throw IOException instead of falling back to unauthenticated request
+                    throw new IOException(
+                            "Unable to resolve credentials with ID '" + credentialId + "' for configuration source.");
+                }
+            }
+        }
+
+        HttpRequest request = requestBuilder.build();
         byte[] yamlBytes;
+
         try {
             HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
 
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new IOException("Failed to fetch configuration from " + location + ". HTTP status code: "
+                throw new IOException("Failed to fetch configuration from " + requestUri + ". HTTP status code: "
                         + response.statusCode());
             }
 
             yamlBytes = response.body();
         } catch (InterruptedException e) {
             currentThread().interrupt();
-            throw new IOException("Interrupted while fetching configuration from: " + location, e);
+            throw new IOException("Interrupted while fetching configuration from: " + requestUri, e);
         }
 
         ResolvedYaml resolved = new ResolvedYaml(fileName, () -> new ByteArrayInputStream(yamlBytes));

--- a/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
@@ -106,8 +106,7 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
                 FetchAuthData.UsernamePassword userPass =
                         credentials.get(credentialId, FetchAuthData.UsernamePassword.class);
                 if (userPass == null) {
-                    throw new IOException(
-                        "Unable to resolve Username/Password for ID: " + credentialId);
+                    throw new IOException("Unable to resolve Username/Password for ID: " + credentialId);
                 }
                 String authString = userPass.getUsername() + ":" + userPass.getPassword();
                 String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));

--- a/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
@@ -8,21 +8,31 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.List;
 
 @Extension(ordinal = -100)
 public class DefaultHttpFetcher implements CasCConfigFetcher {
 
-    private static final String CREDENTIAL_ID_PARAM = "cascCredentialId";
+    @FunctionalInterface
+    public interface HttpSettingsProvider {
+        CascHttpSettings.RemoteConfig getConfigForUrl(String url);
+    }
+
+    private final HttpSettingsProvider settingsProvider;
+
+    public DefaultHttpFetcher() {
+        this(CascHttpSettings::getConfigForUrl);
+    }
+
+    DefaultHttpFetcher(HttpSettingsProvider settingsProvider) {
+        this.settingsProvider = settingsProvider;
+    }
 
     @Override
     public boolean supports(String location) {
@@ -31,59 +41,11 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
 
     @Override
     public FetchResult fetch(String location, FetchCredentials credentials) throws IOException {
-        URI originalUri;
-        try {
-            originalUri = new URI(location);
-        } catch (URISyntaxException e) {
-            throw new IOException("Invalid URL: " + location, e);
-        }
-
-        String rawQuery = originalUri.getRawQuery();
-        String credentialId = null;
-        String sanitizedRawQuery = null;
-
-        if (rawQuery != null && !rawQuery.isEmpty()) {
-            List<String> remainingParams = new ArrayList<>();
-            for (String param : rawQuery.split("&", -1)) {
-                String[] pair = param.split("=", 2);
-                String rawKey = pair[0];
-                String rawValue = pair.length > 1 ? pair[1] : "";
-
-                String decodedKey = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
-
-                if (CREDENTIAL_ID_PARAM.equalsIgnoreCase(decodedKey)) {
-                    credentialId = URLDecoder.decode(rawValue, StandardCharsets.UTF_8);
-                } else {
-                    remainingParams.add(param);
-                }
-            }
-            if (!remainingParams.isEmpty()) {
-                sanitizedRawQuery = String.join("&", remainingParams);
-            }
-        }
-
         URI requestUri;
         try {
-            StringBuilder uriBuilder = new StringBuilder();
-            if (originalUri.getScheme() != null) {
-                uriBuilder.append(originalUri.getScheme()).append("://");
-            }
-            if (originalUri.getRawAuthority() != null) {
-                uriBuilder.append(originalUri.getRawAuthority());
-            }
-            if (originalUri.getRawPath() != null) {
-                uriBuilder.append(originalUri.getRawPath());
-            }
-            if (sanitizedRawQuery != null) {
-                uriBuilder.append("?").append(sanitizedRawQuery);
-            }
-            if (originalUri.getRawFragment() != null) {
-                uriBuilder.append("#").append(originalUri.getRawFragment());
-            }
-
-            requestUri = new URI(uriBuilder.toString());
+            requestUri = new URI(location);
         } catch (URISyntaxException e) {
-            throw new IOException("Failed to sanitize URI: " + location, e);
+            throw new IOException("Invalid URL: " + location, e);
         }
 
         String path = requestUri.getPath();
@@ -99,26 +61,14 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
         HttpRequest.Builder requestBuilder =
                 ProxyConfiguration.newHttpRequestBuilder(requestUri).GET().timeout(Duration.ofSeconds(30));
 
-        if (credentialId != null && !credentialId.isEmpty()) {
-            if (credentials == null) {
-                throw new IOException("Credential ID specified in URL, but no credential resolver was provided.");
-            }
+        CascHttpSettings.RemoteConfig remoteConfig = settingsProvider.getConfigForUrl(location);
 
-            FetchAuthData.UsernamePassword userPass =
-                    credentials.get(credentialId, FetchAuthData.UsernamePassword.class);
-            if (userPass != null) {
-                String authString = userPass.getUsername() + ":" + userPass.getPassword();
-                String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
-                requestBuilder.header("Authorization", "Basic " + encodedAuth);
-            } else {
-                FetchAuthData.Token token = credentials.get(credentialId, FetchAuthData.Token.class);
-                if (token != null) {
-                    requestBuilder.header("Authorization", "Bearer " + token.getToken());
-                } else {
-                    throw new IOException(
-                            "Unable to resolve credentials with ID '" + credentialId + "' for configuration source.");
-                }
+        if (remoteConfig != null && remoteConfig.getAuthMethod() != CascHttpSettings.AuthMethod.NONE) {
+            if (credentials == null) {
+                throw new IOException(
+                        "Credentials required for " + location + " but no credential resolver was provided.");
             }
+            applyAuthentication(requestBuilder, remoteConfig, credentials);
         }
 
         HttpRequest request = requestBuilder.build();
@@ -141,5 +91,53 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
         ResolvedYaml resolved = new ResolvedYaml(fileName, () -> new ByteArrayInputStream(yamlBytes));
 
         return new FetchResult(Collections.singletonList(resolved), (AutoCloseable) null);
+    }
+
+    private void applyAuthentication(
+            HttpRequest.Builder requestBuilder, CascHttpSettings.RemoteConfig config, FetchCredentials credentials)
+            throws IOException {
+        String credentialId = config.getCredentialId();
+
+        switch (config.getAuthMethod()) {
+            case NONE:
+                break;
+
+            case BASIC:
+                FetchAuthData.UsernamePassword userPass =
+                        credentials.get(credentialId, FetchAuthData.UsernamePassword.class);
+                if (userPass == null) {
+                    throw new IOException(
+                        "Unable to resolve Username/Password for ID: " + credentialId);
+                }
+                String authString = userPass.getUsername() + ":" + userPass.getPassword();
+                String encodedAuth = Base64.getEncoder().encodeToString(authString.getBytes(StandardCharsets.UTF_8));
+                requestBuilder.header("Authorization", "Basic " + encodedAuth);
+                break;
+
+            case BEARER:
+                FetchAuthData.Token token = credentials.get(credentialId, FetchAuthData.Token.class);
+                if (token == null) {
+                    throw new IOException("Unable to resolve Token for ID: " + credentialId);
+                }
+                requestBuilder.header("Authorization", "Bearer " + token.getToken());
+                break;
+
+            case API_KEY:
+                FetchAuthData.Token apiKey = credentials.get(credentialId, FetchAuthData.Token.class);
+                if (apiKey == null) {
+                    throw new IOException("Unable to resolve API Key for ID: " + credentialId);
+                }
+
+                String headerName = config.getHeaderName();
+                if (headerName == null || headerName.trim().isEmpty()) {
+                    headerName = "x-api-key";
+                }
+
+                requestBuilder.header(headerName, apiKey.getToken());
+                break;
+
+            default:
+                throw new IOException("Unsupported authentication method: " + config.getAuthMethod());
+        }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcher.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -22,7 +23,6 @@ import java.util.List;
 public class DefaultHttpFetcher implements CasCConfigFetcher {
 
     private static final String CREDENTIAL_ID_PARAM = "cascCredentialId";
-    private static final String FALLBACK_CREDENTIAL_ID_PARAM = "credentialId";
 
     @Override
     public boolean supports(String location) {
@@ -38,38 +38,50 @@ public class DefaultHttpFetcher implements CasCConfigFetcher {
             throw new IOException("Invalid URL: " + location, e);
         }
 
-        String rawQuery = originalUri.getQuery();
+        String rawQuery = originalUri.getRawQuery();
         String credentialId = null;
-        String sanitizedQuery = null;
+        String sanitizedRawQuery = null;
 
         if (rawQuery != null && !rawQuery.isEmpty()) {
             List<String> remainingParams = new ArrayList<>();
-            for (String param : rawQuery.split("&")) {
+            for (String param : rawQuery.split("&", -1)) {
                 String[] pair = param.split("=", 2);
-                String key = pair[0];
-                String value = pair.length > 1 ? pair[1] : "";
+                String rawKey = pair[0];
+                String rawValue = pair.length > 1 ? pair[1] : "";
 
-                if (CREDENTIAL_ID_PARAM.equalsIgnoreCase(key) || FALLBACK_CREDENTIAL_ID_PARAM.equalsIgnoreCase(key)) {
-                    credentialId = value;
+                String decodedKey = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+
+                if (CREDENTIAL_ID_PARAM.equalsIgnoreCase(decodedKey)) {
+                    credentialId = URLDecoder.decode(rawValue, StandardCharsets.UTF_8);
                 } else {
                     remainingParams.add(param);
                 }
             }
             if (!remainingParams.isEmpty()) {
-                sanitizedQuery = String.join("&", remainingParams);
+                sanitizedRawQuery = String.join("&", remainingParams);
             }
         }
 
         URI requestUri;
         try {
-            requestUri = new URI(
-                    originalUri.getScheme(),
-                    originalUri.getUserInfo(),
-                    originalUri.getHost(),
-                    originalUri.getPort(),
-                    originalUri.getPath(),
-                    sanitizedQuery,
-                    originalUri.getFragment());
+            StringBuilder uriBuilder = new StringBuilder();
+            if (originalUri.getScheme() != null) {
+                uriBuilder.append(originalUri.getScheme()).append("://");
+            }
+            if (originalUri.getRawAuthority() != null) {
+                uriBuilder.append(originalUri.getRawAuthority());
+            }
+            if (originalUri.getRawPath() != null) {
+                uriBuilder.append(originalUri.getRawPath());
+            }
+            if (sanitizedRawQuery != null) {
+                uriBuilder.append("?").append(sanitizedRawQuery);
+            }
+            if (originalUri.getRawFragment() != null) {
+                uriBuilder.append("#").append(originalUri.getRawFragment());
+            }
+
+            requestUri = new URI(uriBuilder.toString());
         } catch (URISyntaxException e) {
             throw new IOException("Failed to sanitize URI: " + location, e);
         }

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/fetcher/CascHttpSettings/RemoteConfig/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/fetcher/CascHttpSettings/RemoteConfig/config.jelly
@@ -1,0 +1,65 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%URL Prefix}" field="urlPrefix">
+        <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Authentication Method}" field="authMethod">
+        <f:select class="casc-auth-method"/>
+    </f:entry>
+
+    <f:entry title="${%Credential ID}" field="credentialId">
+        <f:textbox class="casc-cred-id"/>
+    </f:entry>
+
+    <f:entry title="${%Header Name}" field="headerName">
+        <f:textbox class="casc-header-name"/>
+    </f:entry>
+
+    <f:entry title="">
+        <div align="right">
+            <f:repeatableDeleteButton/>
+        </div>
+    </f:entry>
+
+    <script>
+        Behaviour.specify(".casc-auth-method", 'CascAuthMethodToggle', 0, function (e) {
+            const update = function () {
+                const val = e.value;
+                const formTable = e.closest('table') || e.closest('.repeated-chunk');
+                const credInput = formTable.querySelector('.casc-cred-id');
+                const headerInput = formTable.querySelector('.casc-header-name');
+
+                if (credInput &amp;&amp; headerInput) {
+                    const credRow = credInput.closest('.tr') || credInput.closest('tr');
+                    const headerRow = headerInput.closest('.tr') || headerInput.closest('tr');
+
+                    if (val === 'NONE') {
+                        if (credRow) {
+                            credRow.style.display = 'none';
+                        }
+                        if (headerRow) {
+                            headerRow.style.display = 'none';
+                        }
+                    } else if (val === 'API_KEY') {
+                        if (credRow) {
+                            credRow.style.display = '';
+                        }
+                        if (headerRow) {
+                            headerRow.style.display = '';
+                        }
+                    } else {
+                        if (credRow) {
+                            credRow.style.display = '';
+                        }
+                        if (headerRow) {
+                            headerRow.style.display = 'none';
+                        }
+                    }
+                }
+            };
+            e.onchange = update;
+            update();
+        });
+    </script>
+</j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/casc/fetcher/CascHttpSettings/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/casc/fetcher/CascHttpSettings/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:advanced>
+        <f:entry title="${%Remote HTTP Configurations}" field="remoteConfigs">
+            <f:repeatableProperty field="remoteConfigs" />
+        </f:entry>
+    </f:advanced>
+</j:jelly>

--- a/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/CascHttpSettingsTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/CascHttpSettingsTest.java
@@ -1,0 +1,109 @@
+package io.jenkins.plugins.casc.fetcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import hudson.util.FormValidation;
+import io.jenkins.plugins.casc.fetcher.CascHttpSettings.AuthMethod;
+import io.jenkins.plugins.casc.fetcher.CascHttpSettings.RemoteConfig;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class CascHttpSettingsTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testLongestMatchWins() {
+        CascHttpSettings settings = CascHttpSettings.get();
+        settings.setRemoteConfigs(Arrays.asList(
+                new RemoteConfig("https://example.com/api/", "cred-short", AuthMethod.BASIC),
+                new RemoteConfig("https://example.com/api/v2/", "cred-long", AuthMethod.BEARER)));
+
+        RemoteConfig match1 = CascHttpSettings.getConfigForUrl("https://example.com/api/v2/resource");
+        assertNotNull(match1);
+        assertEquals("cred-long", match1.getCredentialId());
+
+        RemoteConfig match2 = CascHttpSettings.getConfigForUrl("https://example.com/api/v1/resource");
+        assertNotNull(match2);
+        assertEquals("cred-short", match2.getCredentialId());
+
+        RemoteConfig match3 = CascHttpSettings.getConfigForUrl("https://example.com/other");
+        assertNull(match3);
+    }
+
+    @Test
+    public void testPathBoundaryMatching() {
+        CascHttpSettings settings = CascHttpSettings.get();
+        settings.setRemoteConfigs(List.of(new RemoteConfig("https://example.com/foo", "cred", AuthMethod.BASIC)));
+
+        assertNotNull(CascHttpSettings.getConfigForUrl("https://example.com/foo/bar"));
+        assertNull(CascHttpSettings.getConfigForUrl("https://example.com/foobar"));
+    }
+
+    @Test
+    public void testPortMatching() {
+        CascHttpSettings settings = CascHttpSettings.get();
+        settings.setRemoteConfigs(Arrays.asList(
+                new RemoteConfig("https://example.com", "cred-https", AuthMethod.BASIC),
+                new RemoteConfig("http://example.com:8080", "cred-8080", AuthMethod.BASIC)));
+
+        assertNotNull(CascHttpSettings.getConfigForUrl("https://example.com:443/test"));
+        assertNotNull(CascHttpSettings.getConfigForUrl("http://example.com:8080/test"));
+        assertNull(CascHttpSettings.getConfigForUrl("https://example.com:8443/test"));
+    }
+
+    @Test
+    public void testDescriptorValidation() {
+        CascHttpSettings.RemoteConfig.DescriptorImpl descriptor = new CascHttpSettings.RemoteConfig.DescriptorImpl();
+
+        assertEquals(FormValidation.Kind.OK, descriptor.doCheckUrlPrefix("https://example.com/path").kind);
+        assertEquals(FormValidation.Kind.OK, descriptor.doCheckUrlPrefix("http://localhost:8080/").kind);
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckUrlPrefix("ftp://example.com").kind);
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckUrlPrefix("").kind);
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckUrlPrefix("https:///path").kind);
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckUrlPrefix("https://example.com?query=1").kind);
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckUrlPrefix("https://example.com#fragment").kind);
+    }
+
+    @Test
+    public void testAuthMethodDefaultsToNone() {
+        RemoteConfig config = new RemoteConfig("https://example.com", null, null);
+
+        assertEquals(AuthMethod.NONE, config.getAuthMethod());
+    }
+
+    @Test
+    public void testCredentialValidation() {
+        CascHttpSettings.RemoteConfig.DescriptorImpl descriptor = new CascHttpSettings.RemoteConfig.DescriptorImpl();
+
+        assertEquals(FormValidation.Kind.OK, descriptor.doCheckCredentialId("", "NONE").kind);
+        assertEquals(FormValidation.Kind.ERROR, descriptor.doCheckCredentialId("", "BASIC").kind);
+        assertEquals(FormValidation.Kind.OK, descriptor.doCheckCredentialId("my-credential", "BASIC").kind);
+    }
+
+    @Test
+    public void testAuthMethods() {
+        assertEquals(4, AuthMethod.values().length);
+        assertEquals(AuthMethod.NONE, AuthMethod.valueOf("NONE"));
+        assertEquals(AuthMethod.BASIC, AuthMethod.valueOf("BASIC"));
+        assertEquals(AuthMethod.BEARER, AuthMethod.valueOf("BEARER"));
+        assertEquals(AuthMethod.API_KEY, AuthMethod.valueOf("API_KEY"));
+    }
+
+    @Test
+    public void testSchemeAndHostMatching() {
+        CascHttpSettings settings = CascHttpSettings.get();
+        settings.setRemoteConfigs(List.of(new RemoteConfig("https://example.com/api", "cred", AuthMethod.BASIC)));
+
+        assertNull(CascHttpSettings.getConfigForUrl("http://example.com/api/config.yaml"));
+        assertNull(CascHttpSettings.getConfigForUrl("https://other.example.com/api/config.yaml"));
+
+        assertNotNull(CascHttpSettings.getConfigForUrl("https://example.com/api/config.yaml"));
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
@@ -10,6 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static java.lang.Thread.currentThread;
 import static java.lang.Thread.interrupted;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Base64.getEncoder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -148,8 +149,7 @@ public class DefaultHttpFetcherTest {
         stubFor(get(urlEqualTo("/private.yaml"))
                 .withHeader(
                         "Authorization",
-                        equalTo("Basic "
-                                + java.util.Base64.getEncoder().encodeToString("user:password".getBytes(UTF_8))))
+                        equalTo("Basic " + getEncoder().encodeToString("user:password".getBytes(UTF_8))))
                 .willReturn(aResponse().withStatus(200).withBody("jenkins:\n  systemMessage: 'Private'")));
 
         FetchCredentials credentials = new FetchCredentials() {
@@ -181,8 +181,7 @@ public class DefaultHttpFetcherTest {
         verify(getRequestedFor(urlEqualTo("/private.yaml"))
                 .withHeader(
                         "Authorization",
-                        equalTo("Basic "
-                                + java.util.Base64.getEncoder().encodeToString("user:password".getBytes(UTF_8)))));
+                        equalTo("Basic " + getEncoder().encodeToString("user:password".getBytes(UTF_8)))));
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
@@ -45,6 +45,23 @@ public class DefaultHttpFetcherTest {
     }
 
     @Test
+    public void testFetchThrowsOnFailedSanitizeUri() {
+        // "http:example.com" parses successfully as an opaque URI initially.
+        // However, the fetcher reconstructs the URI string by unconditionally appending "://" after the scheme.
+        // This results in "http://", which is invalid (missing authority) and throws a URISyntaxException.
+        String targetUrl = "http:example.com";
+
+        IOException e = assertThrows(
+                "Expected fetcher to throw IOException due to URI reconstruction failure",
+                IOException.class,
+                () -> fetcher.fetch(targetUrl, null));
+
+        assertTrue(
+                "Message should indicate sanitization failure",
+                e.getMessage().contains("Failed to sanitize URI: " + targetUrl));
+    }
+
+    @Test
     public void testActualHttpFetchIntegration() throws Exception {
         stubFor(get(urlEqualTo("/casc.yaml"))
                 .willReturn(aResponse().withStatus(200).withBody("jenkins:\n  systemMessage: 'Hello HTTP'")));
@@ -265,5 +282,17 @@ public class DefaultHttpFetcherTest {
 
         verify(getRequestedFor(urlEqualTo("/config.yaml?signature=a%26b&foo=bar"))
                 .withHeader("Authorization", equalTo("Bearer secret-token")));
+    }
+
+    @Test
+    public void testFetchUrlWithFragment() throws Exception {
+        stubFor(get(urlEqualTo("/casc.yaml"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins:\n  systemMessage: 'Fragment Test'")));
+
+        String targetUrl = wireMockRule.baseUrl() + "/casc.yaml#section1";
+        FetchResult result = fetcher.fetch(targetUrl, null);
+
+        assertEquals(1, result.items().size());
+        verify(getRequestedFor(urlEqualTo("/casc.yaml")));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
@@ -21,6 +21,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.stream.Collectors;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -29,7 +30,14 @@ public class DefaultHttpFetcherTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(0);
 
-    private final DefaultHttpFetcher fetcher = new DefaultHttpFetcher();
+    private CascHttpSettings.RemoteConfig mockConfig;
+    private DefaultHttpFetcher fetcher;
+
+    @Before
+    public void setup() {
+        mockConfig = null;
+        fetcher = new DefaultHttpFetcher(url -> mockConfig);
+    }
 
     @Test
     public void testSupportsLogic() {
@@ -42,20 +50,6 @@ public class DefaultHttpFetcherTest {
     @Test(expected = IOException.class)
     public void testFetchThrowsOnInvalidUrl() throws Exception {
         fetcher.fetch("http://example.com/invalid path with spaces", null);
-    }
-
-    @Test
-    public void testFetchThrowsOnFailedSanitizeUri() {
-        String targetUrl = "http:example.com";
-
-        IOException e = assertThrows(
-                "Expected fetcher to throw IOException due to URI reconstruction failure",
-                IOException.class,
-                () -> fetcher.fetch(targetUrl, null));
-
-        assertTrue(
-                "Message should indicate sanitization failure",
-                e.getMessage().contains("Failed to sanitize URI: " + targetUrl));
     }
 
     @Test
@@ -133,10 +127,13 @@ public class DefaultHttpFetcherTest {
     }
 
     @Test
-    public void testFetchWithTokenCredential() throws Exception {
+    public void testFetchWithBearerToken() throws Exception {
         stubFor(get(urlEqualTo("/private.yaml"))
                 .withHeader("Authorization", equalTo("Bearer secret-token"))
                 .willReturn(aResponse().withStatus(200).withBody("jenkins:\n  systemMessage: 'Private'")));
+
+        mockConfig =
+                new CascHttpSettings.RemoteConfig("http://localhost", "MY_TOKEN", CascHttpSettings.AuthMethod.BEARER);
 
         FetchCredentials credentials = new FetchCredentials() {
             @Override
@@ -148,8 +145,7 @@ public class DefaultHttpFetcherTest {
             }
         };
 
-        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=MY_TOKEN";
-
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml";
         FetchResult result = fetcher.fetch(targetUrl, credentials);
 
         assertEquals(1, result.items().size());
@@ -165,6 +161,9 @@ public class DefaultHttpFetcherTest {
                         "Authorization",
                         equalTo("Basic " + getEncoder().encodeToString("user:password".getBytes(UTF_8))))
                 .willReturn(aResponse().withStatus(200).withBody("jenkins:\n  systemMessage: 'Private'")));
+
+        mockConfig = new CascHttpSettings.RemoteConfig(
+                "http://localhost", "MY_CREDENTIALS", CascHttpSettings.AuthMethod.BASIC);
 
         FetchCredentials credentials = new FetchCredentials() {
             @Override
@@ -186,8 +185,7 @@ public class DefaultHttpFetcherTest {
             }
         };
 
-        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=MY_CREDENTIALS";
-
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml";
         FetchResult result = fetcher.fetch(targetUrl, credentials);
 
         assertEquals(1, result.items().size());
@@ -199,31 +197,60 @@ public class DefaultHttpFetcherTest {
     }
 
     @Test
-    public void testCredentialIdIsRemovedFromRequestUrl() throws Exception {
-        stubFor(get(urlEqualTo("/config.yaml?foo=bar"))
-                .withHeader("Authorization", equalTo("Bearer secret-token"))
+    public void testFetchWithApiKeyCustomHeader() throws Exception {
+        stubFor(get(urlEqualTo("/private.yaml"))
+                .withHeader("X-Custom-Auth", equalTo("secret-key"))
                 .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
+
+        mockConfig = new CascHttpSettings.RemoteConfig(
+                "http://localhost", "MY_API_KEY", CascHttpSettings.AuthMethod.API_KEY);
+        mockConfig.setHeaderName("X-Custom-Auth");
 
         FetchCredentials credentials = new FetchCredentials() {
             @Override
             public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
-                if ("MY_TOKEN".equals(credentialId) && type == FetchAuthData.Token.class) {
-                    return type.cast((FetchAuthData.Token) () -> "secret-token");
+                if ("MY_API_KEY".equals(credentialId) && type == FetchAuthData.Token.class) {
+                    return type.cast((FetchAuthData.Token) () -> "secret-key");
                 }
                 return null;
             }
         };
 
-        String targetUrl = wireMockRule.baseUrl() + "/config.yaml?foo=bar&cascCredentialId=MY_TOKEN";
+        fetcher.fetch(wireMockRule.baseUrl() + "/private.yaml", credentials);
 
-        fetcher.fetch(targetUrl, credentials);
+        verify(getRequestedFor(urlEqualTo("/private.yaml")).withHeader("X-Custom-Auth", equalTo("secret-key")));
+    }
 
-        verify(getRequestedFor(urlEqualTo("/config.yaml?foo=bar"))
-                .withHeader("Authorization", equalTo("Bearer secret-token")));
+    @Test
+    public void testFetchWithApiKeyDefaultHeader() throws Exception {
+        stubFor(get(urlEqualTo("/private.yaml"))
+                .withHeader("x-api-key", equalTo("secret-key"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
+
+        mockConfig = new CascHttpSettings.RemoteConfig(
+                "http://localhost", "MY_API_KEY", CascHttpSettings.AuthMethod.API_KEY);
+        mockConfig.setHeaderName("");
+
+        FetchCredentials credentials = new FetchCredentials() {
+            @Override
+            public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
+                if ("MY_API_KEY".equals(credentialId) && type == FetchAuthData.Token.class) {
+                    return type.cast((FetchAuthData.Token) () -> "secret-key");
+                }
+                return null;
+            }
+        };
+
+        fetcher.fetch(wireMockRule.baseUrl() + "/private.yaml", credentials);
+
+        verify(getRequestedFor(urlEqualTo("/private.yaml")).withHeader("x-api-key", equalTo("secret-key")));
     }
 
     @Test
     public void testFetchThrowsWhenCredentialCannotBeResolved() {
+        mockConfig =
+                new CascHttpSettings.RemoteConfig("http://localhost", "UNKNOWN", CascHttpSettings.AuthMethod.BEARER);
+
         FetchCredentials credentials = new FetchCredentials() {
             @Override
             public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
@@ -231,54 +258,21 @@ public class DefaultHttpFetcherTest {
             }
         };
 
-        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=UNKNOWN";
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml";
 
         IOException e = assertThrows(IOException.class, () -> fetcher.fetch(targetUrl, credentials));
-
-        assertTrue(e.getMessage().contains("Unable to resolve credentials with ID 'UNKNOWN'"));
+        assertTrue(e.getMessage().contains("Unable to resolve Token for ID: UNKNOWN"));
     }
 
     @Test
     public void testFetchThrowsWhenCredentialResolverIsMissing() {
-        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=MY_TOKEN";
+        mockConfig =
+                new CascHttpSettings.RemoteConfig("http://localhost", "MY_TOKEN", CascHttpSettings.AuthMethod.BEARER);
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml";
 
         IOException e = assertThrows(IOException.class, () -> fetcher.fetch(targetUrl, null));
 
         assertTrue(e.getMessage().contains("no credential resolver was provided"));
-    }
-
-    @Test
-    public void testGenericCredentialIdIsPreservedAsNormalQueryParam() throws Exception {
-        stubFor(get(urlEqualTo("/private.yaml?credentialId=SERVER_PARAM"))
-                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
-
-        fetcher.fetch(wireMockRule.baseUrl() + "/private.yaml?credentialId=SERVER_PARAM", null);
-
-        verify(getRequestedFor(urlEqualTo("/private.yaml?credentialId=SERVER_PARAM")));
-    }
-
-    @Test
-    public void testPreservesEncodedQueryParameters() throws Exception {
-        stubFor(get(urlEqualTo("/config.yaml?signature=a%26b&foo=bar"))
-                .withHeader("Authorization", equalTo("Bearer secret-token"))
-                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
-
-        FetchCredentials credentials = new FetchCredentials() {
-            @Override
-            public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
-                if ("MY_TOKEN".equals(credentialId) && type == FetchAuthData.Token.class) {
-                    return type.cast((FetchAuthData.Token) () -> "secret-token");
-                }
-                return null;
-            }
-        };
-
-        String targetUrl = wireMockRule.baseUrl() + "/config.yaml?signature=a%26b&cascCredentialId=MY_TOKEN&foo=bar";
-
-        fetcher.fetch(targetUrl, credentials);
-
-        verify(getRequestedFor(urlEqualTo("/config.yaml?signature=a%26b&foo=bar"))
-                .withHeader("Authorization", equalTo("Bearer secret-token")));
     }
 
     @Test
@@ -291,5 +285,27 @@ public class DefaultHttpFetcherTest {
 
         assertEquals(1, result.items().size());
         verify(getRequestedFor(urlEqualTo("/casc.yaml")));
+    }
+
+    @Test
+    public void testFetchWithNoAuthentication() throws Exception {
+        stubFor(get(urlEqualTo("/public.yaml"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
+
+        mockConfig = new CascHttpSettings.RemoteConfig("http://localhost", null, CascHttpSettings.AuthMethod.NONE);
+
+        fetcher.fetch(wireMockRule.baseUrl() + "/public.yaml", null);
+
+        verify(getRequestedFor(urlEqualTo("/public.yaml")).withoutHeader("Authorization"));
+    }
+
+    @Test
+    public void testFetchWithoutMatchingConfiguration() throws Exception {
+        stubFor(get(urlEqualTo("/public.yaml"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
+
+        fetcher.fetch(wireMockRule.baseUrl() + "/public.yaml", null);
+
+        verify(getRequestedFor(urlEqualTo("/public.yaml")).withoutHeader("Authorization"));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
@@ -1,9 +1,12 @@
 package io.jenkins.plugins.casc.fetcher;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static java.lang.Thread.currentThread;
 import static java.lang.Thread.interrupted;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -112,5 +115,145 @@ public class DefaultHttpFetcherTest {
             @SuppressWarnings("unused")
             boolean cleared = interrupted();
         }
+    }
+
+    @Test
+    public void testFetchWithTokenCredential() throws Exception {
+        stubFor(get(urlEqualTo("/private.yaml"))
+                .withHeader("Authorization", equalTo("Bearer secret-token"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins:\n  systemMessage: 'Private'")));
+
+        FetchCredentials credentials = new FetchCredentials() {
+            @Override
+            public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
+                if ("MY_TOKEN".equals(credentialId) && type == FetchAuthData.Token.class) {
+                    return type.cast((FetchAuthData.Token) () -> "secret-token");
+                }
+                return null;
+            }
+        };
+
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=MY_TOKEN";
+
+        FetchResult result = fetcher.fetch(targetUrl, credentials);
+
+        assertEquals(1, result.items().size());
+
+        verify(getRequestedFor(urlEqualTo("/private.yaml"))
+                .withHeader("Authorization", equalTo("Bearer secret-token")));
+    }
+
+    @Test
+    public void testFetchWithUsernamePasswordCredential() throws Exception {
+        stubFor(get(urlEqualTo("/private.yaml"))
+                .withHeader(
+                        "Authorization",
+                        equalTo("Basic "
+                                + java.util.Base64.getEncoder().encodeToString("user:password".getBytes(UTF_8))))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins:\n  systemMessage: 'Private'")));
+
+        FetchCredentials credentials = new FetchCredentials() {
+            @Override
+            public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
+                if ("MY_CREDENTIALS".equals(credentialId) && type == FetchAuthData.UsernamePassword.class) {
+                    return type.cast(new FetchAuthData.UsernamePassword() {
+                        @Override
+                        public String getUsername() {
+                            return "user";
+                        }
+
+                        @Override
+                        public String getPassword() {
+                            return "password";
+                        }
+                    });
+                }
+                return null;
+            }
+        };
+
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=MY_CREDENTIALS";
+
+        FetchResult result = fetcher.fetch(targetUrl, credentials);
+
+        assertEquals(1, result.items().size());
+
+        verify(getRequestedFor(urlEqualTo("/private.yaml"))
+                .withHeader(
+                        "Authorization",
+                        equalTo("Basic "
+                                + java.util.Base64.getEncoder().encodeToString("user:password".getBytes(UTF_8)))));
+    }
+
+    @Test
+    public void testCredentialIdIsRemovedFromRequestUrl() throws Exception {
+        stubFor(get(urlEqualTo("/config.yaml?foo=bar"))
+                .withHeader("Authorization", equalTo("Bearer secret-token"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
+
+        FetchCredentials credentials = new FetchCredentials() {
+            @Override
+            public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
+                if ("MY_TOKEN".equals(credentialId) && type == FetchAuthData.Token.class) {
+                    return type.cast((FetchAuthData.Token) () -> "secret-token");
+                }
+                return null;
+            }
+        };
+
+        String targetUrl = wireMockRule.baseUrl() + "/config.yaml?foo=bar&cascCredentialId=MY_TOKEN";
+
+        fetcher.fetch(targetUrl, credentials);
+
+        // FIXED: Using getRequestedFor
+        verify(getRequestedFor(urlEqualTo("/config.yaml?foo=bar"))
+                .withHeader("Authorization", equalTo("Bearer secret-token")));
+    }
+
+    @Test
+    public void testFetchThrowsWhenCredentialCannotBeResolved() {
+        FetchCredentials credentials = new FetchCredentials() {
+            @Override
+            public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
+                return null;
+            }
+        };
+
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=UNKNOWN";
+
+        IOException e = assertThrows(IOException.class, () -> fetcher.fetch(targetUrl, credentials));
+
+        assertTrue(e.getMessage().contains("Unable to resolve credentials with ID 'UNKNOWN'"));
+    }
+
+    @Test
+    public void testFetchThrowsWhenCredentialResolverIsMissing() {
+        String targetUrl = wireMockRule.baseUrl() + "/private.yaml?cascCredentialId=MY_TOKEN";
+
+        IOException e = assertThrows(IOException.class, () -> fetcher.fetch(targetUrl, null));
+
+        assertTrue(e.getMessage().contains("no credential resolver was provided"));
+    }
+
+    @Test
+    public void testFetchWithCredentialIdParameter() throws Exception {
+        stubFor(get(urlEqualTo("/private.yaml"))
+                .withHeader("Authorization", equalTo("Bearer secret-token"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
+
+        FetchCredentials credentials = new FetchCredentials() {
+            @Override
+            public <T extends FetchAuthData> T get(String credentialId, Class<T> type) {
+                if ("MY_TOKEN".equals(credentialId) && type == FetchAuthData.Token.class) {
+                    return type.cast((FetchAuthData.Token) () -> "secret-token");
+                }
+                return null;
+            }
+        };
+
+        fetcher.fetch(wireMockRule.baseUrl() + "/private.yaml?credentialId=MY_TOKEN", credentials);
+
+        verify(getRequestedFor(urlEqualTo("/private.yaml"))
+                .withHeader("Authorization", equalTo("Bearer secret-token")));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
@@ -205,7 +205,6 @@ public class DefaultHttpFetcherTest {
 
         fetcher.fetch(targetUrl, credentials);
 
-        // FIXED: Using getRequestedFor
         verify(getRequestedFor(urlEqualTo("/config.yaml?foo=bar"))
                 .withHeader("Authorization", equalTo("Bearer secret-token")));
     }
@@ -236,8 +235,18 @@ public class DefaultHttpFetcherTest {
     }
 
     @Test
-    public void testFetchWithCredentialIdParameter() throws Exception {
-        stubFor(get(urlEqualTo("/private.yaml"))
+    public void testGenericCredentialIdIsPreservedAsNormalQueryParam() throws Exception {
+        stubFor(get(urlEqualTo("/private.yaml?credentialId=SERVER_PARAM"))
+                .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
+
+        fetcher.fetch(wireMockRule.baseUrl() + "/private.yaml?credentialId=SERVER_PARAM", null);
+
+        verify(getRequestedFor(urlEqualTo("/private.yaml?credentialId=SERVER_PARAM")));
+    }
+
+    @Test
+    public void testPreservesEncodedQueryParameters() throws Exception {
+        stubFor(get(urlEqualTo("/config.yaml?signature=a%26b&foo=bar"))
                 .withHeader("Authorization", equalTo("Bearer secret-token"))
                 .willReturn(aResponse().withStatus(200).withBody("jenkins: {}")));
 
@@ -251,9 +260,11 @@ public class DefaultHttpFetcherTest {
             }
         };
 
-        fetcher.fetch(wireMockRule.baseUrl() + "/private.yaml?credentialId=MY_TOKEN", credentials);
+        String targetUrl = wireMockRule.baseUrl() + "/config.yaml?signature=a%26b&cascCredentialId=MY_TOKEN&foo=bar";
 
-        verify(getRequestedFor(urlEqualTo("/private.yaml"))
+        fetcher.fetch(targetUrl, credentials);
+
+        verify(getRequestedFor(urlEqualTo("/config.yaml?signature=a%26b&foo=bar"))
                 .withHeader("Authorization", equalTo("Bearer secret-token")));
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/fetcher/DefaultHttpFetcherTest.java
@@ -46,9 +46,6 @@ public class DefaultHttpFetcherTest {
 
     @Test
     public void testFetchThrowsOnFailedSanitizeUri() {
-        // "http:example.com" parses successfully as an opaque URI initially.
-        // However, the fetcher reconstructs the URI string by unconditionally appending "://" after the scheme.
-        // This results in "http://", which is invalid (missing authority) and throws a URISyntaxException.
         String targetUrl = "http:example.com";
 
         IOException e = assertThrows(


### PR DESCRIPTION
Addresses https://github.com/jenkinsci/configuration-as-code-plugin/pull/2865#discussion_r3539725034

Adds URL-based credential resolution for DefaultHttpFetcher, supporting token and username/password authentication, sanitizing credential parameters from outgoing requests, and failing fast when credentials cannot be resolved. Adds WireMock tests covering authentication, credential resolution, URL sanitization, and error handling.

### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../blob/master/docs/CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test case? That demonstrates the feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information
-->
