### PR TITLE
Format WireMock replacement

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -93,15 +93,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>3.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Applies the `mvn spotless:apply` change requested in #2891.

Spotless moves the new `org.wiremock:wiremock-standalone` test dependency after
`jsr305`. No dependency coordinates or production code are changed.

Verification (JDK 21):

- `mvn -ntp spotless:apply`
- `mvn -ntp -pl plugin -am -DskipTests spotless:check`
- The verify run completed the plugin's 206 tests and the test harness's 194 tests,
  plus their Enforcer, SpotBugs, Checkstyle, and Spotless gates, with no failures.

### Your checklist for this pull request

- [x] Make sure you are requesting to pull a topic/feature/bugfix branch and not your master branch
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in Jenkins JIRA: #2891
- [x] Link to relevant pull requests, especially upstream and downstream changes: #2891
- [ ] Did you provide a test-case? (not applicable to a formatter-only companion; the existing suites above pass)
