### PR TITLE
Update Jenkins baseline to 2.555.3 and require Java 21

### DIFF
--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -127,6 +127,14 @@
       <artifactId>artifactory</artifactId>
       <version>4.0.8</version>
       <scope>test</scope>
+      <exclusions>
+        <!-- build-info-api pulls jackson-annotations 2.14.1, which shadows the newer copy
+             jackson2-api provides through jackson-annotations2-api and breaks ObjectMapper -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/ConfigurationAsCode.java
@@ -822,8 +822,9 @@ public class ConfigurationAsCode extends ManagementLink {
     }
 
     private static boolean isHidden(Path path) {
-        return IntStream.range(0, path.getNameCount()).mapToObj(path::getName).anyMatch(subPath -> subPath.toString()
-                .startsWith("."));
+        return IntStream.range(0, path.getNameCount())
+                .mapToObj(path::getName)
+                .anyMatch(subPath -> subPath.toString().startsWith("."));
     }
 
     @FunctionalInterface

--- a/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/casc/core/JenkinsConfigurator.java
@@ -24,6 +24,7 @@ import io.vavr.control.Try;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -62,24 +63,26 @@ public class JenkinsConfigurator extends BaseConfigurator<Jenkins> implements Ro
 
         // Add remoting security, all legwork will be done by a configurator
         attributes.add(new Attribute<Jenkins, AdminWhitelistRule>("remotingSecurity", AdminWhitelistRule.class)
-                .getter(j -> j.getInjector().getInstance(AdminWhitelistRule.class))
+                .getter(j -> Objects.requireNonNull(j.getInjector()).getInstance(AdminWhitelistRule.class))
                 .setter(noop()));
 
         // Override "nodes" getter so we don't export Nodes registered by Cloud plugins
-        Attribute.<Jenkins, List<Node>>get(attributes, "nodes").ifPresent(attribute -> attribute
-                .getter(jenkins -> jenkins.getNodes().stream()
-                        .filter(node -> !shouldKeepNode(node))
-                        .collect(Collectors.toList()))
-                .setter((jenkins, configuredNodes) -> {
-                    List<String> configuredNodesNames =
-                            configuredNodes.stream().map(Node::getNodeName).collect(Collectors.toList());
-                    List<Node> nodesToKeep = jenkins.getNodes().stream()
-                            .filter(node -> !configuredNodesNames.contains(node.getNodeName()))
-                            .filter(this::shouldKeepNode)
-                            .collect(Collectors.toList());
-                    nodesToKeep.addAll(configuredNodes);
-                    jenkins.setNodes(nodesToKeep);
-                }));
+        Attribute.<Jenkins, List<Node>>get(attributes, "nodes")
+                .ifPresent(attribute -> attribute
+                        .getter(jenkins -> jenkins.getNodes().stream()
+                                .filter(node -> !shouldKeepNode(node))
+                                .collect(Collectors.toList()))
+                        .setter((jenkins, configuredNodes) -> {
+                            List<String> configuredNodesNames = configuredNodes.stream()
+                                    .map(Node::getNodeName)
+                                    .collect(Collectors.toList());
+                            List<Node> nodesToKeep = jenkins.getNodes().stream()
+                                    .filter(node -> !configuredNodesNames.contains(node.getNodeName()))
+                                    .filter(this::shouldKeepNode)
+                                    .collect(Collectors.toList());
+                            nodesToKeep.addAll(configuredNodes);
+                            jenkins.setNodes(nodesToKeep);
+                        }));
 
         // Add updateCenter, all legwork will be done by a configurator
         attributes.add(new Attribute<Jenkins, UpdateCenter>("updateCenter", UpdateCenter.class)

--- a/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/UnknownRootElementTest.java
@@ -15,18 +15,22 @@ class UnknownRootElementTest {
 
     @Test
     void oneUnknown(JenkinsRule j) {
-        ConfiguratorException ex = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
-                .configure(Objects.requireNonNull(getClass().getResource("unknown1.yml"))
-                        .toExternalForm()));
+        ConfiguratorException ex = assertThrows(
+                ConfiguratorException.class,
+                () -> ConfigurationAsCode.get()
+                        .configure(Objects.requireNonNull(getClass().getResource("unknown1.yml"))
+                                .toExternalForm()));
 
         assertThat(ex.getMessage(), containsString("No configurator found for the following root element: alice"));
     }
 
     @Test
     void twoUnknown(JenkinsRule j) {
-        ConfiguratorException ex = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
-                .configure(Objects.requireNonNull(getClass().getResource("unknown2.yml"))
-                        .toExternalForm()));
+        ConfiguratorException ex = assertThrows(
+                ConfiguratorException.class,
+                () -> ConfigurationAsCode.get()
+                        .configure(Objects.requireNonNull(getClass().getResource("unknown2.yml"))
+                                .toExternalForm()));
 
         assertThat(
                 ex.getMessage(), containsString("No configurator found for the following root elements: bob, alice"));

--- a/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfiguratorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/casc/impl/configurators/HeteroDescribableConfiguratorTest.java
@@ -52,9 +52,9 @@ public class HeteroDescribableConfiguratorTest {
                         getClass().getResource("HeteroDescribableConfiguratorTest_scalarInterpolation.yml"))
                 .toExternalForm();
 
-        UnknownAttributesException thrown =
-                assertThrows(UnknownAttributesException.class, () -> ConfigurationAsCode.get()
-                        .configure(yamlResource));
+        UnknownAttributesException thrown = assertThrows(
+                UnknownAttributesException.class,
+                () -> ConfigurationAsCode.get().configure(yamlResource));
 
         assertThat(
                 "Exception should mention the failure to find an implementation",
@@ -65,9 +65,11 @@ public class HeteroDescribableConfiguratorTest {
 
     @Test
     public void shouldFailWhenMultipleImplementationsProvidedForNestedSingleValuedDescribable() {
-        ConfiguratorException exception = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
-                .configure(Objects.requireNonNull(getClass().getResource("multiple-implementations.yml"))
-                        .toExternalForm()));
+        ConfiguratorException exception = assertThrows(
+                ConfiguratorException.class,
+                () -> ConfigurationAsCode.get()
+                        .configure(Objects.requireNonNull(getClass().getResource("multiple-implementations.yml"))
+                                .toExternalForm()));
 
         String errorMessage = exception.getMessage();
         if (exception.getCause() != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2138.v03274d462c13</version>
+    <version>6.2221.va_045130417c9</version>
     <relativePath />
   </parent>
 
@@ -39,10 +39,13 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/configuration-as-code-plugin</gitHubRepo>
-    <jenkins.baseline>2.541</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.555</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <!-- the aggregator never compiles, so it never gets the parent's target/java-level marker and
+         would default to release 17, which bans the Java 21 bytecode of a 2.555 core -->
+    <maven.compiler.release>21</maven.compiler.release>
     <tagNameFormat>configuration-as-code-@{project.version}</tagNameFormat>
-    <plugin-bom.version>6269.v7a_159d68a_366</plugin-bom.version>
+    <plugin-bom.version>6931.vea_a_b_c6fd017d</plugin-bom.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/YamlMaxAliasesCollectionTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/YamlMaxAliasesCollectionTest.java
@@ -23,8 +23,10 @@ public class YamlMaxAliasesCollectionTest {
     @Test
     public void testAMaxOfOneEnv() {
         env.set(ConfigurationContext.CASC_YAML_MAX_ALIASES_ENV, "1");
-        ConfiguratorException e = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
-                .configure(getClass().getResource("maxAliasesLimit.yml").toExternalForm()));
+        ConfiguratorException e = assertThrows(
+                ConfiguratorException.class,
+                () -> ConfigurationAsCode.get()
+                        .configure(getClass().getResource("maxAliasesLimit.yml").toExternalForm()));
         assertEquals(
                 "Number of aliases for non-scalar nodes exceeds the specified max=1\n"
                         + "You can increase the maximum by setting an environment variable or property\n"
@@ -36,8 +38,10 @@ public class YamlMaxAliasesCollectionTest {
     @Test
     public void testAMaxOfOneProp() {
         System.setProperty(ConfigurationContext.CASC_YAML_MAX_ALIASES_PROPERTY, "1");
-        ConfiguratorException e = assertThrows(ConfiguratorException.class, () -> ConfigurationAsCode.get()
-                .configure(getClass().getResource("maxAliasesLimit.yml").toExternalForm()));
+        ConfiguratorException e = assertThrows(
+                ConfiguratorException.class,
+                () -> ConfigurationAsCode.get()
+                        .configure(getClass().getResource("maxAliasesLimit.yml").toExternalForm()));
         assertEquals(
                 "Number of aliases for non-scalar nodes exceeds the specified max=1\n"
                         + "You can increase the maximum by setting an environment variable or property\n"

--- a/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
+++ b/test-harness/src/test/java/io/jenkins/plugins/casc/impl/configurators/DataBoundConfiguratorTest.java
@@ -170,7 +170,8 @@ class DataBoundConfiguratorTest {
                 "string is required to configure class io.jenkins.plugins.casc.impl.configurators.nonnull.nonnullparampackage.PackageParametersAreNonnullByDefault";
 
         ConfiguratorException exception = assertThrows(
-                ConfiguratorException.class, () -> registry.lookupOrFail(PackageParametersAreNonnullByDefault.class)
+                ConfiguratorException.class,
+                () -> registry.lookupOrFail(PackageParametersAreNonnullByDefault.class)
                         .configure(config, new ConfigurationContext(registry)));
 
         assertThat(exception.getMessage(), is(expectedMessage));
@@ -214,9 +215,10 @@ class DataBoundConfiguratorTest {
         Mapping config = new Mapping();
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
 
-        ConfiguratorException exception = assertThrows(ConfiguratorException.class, () -> registry.lookupOrFail(
-                        JakartaNonnullRequiredParameterConstructor.class)
-                .configure(config, new ConfigurationContext(registry)));
+        ConfiguratorException exception = assertThrows(
+                ConfiguratorException.class,
+                () -> registry.lookupOrFail(JakartaNonnullRequiredParameterConstructor.class)
+                        .configure(config, new ConfigurationContext(registry)));
 
         assertThat(
                 exception.getMessage(),

--- a/test-harness/src/test/resources/io/jenkins/plugins/casc/validJenkinsBaseConfigWithSymbol.yml
+++ b/test-harness/src/test/resources/io/jenkins/plugins/casc/validJenkinsBaseConfigWithSymbol.yml
@@ -1,4 +1,3 @@
 jenkins:
   crumbIssuer:
-    standard:
-      excludeClientIPFromCrumb: false
+    standard: {}


### PR DESCRIPTION
Update the Jenkins baseline from 2.541.1 to 2.555.3, one of the [currently recommended versions](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions).

The Jenkinsfile already tests `linux/25` and `windows/21`, both of which a 2.555 baseline supports, so the matrix is unchanged.

## What's changed

- `jenkins.baseline` 2.541 -> 2.555, and `plugin-bom.version` to the matching `bom-2.555.x` release.
- Bumped the parent POM to 6.2221.va_045130417c9. The old parent's `EnforceBytecodeVersion` capped bytecode at Java 17 and so banned `jenkins-core:2.555.3` itself.
- Set `maven.compiler.release` to 21 on the aggregator. The aggregator never compiles, so it never gets the `target/java-level/21` marker the parent uses to activate its Java-level profile, and it would otherwise fall back to 17 and re-trigger the same enforcer failure. The modules are unaffected — they derive their level as usual.
- `JenkinsConfigurator.describe()` now wraps `Jenkins.getInjector()` in `Objects.requireNonNull`. It is `@CheckForNull` in current core, so SpotBugs raised `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE`. Behaviour is unchanged — a null injector would already have thrown here.
- Dropped `excludeClientIPFromCrumb` from `validJenkinsBaseConfigWithSymbol.yml`; core no longer uses it, so the generated schema rejects it. The fixture keeps `standard: {}`, which is what the test is actually for — checking that the `standard` symbol resolves. An empty `standard:` is not enough: it parses as null and the schema wants an object.
- Excluded the stale `com.fasterxml.jackson.core:jackson-annotations` that `artifactory` -> `build-info-api` drags in at 2.14.1. It shadowed the 2.22 copy `jackson2-api` supplies via `jackson-annotations2-api`, and `ObjectMapper` then failed to initialise with `NoClassDefFoundError: JsonSerializeAs` in `SlackTest`, `AzureKeyVaultTest` and `SonarQubeTest`.
- Reformatted five files with `mvn spotless:apply`. The newer parent ships a newer palantir-java-format, and `spotless.check.skip` is `false` here, so the build fails without it. No behaviour change.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS, across all three modules.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk baseline update across the plugins I maintain. If anything here looks wrong, please comment on this PR.
